### PR TITLE
Changes from Andrew and Bibhu

### DIFF
--- a/AllHadronicSUSY/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/AllHadronicSUSY/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -221,7 +221,7 @@ gammajets=False):
     from AllHadronicSUSY.Utils.metdouble_cfi import metdouble
     process.MET = metdouble.clone(
     METTag  = cms.InputTag("slimmedMETs"),
-    JetTag  = cms.InputTag('HTJets'),
+    JetTag  = cms.InputTag('HTJets')
     )
     process.Baseline += process.MET
     VarsDouble.extend(['MET:minDeltaPhiN','MET:DeltaPhiN1','MET:DeltaPhiN2','MET:DeltaPhiN3','MET:Pt(METPt)','MET:Phi(METPhi)'])
@@ -232,7 +232,8 @@ gammajets=False):
     BTagInputTag	        = cms.string('combinedInclusiveSecondaryVertexV2BJetTags'),
     METTag  = cms.InputTag("slimmedMETs"),
     )
-    process.LostLepton += process.JetsProperties
+    process.Baseline += process.JetsProperties
+    #process.LostLepton += process.JetsProperties
     from AllHadronicSUSY.Utils.genLeptonRecoCand_cfi import genLeptonRecoCand
     process.GenLeptons = genLeptonRecoCand.clone(
     PrunedGenParticleTag  = cms.InputTag("prunedGenParticles"),

--- a/AllHadronicSUSY/Utils/interface/CleanPATJetProducer.h
+++ b/AllHadronicSUSY/Utils/interface/CleanPATJetProducer.h
@@ -1,0 +1,57 @@
+#include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
+#include <DataFormats/PatCandidates/interface/Photon.h>
+#include <DataFormats/PatCandidates/interface/Jet.h>
+#include "FWCore/Utilities/interface/InputTag.h"
+#include <vector>
+#include "TLorentzVector.h"
+
+class CleanPATJetProducer : public edm::EDProducer {
+
+public:
+  explicit CleanPATJetProducer(const edm::ParameterSet&);
+  ~CleanPATJetProducer();
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+  
+private:
+  virtual void beginJob() ;
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void endJob() ;
+  
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  
+  // ----------member data ---------------------------
+
+
+  // ---------- configurable data ----------------
+  // --------------- members ---------------------
+  
+  std::string jetCollection;     // name of particle collection
+  edm::InputTag photonCollection;
+  edm::InputTag rhoCollection;
+  bool        debug;
+  
+  bool isBarrelPhoton,isEndcapPhoton,isGenMatched;
+  double chIso,nuIso,gamIso;
+  bool passID,passIso,passAcc;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+};

--- a/AllHadronicSUSY/Utils/interface/PhotonIDisoProducer.h
+++ b/AllHadronicSUSY/Utils/interface/PhotonIDisoProducer.h
@@ -1,0 +1,39 @@
+#include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
+#include <DataFormats/PatCandidates/interface/Photon.h>
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include <vector>
+
+
+class PhotonIDisoProducer : public edm::EDProducer {
+
+public:
+  explicit PhotonIDisoProducer(const edm::ParameterSet&);
+  ~PhotonIDisoProducer();
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+  
+private:
+  virtual void beginJob() ;
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void endJob() ;
+  
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  
+  // ----------member data ---------------------------
+
+
+  // ---------- configurable data ----------------
+  // --------------- members ---------------------
+  
+  edm::InputTag photonCollection; 
+  edm::InputTag rhoCollection;    
+  bool        debug;
+
+};
+
+

--- a/AllHadronicSUSY/Utils/interface/classes.h
+++ b/AllHadronicSUSY/Utils/interface/classes.h
@@ -1,0 +1,11 @@
+#include "TLorentzVector.h"
+#include <DataFormats/PatCandidates/interface/Jet.h>
+
+namespace {
+  struct dictionary {
+    std::vector<TLorentzVector> vlv;
+    std::vector<pat::Jet> vpj;
+    std::vector<std::vector<TLorentzVector> > vvlv;
+    std::vector<std::vector<pat::Jet> > vvpj;
+  };
+}

--- a/AllHadronicSUSY/Utils/interface/classes_def.xml
+++ b/AllHadronicSUSY/Utils/interface/classes_def.xml
@@ -1,0 +1,6 @@
+<lcgdict>
+  <class name="std::vector<TLorentzVector>"/>
+  <class name="std::vector<std::vector<TLorentzVector> >"/>
+  <class name="std::vector<pat::Jet>"/>
+  <class name="std::vector<std::vector<pat::Jet> >"/>
+</lcgdict>

--- a/AllHadronicSUSY/Utils/src/CleanPATJetProducer.cc
+++ b/AllHadronicSUSY/Utils/src/CleanPATJetProducer.cc
@@ -1,0 +1,311 @@
+// -*- C++ -*-
+//
+// Package:    AllHadronicSUSY/Utils
+// Class:      CleanPATJetProducer
+// 
+/*
+
+ Description: Takes photons and jet collections
+ from cfg and removes all jets which match photon
+ (currently matching is done with dR<0.4 criteria) 
+ A collection of pat::Jet is saved to the event.
+
+*/
+//
+// Original Author: Bibhuprasad Mahakud 
+//         Created: 5th March 2015
+// 
+// 
+
+// system include files
+#include <memory>
+#include <DataFormats/PatCandidates/interface/Jet.h>
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "AllHadronicSUSY/Utils/interface/CleanPATJetProducer.h"
+#include "AllHadronicSUSY/Utils/src/effArea.cc"
+#include "TLorentzVector.h"
+
+#include <vector>
+
+CleanPATJetProducer::CleanPATJetProducer(const edm::ParameterSet& iConfig):
+  jetCollection(iConfig.getUntrackedParameter<std::string>("jetCollection")),
+  photonCollection(iConfig.getUntrackedParameter<edm::InputTag>("photonCollection")),
+  rhoCollection(iConfig.getUntrackedParameter<edm::InputTag>("rhoCollection")),
+  debug(iConfig.getUntrackedParameter<bool>("debug",true))
+{
+  produces< std::vector< pat::Jet > >("");
+}
+
+
+CleanPATJetProducer::~CleanPATJetProducer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+CleanPATJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  //initialize 'collection' to be saved in event
+  std::auto_ptr< std::vector< pat::Jet > >  patJet4Vec( new std::vector< pat::Jet > () );
+  vector< TLorentzVector > *purePhoton = 0;
+
+  using namespace edm;
+  Handle< View< pat::Photon> > photonCands;
+  iEvent.getByLabel( photonCollection ,photonCands);
+
+  edm::Handle< double > rho_;
+  iEvent.getByLabel(rhoCollection,rho_);
+  double rho = *rho_;
+
+  if( debug ) std::cout << "got photon collection" << std::endl;
+
+  // - - - - - - - - - - - - - - - - - - - - 
+  // Initializing effective area to be used 
+  // for rho corrections to the photon isolation
+  // variables.  -- currently these are taken from
+  // the 2012 EGamma PAG recommendations and need 
+  // to be updated
+  // - - - - - - - - - - - - - - - - - - - - 
+  effArea* effAreas = new effArea();
+  effAreas->addEffA( 0.0,   1.0,   0.012, 0.030, 0.148 );
+  effAreas->addEffA( 1.0,   1.479, 0.010, 0.057, 0.130 );
+  effAreas->addEffA( 1.479, 2.0,   0.014, 0.039, 0.112 );
+  effAreas->addEffA( 2.0,   2.2,   0.012, 0.015, 0.216 );
+  effAreas->addEffA( 2.2,   2.3,   0.016, 0.024, 0.262 );
+  effAreas->addEffA( 2.3,   2.4,   0.020, 0.039, 0.260 );
+  effAreas->addEffA( 2.4,   99.,   0.012, 0.072, 0.266 );
+  double PhotonPt=0;
+  
+  // - - - - - - - - - - - - - - - - - - - - 
+  // loop over all photons to find the best photon
+  // 'pure' photon.  This is defined to be the 
+  // highest pt photon that passes all the iso
+  // and id cuts.  
+  // - - - - - - - - - - - - - - - - - - - - 
+  for( View< pat::Photon >::const_iterator iPhoton = photonCands->begin();
+       iPhoton != photonCands->end();
+       ++iPhoton){//photon loop starts
+ 
+    isBarrelPhoton=false;
+    isEndcapPhoton=false;
+    isGenMatched=false;
+    passID=false;
+    passIso=false;
+    passAcc=false;
+
+ 
+ 
+    double PhEta=iPhoton->eta();
+    if(fabs(PhEta) < 1.4442  ){
+      isBarrelPhoton=true;
+    }
+    else if(fabs(PhEta)>1.566 && fabs(PhEta)<2.5){
+      isEndcapPhoton=true;
+    }
+    else {
+      isBarrelPhoton=false;
+      isEndcapPhoton=false;
+
+    }
+
+    if(isBarrelPhoton || isEndcapPhoton){
+      passAcc=true;
+    }
+  
+    // bool genPhoton,isgenMatched;
+    isGenMatched=iPhoton->genPhoton() != NULL;
+  
+    // apply id cuts
+    if(isBarrelPhoton){
+  
+      if(iPhoton->hadTowOverEm() < 0.05 && iPhoton->hasPixelSeed()==false && iPhoton->sigmaIetaIeta() < 0.011){//id criterias barrel
+	passID=true;
+
+      }//id criterias
+
+    } 
+    else if(isEndcapPhoton){
+      if(iPhoton->hadTowOverEm() < 0.05 && iPhoton->hasPixelSeed()==false && iPhoton->sigmaIetaIeta() < 0.031){//id criteria endcap
+	passID=true;
+
+      }//id criterias endcap
+
+    }
+    else {
+      passID=false;
+    }
+ 
+    // compute the rho corrected isolation variable using
+    // the effective areas defined above
+    chIso = effAreas->rhoCorrectedIso(  pfCh  , iPhoton->chargedHadronIso() , iPhoton->eta() , rho );
+    nuIso = effAreas->rhoCorrectedIso(  pfNu  , iPhoton->neutralHadronIso() , iPhoton->eta() , rho );
+    gamIso = effAreas->rhoCorrectedIso( pfGam , iPhoton->photonIso()        , iPhoton->eta() , rho );
+   
+    // apply isolation cuts
+    if(isBarrelPhoton){
+      if(chIso <0.7 && nuIso <  (0.4 + 0.04*(iPhoton->pt()))  && gamIso < ( 0.5 + 0.005*(iPhoton->pt())) ){
+	passIso=true;      
+      }
+     
+    }
+    else if(isEndcapPhoton){
+      if(chIso <0.5 && nuIso <  (1.5 + 0.04*(iPhoton->pt()))  && gamIso < ( 1.0 + 0.005*(iPhoton->pt())) ){
+	passIso=true;
+      }
+
+    }
+    else{
+      passIso=false;
+    }
+
+    // check if photons is a good photon
+    if( passAcc && passID && passIso && iPhoton->pt() > 100.0){//pure photons
+      // make sure only the highest pt photon is used
+      if(iPhoton->pt() > PhotonPt){ 
+	purePhoton->clear();
+	TLorentzVector temp;
+	temp.SetPtEtaPhiE(iPhoton->pt(),
+			  iPhoton->eta(),
+			  iPhoton->phi(),
+			  iPhoton->energy());
+	purePhoton->push_back( temp );
+	PhotonPt=iPhoton->pt();
+
+      }
+    
+    }//pure photons    
+
+  }//photon loop
+
+  if( debug ) cout<<"number of photons = "<<purePhoton->size()<<endl;
+  
+  // get jet collection
+  Handle< View<pat::Jet> > jetCands;
+  iEvent.getByLabel(jetCollection,jetCands);
+
+  if( debug ){
+    std::cout << "new events" << std::endl;
+    std::cout << "===================" << std::endl;
+  }
+
+  // - - - - - - - - - - - - - - - - - - - - 
+  // loop over jet collection and match jets
+  // with the 'pure' photon selected above
+  // - - - - - - - - - - - - - - - - - - - -   
+  for(View<pat::Jet>::const_iterator iPart = jetCands->begin(); iPart != jetCands->end(); ++iPart){//loop over ak4Jets
+      
+    if( debug ) {
+      std::cout << "input  p_{mu}: " 
+		<< iPart->px() << " " 
+		<< iPart->py() << " " 
+		<< iPart->pz() << " " 
+		<< iPart->energy() << std::endl;
+    }// end debug
+
+    if(purePhoton->size()==1){
+      double PhEta=purePhoton->at(0).Eta();  
+      double PhPhi=purePhoton->at(0).Phi();
+  
+      double jetEta=iPart->eta();
+      double jetPhi=iPart->phi();
+
+      double dEta=PhEta-jetEta;
+      double dPhi=PhPhi-jetPhi;
+      if (fabs(PhPhi-jetPhi) > 3.14159){
+	dPhi= 2*3.14159-(PhPhi-jetPhi );
+      }
+
+      double dR=sqrt((dEta*dEta)+(dPhi*dPhi)); 
+      if(dR > 0.4 ){//deltaR cut photon and jet
+
+        patJet4Vec->push_back(*iPart);
+
+      }//photon and jet
+
+    }else if(purePhoton->size()==0){
+
+      patJet4Vec->push_back(*iPart);
+
+    }
+
+  }// end loop over ak4Jets 
+
+ 
+  iEvent.put(patJet4Vec); 
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+
+CleanPATJetProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+CleanPATJetProducer::endJob() 
+{
+}
+
+// ------------ method called when starting to processes a run  ------------
+void 
+CleanPATJetProducer::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a run  ------------
+void 
+CleanPATJetProducer::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when starting to processes a luminosity block  ------------
+void 
+CleanPATJetProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+void 
+CleanPATJetProducer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+CleanPATJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  /*
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+  */
+
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(CleanPATJetProducer);

--- a/AllHadronicSUSY/Utils/src/CleanPATJetProducer.cc
+++ b/AllHadronicSUSY/Utils/src/CleanPATJetProducer.cc
@@ -43,6 +43,7 @@ CleanPATJetProducer::CleanPATJetProducer(const edm::ParameterSet& iConfig):
   debug(iConfig.getUntrackedParameter<bool>("debug",true))
 {
   produces< std::vector< pat::Jet > >("");
+  produces< std::vector< pat::Photon > >("bestPhoton");
 }
 
 
@@ -66,7 +67,7 @@ CleanPATJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   //initialize 'collection' to be saved in event
   std::auto_ptr< std::vector< pat::Jet > >  patJet4Vec( new std::vector< pat::Jet > () );
-  vector< TLorentzVector > *purePhoton = 0;
+  std::auto_ptr< std::vector< pat::Photon > > purePhoton( new std::vector< pat::Photon > () );
 
   using namespace edm;
   Handle< View< pat::Photon> > photonCands;
@@ -187,7 +188,7 @@ CleanPATJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 			  iPhoton->eta(),
 			  iPhoton->phi(),
 			  iPhoton->energy());
-	purePhoton->push_back( temp );
+	purePhoton->push_back( *iPhoton );
 	PhotonPt=iPhoton->pt();
 
       }
@@ -222,8 +223,8 @@ CleanPATJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }// end debug
 
     if(purePhoton->size()==1){
-      double PhEta=purePhoton->at(0).Eta();  
-      double PhPhi=purePhoton->at(0).Phi();
+      double PhEta=purePhoton->at(0).eta();  
+      double PhPhi=purePhoton->at(0).phi();
   
       double jetEta=iPart->eta();
       double jetPhi=iPart->phi();
@@ -248,9 +249,10 @@ CleanPATJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
 
   }// end loop over ak4Jets 
+  
+  iEvent.put(purePhoton, "bestPhoton" ); 
+  iEvent.put(patJet4Vec ); 
 
- 
-  iEvent.put(patJet4Vec); 
 }
 
 

--- a/AllHadronicSUSY/Utils/src/JetProperties.cc
+++ b/AllHadronicSUSY/Utils/src/JetProperties.cc
@@ -117,7 +117,9 @@ JetProperties::JetProperties(const edm::ParameterSet& iConfig)
 	produces<std::vector<int> > (string12).setBranchAlias(string12);
 	const std::string string13("bDiscriminator");
 	produces<std::vector<double> > (string13).setBranchAlias(string13);
-	
+
+	produces<std::vector<int> > ("flavor");
+
 }
 
 
@@ -156,6 +158,7 @@ JetProperties::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	std::auto_ptr< std::vector<double> > muonEnergyFraction(new std::vector<double>);
 	std::auto_ptr< std::vector<int> > muonMultiplicity(new std::vector<int>);
 	std::auto_ptr< std::vector<double> > bDiscriminator(new std::vector<double>);
+	std::auto_ptr< std::vector<int> > flavor(new std::vector<int>);
 	using namespace edm;
 	using namespace reco;
 	using namespace pat;
@@ -180,6 +183,7 @@ JetProperties::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 			muonEnergyFraction->push_back( Jets->at(i).muonEnergyFraction() );
 			muonMultiplicity->push_back( Jets->at(i).muonMultiplicity() );
 			bDiscriminator->push_back( Jets->at(i).bDiscriminator(btagname_) );
+			flavor->push_back( Jets->at(i).partonFlavour() );
 		}
 	}
 	const std::string string00("");
@@ -213,7 +217,9 @@ JetProperties::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	iEvent.put(muonMultiplicity,string12);
 	const std::string string13("bDiscriminator");
 	iEvent.put(bDiscriminator,string13);
-	
+
+	iEvent.put(flavor,"flavor");
+
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/AllHadronicSUSY/Utils/src/PhotonIDisoProducer.cc
+++ b/AllHadronicSUSY/Utils/src/PhotonIDisoProducer.cc
@@ -1,0 +1,226 @@
+// -*- C++ -*-
+//
+// Package:    SuSySubstructure
+// Class:      PhotonIDisoProducer
+// 
+/*
+
+ Description: Takes as cfg input a jet collection 
+ and clusters the jets into large-R anti-kt jets.
+ A collection of 4-vectors corresponding to these 
+ jets is saved to the event.
+
+*/
+//
+// Original Author:  Andrew Whitbeck
+//         Created:  Wed March 7, 2014
+// 
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "..//interface/PhotonIDisoProducer.h"
+#include "effArea.cc"
+
+#include "TLorentzVector.h"
+#include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
+
+#include <vector>
+
+PhotonIDisoProducer::PhotonIDisoProducer(const edm::ParameterSet& iConfig):
+  photonCollection(iConfig.getUntrackedParameter<edm::InputTag>("photonCollection")),
+  rhoCollection(iConfig.getUntrackedParameter<edm::InputTag>("rhoCollection")),
+  debug(iConfig.getUntrackedParameter<bool>("debug",true))
+{
+  produces< std::vector< TLorentzVector > >(""); 
+  produces< std::vector< double > >("isEB").setBranchAlias( photonCollection.label()+"isEB" );; 
+  produces< std::vector< double > >("genMatched"); 
+  produces< std::vector< double > >("hadTowOverEM"); 
+  produces< std::vector< double > >("sigmaIetaIeta"); 
+  produces< std::vector< double > >("pfChargedIso"); 
+  produces< std::vector< double > >("pfNeutralIso"); 
+  produces< std::vector< double > >("pfGammaIso"); 
+  produces< std::vector< double > >("pfChargedIsoRhoCorr"); 
+  produces< std::vector< double > >("pfNeutralIsoRhoCorr"); 
+  produces< std::vector< double > >("pfGammaIsoRhoCorr"); 
+  produces< std::vector< double > >("hasPixelSeed"); 
+}
+
+
+PhotonIDisoProducer::~PhotonIDisoProducer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+PhotonIDisoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  using namespace edm;
+
+  std::auto_ptr< std::vector< TLorentzVector > > photon ( new std::vector< TLorentzVector > () );
+  
+  std::auto_ptr< std::vector< double > > photon_isEB( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_genMatched( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_hadTowOverEM( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_sigmaIetaIeta( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_pfGammaIso( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_pfChargedIso( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_pfNeutralIso( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_pfGammaIsoRhoCorr( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_pfChargedIsoRhoCorr( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_pfNeutralIsoRhoCorr( new std::vector< double > () );
+  std::auto_ptr< std::vector< double > > photon_hasPixelSeed( new std::vector< double > () );
+
+  if( debug ){
+    std::cout << "new events" << std::endl;
+    std::cout << "===================" << std::endl;
+  
+  }
+  
+  Handle< View< pat::Photon> > photonCands;
+  iEvent.getByLabel( photonCollection ,photonCands);
+
+  edm::Handle< double > rho_;
+  iEvent.getByLabel(rhoCollection,rho_);
+  double rho = *rho_;
+
+  if( debug ) std::cout << "got photon collection" << std::endl;
+
+  effArea* effAreas = new effArea();
+  effAreas->addEffA( 0.0,   1.0,   0.012, 0.030, 0.148 );
+  effAreas->addEffA( 1.0,   1.479, 0.010, 0.057, 0.130 );
+  effAreas->addEffA( 1.479, 2.0,   0.014, 0.039, 0.112 );
+  effAreas->addEffA( 2.0,   2.2,   0.012, 0.015, 0.216 );
+  effAreas->addEffA( 2.2,   2.3,   0.016, 0.024, 0.262 );
+  effAreas->addEffA( 2.3,   2.4,   0.020, 0.039, 0.260 );
+  effAreas->addEffA( 2.4,   99.,   0.012, 0.072, 0.266 );
+
+  for( View< pat::Photon >::const_iterator iPhoton = photonCands->begin();
+        iPhoton != photonCands->end();
+        ++iPhoton){
+
+    if( debug ) {
+      std::cout << "photon pt: " << iPhoton->pt() << std::endl;
+      std::cout << "photon eta: " << iPhoton->eta() << std::endl;
+      std::cout << "photon phi: " << iPhoton->phi() << std::endl;
+    }
+
+    TLorentzVector temp;
+    temp.SetPtEtaPhiE(iPhoton->pt(),
+		      iPhoton->eta(),
+		      iPhoton->phi(),
+		      iPhoton->energy());
+    photon->push_back( temp );
+
+    photon_isEB->push_back( iPhoton->isEB() );
+    photon_genMatched->push_back( iPhoton->genPhoton() != NULL );
+    photon_hadTowOverEM->push_back( iPhoton->hadTowOverEm() ) ;
+    photon_sigmaIetaIeta->push_back( iPhoton->sigmaIetaIeta() ) ;
+    
+    photon_pfChargedIso->push_back(      iPhoton->chargedHadronIso() );
+    photon_pfGammaIso->push_back(        iPhoton->photonIso() );
+    photon_pfNeutralIso->push_back(      iPhoton->neutralHadronIso() );
+
+    double chIso = effAreas->rhoCorrectedIso(  pfCh  , iPhoton->chargedHadronIso() , iPhoton->eta() , rho ); 
+    double nuIso = effAreas->rhoCorrectedIso(  pfNu  , iPhoton->neutralHadronIso() , iPhoton->eta() , rho ); 
+    double gamIso = effAreas->rhoCorrectedIso( pfGam , iPhoton->photonIso()        , iPhoton->eta() , rho ); 
+
+    photon_pfChargedIsoRhoCorr->push_back( chIso  );
+    photon_pfGammaIsoRhoCorr->push_back(   nuIso  );
+    photon_pfNeutralIsoRhoCorr->push_back( gamIso );
+
+    photon_hasPixelSeed->push_back( iPhoton->hasPixelSeed() );
+
+  }
+
+  iEvent.put(photon); 
+  iEvent.put(photon_isEB , "isEB" );
+  iEvent.put(photon_genMatched , "genMatched" );
+  iEvent.put(photon_hadTowOverEM , "hadTowOverEM" );
+  iEvent.put(photon_sigmaIetaIeta , "sigmaIetaIeta" );
+  iEvent.put(photon_pfChargedIso , "pfChargedIso" );
+  iEvent.put(photon_pfNeutralIso , "pfNeutralIso" );
+  iEvent.put(photon_pfGammaIso , "pfGammaIso" );
+  iEvent.put(photon_pfChargedIsoRhoCorr , "pfChargedIsoRhoCorr" );
+  iEvent.put(photon_pfNeutralIsoRhoCorr , "pfNeutralIsoRhoCorr" );
+  iEvent.put(photon_pfGammaIsoRhoCorr , "pfGammaIsoRhoCorr" );
+  iEvent.put(photon_hasPixelSeed , "hasPixelSeed" );
+ 
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+
+PhotonIDisoProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+PhotonIDisoProducer::endJob() 
+{
+}
+
+// ------------ method called when starting to processes a run  ------------
+void 
+PhotonIDisoProducer::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a run  ------------
+void 
+PhotonIDisoProducer::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when starting to processes a luminosity block  ------------
+void 
+PhotonIDisoProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+void 
+PhotonIDisoProducer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+PhotonIDisoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  /*
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+  */
+
+}
+
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(PhotonIDisoProducer);

--- a/AllHadronicSUSY/Utils/src/effArea.cc
+++ b/AllHadronicSUSY/Utils/src/effArea.cc
@@ -1,0 +1,59 @@
+#include <vector>
+#include <iostream>
+#include <cmath>
+using namespace std;
+
+enum isoType {pfCh,pfNu,pfGam,coneCh,coneNu,coneGam,NisoTypes};
+
+class effArea{
+
+public:
+  vector<double> etaHigh;
+  vector<double> etaLow;
+  vector< vector<double> > effA;
+
+  effArea(double etaLow_,double etaHigh_,double effA_pfCh_,double effA_pfNu_,double effA_pfGa_){
+
+    addEffA(etaLow_, etaHigh_, effA_pfCh_, effA_pfNu_, effA_pfGa_);
+
+  };
+
+  effArea(){};
+
+  void addEffA(double etaLow_,double etaHigh_,double effA_pfCh_,double effA_pfNu_,double effA_pfGa_){
+
+    etaHigh.push_back( etaHigh_ );
+    etaLow.push_back( etaLow_ );
+    vector<double> temp;
+    temp.push_back(effA_pfCh_);
+    temp.push_back(effA_pfNu_);
+    temp.push_back(effA_pfGa_);
+    effA.push_back( temp );
+
+  };
+
+  double rhoCorrectedIso(isoType isoType_, double isoVal, double eta, double rho){
+
+    int iEta = -1;
+
+    // find the relevant eta range
+    for( unsigned int i = 0 ; i < etaHigh.size() ; i++ ){
+
+      if( fabs(eta) < etaHigh[i] && fabs(eta) > etaLow[i] ){
+	iEta = i;
+	break;
+      }
+
+    }
+
+    if( iEta < 0 ){
+
+      std::cout << "AHHHHH: couldn't match eta region... eta=" << fabs(eta) << std::endl;
+      return 99999. ;
+
+    }else 
+      return max( isoVal - effA[iEta][isoType_]*rho , 0. );
+
+  };
+
+};


### PR DESCRIPTION
There are four sets of changes:

- additions for photon+jets studies: 
   AllHadronicSUSY/Utils/interface/CleanPATJetProducer.h
   AllHadronicSUSY/Utils/interface/PhotonIDisoProducer.h
   AllHadronicSUSY/Utils/interface/classes.h
   AllHadronicSUSY/Utils/interface/classes_def.xml
   AllHadronicSUSY/Utils/src/CleanPATJetProducer.cc
   AllHadronicSUSY/Utils/src/PhotonIDisoProducer.cc

probably there are no big complaints here, although we did make a class definition file so that certain dictionaries are generated for objects like pat::jet

- minor changes to the main configuration file.  I think that this will cause a conflict with Rishi's updates.  The changes here are minor, but I think that the JetsProperties module should be grouped into the Baseline workflow.  We don't have to add this information to the trees, but we might as well have the module run in case... I don't have any strong opinions on this though.

- additional functionality in METDouble producer.  I have added the ability to pass a set of reco::candidate objects which will be removed from all of the MET and deltaPhi calculations.  This is done in a very simple way, in lieu of have redoing the full MET calculation (which I don't think anyone has implemented).  This makes life a lot easier for Photon studies and probably is useful for di-lepton studies.

- final there are some minor changes like removing blank spaces -- I don't know how to remove these from the pull request :(  ... still a newb