### PR TITLE
FilterFlags and TriggerResults is smarter

### DIFF
--- a/AllHadronicSUSY/Utils/python/filterdecisionproducer_cfi.py
+++ b/AllHadronicSUSY/Utils/python/filterdecisionproducer_cfi.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 filterDecisionProducer = cms.EDProducer('FilterDecisionProducer',
 trigTagArg1  = cms.string('TriggerResults'),
 trigTagArg2  = cms.string(''),
-trigTagArg3  = cms.string('PAT'),
+trigTagArg3  = cms.string(''),
 filterName    =   cms.string("Flag_METFilters")
 )

--- a/AllHadronicSUSY/Utils/src/FilterDecisionProducer.cc
+++ b/AllHadronicSUSY/Utils/src/FilterDecisionProducer.cc
@@ -86,8 +86,19 @@ FilterDecisionProducer::FilterDecisionProducer(const edm::ParameterSet& iConfig)
   trigTagArg1_ = iConfig.getParameter <std::string> ("trigTagArg1");
   trigTagArg2_ = iConfig.getParameter <std::string> ("trigTagArg2");
   trigTagArg3_ = iConfig.getParameter <std::string> ("trigTagArg3");
-  trigResultsTag_ = edm::InputTag(trigTagArg1_,trigTagArg2_,trigTagArg3_);
+  // We we make the producer a little smarter. There are four cases we look at
+  // 1) trigTagArg1_ and trigTagArg3_ are set, if this is the case we create the label bases on all three arguments
+  // 2) trigTagArg3_ is not set, in this case we create the label based only on  trigTagArg1_
+  // 3) Neither trigTagArg1_ or TrigTagArg3_ are set, in this case we default to searching for "TriggerResults"
+  // 4) trigTag1_ is not set, but trigTagArg3_ is set, we look for "TriggerResults" in the process defined by trigTagArg3_
 
+  if(trigTagArg1_.empty()) trigTagArg1_ = "TriggerResults";
+  
+  if(trigTagArg3_.empty()){
+    trigResultsTag_ = edm::InputTag(trigTagArg1_);
+  } else {
+    trigResultsTag_ = edm::InputTag(trigTagArg1_,trigTagArg2_,trigTagArg3_);
+  }
 
   produces<int>("");
 

--- a/AllHadronicSUSY/Utils/src/TriggerProducer.cc
+++ b/AllHadronicSUSY/Utils/src/TriggerProducer.cc
@@ -92,13 +92,28 @@ TriggerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   std::auto_ptr<std::vector<int> > passTrigVec(new std::vector<int>());
   std::auto_ptr<std::vector<std::string> > trigNamesVec(new std::vector<std::string>());
 
-  int passesTrigger;
+  //int passesTrigger;
   edm::Handle<edm::TriggerResults> trigResults; //our trigger result object
   trigResults = trigResults;
   iEvent.getByLabel(trigResultsTag_,trigResults);
   const edm::TriggerNames& trigNames = iEvent.triggerNames(*trigResults); 
 
-  for(unsigned int i = 0; i < parsedTrigNamesVec.size(); i++)
+  //Find the matching triggers
+
+  std::string testTriggerName;
+  for(unsigned int trigIndex = 0; trigIndex < trigNames.size(); trigIndex++){
+    testTriggerName = trigNames.triggerName(trigIndex);
+    for(unsigned int parsedIndex = 0; parsedIndex < parsedTrigNamesVec.size(); parsedIndex++){
+      if(testTriggerName.find(parsedTrigNamesVec.at(parsedIndex)) != std::string::npos){
+	  trigNamesVec->push_back(testTriggerName.c_str());
+	  passTrigVec->push_back(trigResults->accept(trigIndex));
+	  //std::cout << "Matched: " << testTriggerName << std::endl;
+	  //break; //We only match one trigger to each trigger name fragment passed
+      }
+    }
+  }
+      /*
+ for(unsigned int i = 0; i < parsedTrigNamesVec.size(); i++)
     {
       passesTrigger = -1;
       trigNamesVec->push_back(parsedTrigNamesVec.at(i).c_str());
@@ -108,7 +123,7 @@ TriggerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	}
 	  passTrigVec->push_back(passesTrigger);
     }
-
+      */
   // for (int iHLT = 0 ; iHLT<static_cast<int>(trigResults->size()); ++iHLT) 
   // {	
   //   //std::cout << "tname="<< trigNames.triggerName(iHLT)<< std::endl;


### PR DESCRIPTION
FilterFlags can now be set to locate the product using default values
TriggerResults can now match substrings. It will search for TriggerNames that contain the passed names as substrings.

The current behaviour is preserved if the entire trigger name is passed; however, it is now possible to pass a trigger name fragment, it will search for any triggers names that contain the fragment as a substring.
