### PR TITLE
better integration for DeltaPhiQCD, cleanup and fix a few bugs

### DIFF
--- a/Production/test/runMakeTreeFromMiniAOD_cfg.py
+++ b/Production/test/runMakeTreeFromMiniAOD_cfg.py
@@ -32,7 +32,21 @@ jsonfile=parameters.value("jsonfile",scenario.jsonfile)
 jecfile=parameters.value("jecfile",scenario.jecfile)
 residual=parameters.value("residual",scenario.residual)
 era=parameters.value("era",scenario.era)
-    
+
+# The process needs to be defined AFTER reading sys.argv,
+# otherwise edmConfigHash fails
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+process = cms.Process("RA2EventSelection")
+if era=="Run2_25ns":
+    process = cms.Process("RA2EventSelection",eras.Run2_25ns)
+elif era=="Run2_50ns":
+    process = cms.Process("RA2EventSelection",eras.Run2_50ns)
+
+# configure geometry & conditions
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
+
 # Load input files
 readFiles = cms.untracked.vstring()
 
@@ -45,7 +59,7 @@ if dataset!=[] :
 
 # print out settings
 print "***** SETUP ************************************"
-print " dataset: "+str(dataset)
+print " dataset: "+str(readFiles)
 print " outfile: "+outfile
 print " "
 print " storing lostlepton variables: "+str(lostlepton)
@@ -65,20 +79,6 @@ if len(jsonfile)>0: print " JSON file applied: "+jsonfile
 if len(jecfile)>0: print " JECs applied: "+jecfile+(" (residuals)" if residual else "")
 print " era of this dataset: "+era
 print "************************************************"
-
-# The process needs to be defined AFTER reading sys.argv,
-# otherwise edmConfigHash fails
-import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process("RA2EventSelection")
-if era=="Run2_25ns":
-    process = cms.Process("RA2EventSelection",eras.Run2_25ns)
-elif era=="Run2_50ns":
-    process = cms.Process("RA2EventSelection",eras.Run2_50ns)
-
-# configure geometry & conditions
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 
 from TreeMaker.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD
 process = makeTreeFromMiniAOD(process,

--- a/Production/test/runMakeTreeFromMiniAOD_cfg.py
+++ b/Production/test/runMakeTreeFromMiniAOD_cfg.py
@@ -51,6 +51,7 @@ print " "
 print " storing lostlepton variables: "+str(lostlepton)
 print " storing hadtau variables: "+str(hadtau)
 print " storing Zinv variables: "+str(doZinv)
+print " storing QCD variables: "+str(QCD)
 print " "
 print " storing tag and probe variables: "+str(tagandprobe)
 print " storing track debugging variables: "+str(debugtracks)

--- a/TreeMaker/python/DeltaPhiQCD.py
+++ b/TreeMaker/python/DeltaPhiQCD.py
@@ -1,43 +1,67 @@
 import FWCore.ParameterSet.Config as cms
 
-def DeltaPhiQCD(process, METTag, is74X):
-      from TreeMaker.Utils.deltaphiqcd_cfi import deltaphiqcd
-      process.DeltaPhiQCD = deltaphiqcd.clone (
-      JetTagRecoJets      = cms.InputTag ( 'GoodJets' ) ,
-      JetTagGenJets       = cms.InputTag ( 'slimmedGenJets' ) ,
-      BTagInputTag        = cms.string   ( 'combinedInclusiveSecondaryVertexV2BJetTags' ) ,
-      GenParticleTag      = cms.InputTag ( 'prunedGenParticles' ) ,
-      GenMETTag           = METTag
-      )
+def DeltaPhiQCD(process, is74X, geninfo):
+    process.DeltaPhiQCDSeq = cms.Sequence()
 
-      if is74X:
-         process.DeltaPhiQCD.BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags')
+    if geninfo:
+        #make genjet subcollections
+        from TreeMaker.Utils.subJetSelection_cfi import SubGenJetSelection
+        
+        process.GenHTJets = SubGenJetSelection.clone(
+            JetTag = cms.InputTag('slimmedGenJets'),
+            MinPt  = cms.double(30),
+            MaxEta = cms.double(2.4),
+        )
+        process.DeltaPhiQCDSeq += process.GenHTJets
+        
+        process.GenMHTJets = SubGenJetSelection.clone(
+            JetTag = cms.InputTag('slimmedGenJets'),
+            MinPt  = cms.double(30),
+            MaxEta = cms.double(5.0),
+        )
+        process.DeltaPhiQCDSeq += process.GenMHTJets
+        process.TreeMaker2.VectorRecoCand.extend ( [ 'GenMHTJets(GenJets)' ] )
+        
+        #make gen MHT
+        from TreeMaker.Utils.mhtdouble_cfi import mhtdouble
+        process.GenMHT = mhtdouble.clone(
+            JetTag  = cms.InputTag('GenMHTJets'),
+        )
+        process.DeltaPhiQCDSeq += process.GenMHT
+        process.TreeMaker2.VarsDouble.extend(['GenMHT:Pt(GenMHT)','GenMHT:Phi(GenMHT_Phi)'])
 
-      process.Baseline += process.DeltaPhiQCD
+    from TreeMaker.Utils.deltaphiqcd_cfi import deltaphiqcd
+    process.DeltaPhiQCD = deltaphiqcd.clone (
+        JetTagRecoJets      = cms.VInputTag ( 'MHTJets','HTJets' ) ,
+        JetTagGenJets       = cms.VInputTag ( 'GenMHTJets', 'GenHTJets' ) ,
+        BTagInputTag        = cms.string   ( 'combinedInclusiveSecondaryVertexV2BJetTags' ) ,
+        GenParticleTag      = cms.InputTag ( 'prunedGenParticles' ) ,
+    )
+    if is74X:
+       process.DeltaPhiQCD.BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags')
+    process.DeltaPhiQCDSeq += process.DeltaPhiQCD
+    
+    process.AdditionalSequence += process.DeltaPhiQCDSeq
+
+    process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:RJetDeltaPhi' ] )
+
+    process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:GenDeltaPhi' ] )
+
+    process.TreeMaker2.VectorTLorentzVector.extend ( [ 'DeltaPhiQCD:NeutrinoLorentzVector' ] )
+    process.TreeMaker2.VectorInt.extend ( [ 'DeltaPhiQCD:NeutrinoPdg' ] )
+    process.TreeMaker2.VectorInt.extend ( [ 'DeltaPhiQCD:NeutrinoMotherPdg' ] )
+
+    process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:RJetMinDeltaPhiEta24'      ] )
+    process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:RJetMinDeltaPhiEta5'       ] )
+    process.TreeMaker2.VectorInt.extend    ( [ 'DeltaPhiQCD:RJetMinDeltaPhiIndexEta24' ] )
+    process.TreeMaker2.VectorInt.extend    ( [ 'DeltaPhiQCD:RJetMinDeltaPhiIndexEta5'  ] )
+
+    process.TreeMaker2.VectorString.extend ( [ 'DeltaPhiQCD:minDeltaPhiNames'          ] )
+
+    process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:GenMinDeltaPhiEta24'       ] )
+    process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:GenMinDeltaPhiEta5'        ] )
+    process.TreeMaker2.VectorInt.extend    ( [ 'DeltaPhiQCD:GenMinDeltaPhiIndexEta24'  ] )
+    process.TreeMaker2.VectorInt.extend    ( [ 'DeltaPhiQCD:GenMinDeltaPhiIndexEta5'   ] )
 
 
-      process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:RJetDeltaPhi' ] )
-
-      process.TreeMaker2.VectorTLorentzVector.extend ( [ 'DeltaPhiQCD:GenLorentzVector' ] )
-      process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:GenDeltaPhi' ] )
-
-      process.TreeMaker2.VarsDouble.extend ( [ 'DeltaPhiQCD:GenMET' , 'DeltaPhiQCD:GenMETphi' , 'DeltaPhiQCD:GenMHT' , 'DeltaPhiQCD:GenMHTphi' ] )
-
-      process.TreeMaker2.VectorTLorentzVector.extend ( [ 'DeltaPhiQCD:NeutrinoLorentzVector' ] )
-      process.TreeMaker2.VectorInt.extend ( [ 'DeltaPhiQCD:NeutrinoPdg' ] )
-      process.TreeMaker2.VectorInt.extend ( [ 'DeltaPhiQCD:NeutrinoMotherPdg' ] )
-
-      process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:RJetMinDeltaPhiEta24'      ] )
-      process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:RJetMinDeltaPhiEta5'       ] )
-      process.TreeMaker2.VectorInt.extend    ( [ 'DeltaPhiQCD:RJetMinDeltaPhiIndexEta24' ] )
-      process.TreeMaker2.VectorInt.extend    ( [ 'DeltaPhiQCD:RJetMinDeltaPhiIndexEta5'  ] )
-
-      process.TreeMaker2.VectorString.extend ( [ 'DeltaPhiQCD:minDeltaPhiNames'          ] )
-
-      process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:GenMinDeltaPhiEta24'       ] )
-      process.TreeMaker2.VectorDouble.extend ( [ 'DeltaPhiQCD:GenMinDeltaPhiEta5'        ] )
-      process.TreeMaker2.VectorInt.extend    ( [ 'DeltaPhiQCD:GenMinDeltaPhiIndexEta24'  ] )
-      process.TreeMaker2.VectorInt.extend    ( [ 'DeltaPhiQCD:GenMinDeltaPhiIndexEta5'   ] )
-
-
-      return process
+    return process

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -605,10 +605,14 @@ QCD=False,
     from TreeMaker.Utils.metdouble_cfi import metdouble
     process.MET = metdouble.clone(
         METTag = METTag,
+        GenMETTag = cms.InputTag("slimmedMETs","","PAT"), #deliberately hardcoded
         JetTag = cms.InputTag('HTJets'),
+        geninfo = cms.untracked.bool(geninfo),
     )
     process.Baseline += process.MET
     VarsDouble.extend(['MET:minDeltaPhiN','MET:DeltaPhiN1','MET:DeltaPhiN2','MET:DeltaPhiN3','MET:Pt(METPt)','MET:Phi(METPhi)'])
+    if geninfo:
+        VarsDouble.extend(['MET:GenPt(GenMETPt)','MET:GenPhi(GenMETPhi)'])
 
     ## ----------------------------------------------------------------------------------------------
     ## Jet properties
@@ -689,7 +693,7 @@ QCD=False,
     ## ----------------------------------------------------------------------------------------------
     if QCD:
         from TreeMaker.TreeMaker.DeltaPhiQCD import DeltaPhiQCD
-        process = DeltaPhiQCD(process, METTag, is74X)
+        process = DeltaPhiQCD(process,is74X,geninfo)
 
     ## ----------------------------------------------------------------------------------------------
     ## ----------------------------------------------------------------------------------------------

--- a/Utils/python/deltaphiqcd_cfi.py
+++ b/Utils/python/deltaphiqcd_cfi.py
@@ -1,10 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 deltaphiqcd  = cms.EDProducer ( 'DeltaPhiQCD',
-JetTagRecoJets = cms.InputTag ( 'GoodJets' ) ,
-JetTagGenJets = cms.InputTag ( 'slimmedGenJets' ) ,
-BTagInputTag = cms.InputTag ( 'combinedInclusiveSecondaryVertexV2BJetTags' ) ,
-GenParticleTag = cms.InputTag ( 'prunedGenParticles' ) ,
-GenMETTag  = cms.InputTag ( 'slimmedMETs' )
+    JetTagRecoJets      = cms.VInputTag ( 'MHTJets','HTJets' ) ,
+    JetTagGenJets       = cms.VInputTag ( 'GenMHTJets', 'GenHTJets' ) ,
+    BTagInputTag = cms.InputTag ( 'combinedInclusiveSecondaryVertexV2BJetTags' ) ,
+    GenParticleTag = cms.InputTag ( 'prunedGenParticles' ) ,
 )
 

--- a/Utils/python/metdouble_cfi.py
+++ b/Utils/python/metdouble_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 metdouble = cms.EDProducer('METDouble',
    METTag  = cms.InputTag("slimmedMETs"),
+   GenMETTag  = cms.InputTag("slimmedMETs"),
    JetTag  = cms.InputTag('JetTag'),
    cleanTag = cms.untracked.VInputTag()
 )

--- a/Utils/python/subJetSelection_cfi.py
+++ b/Utils/python/subJetSelection_cfi.py
@@ -5,3 +5,9 @@ SubJetSelection = cms.EDProducer('SubJetSelection',
                                  MinPt = cms.double(30),
                                  MaxEta = cms.double(5.0),
 )
+
+SubGenJetSelection = cms.EDProducer('SubGenJetSelection',
+                                 JetTag = cms.InputTag('slimmedGenJets'),
+                                 MinPt = cms.double(30),
+                                 MaxEta = cms.double(5.0),
+)

--- a/Utils/src/DeltaPhiQCD.cc
+++ b/Utils/src/DeltaPhiQCD.cc
@@ -197,7 +197,7 @@ void DeltaPhiQCD::produce ( edm::Event& iEvent, const edm::EventSetup& iSetup )
                 LorentzVector mhtLorentzstar2 = mhtLorentzstar + src->at(i).p4();
                 deltaphistar = std::abs( reco::deltaPhi( src->at(i).phi(), mhtLorentzstar2.phi() ) );
 
-                if ( std::abs ( mindeltaphistar ) > std::abs ( deltaphistar ) ) { mindeltaphistar = deltaphistar; mindeltaphistarindex = i; }
+                if ( std::abs ( mindeltaphistar ) > std::abs ( deltaphistar ) ) { mindeltaphistar = deltaphistar; mindeltaphistarindex = i + 1; }
 
             } //i
 
@@ -320,7 +320,7 @@ void DeltaPhiQCD::produce ( edm::Event& iEvent, const edm::EventSetup& iSetup )
             {
                 LorentzVector genmhtLorentzstar2 = genmhtLorentzstar + gensrc->at(k).p4();
                 gendeltaphistar = std::abs( reco::deltaPhi( gensrc -> at(k).phi(), genmhtLorentzstar2.phi() ) ) ;
-                if ( std::abs( genmindeltaphistar ) > std::abs( gendeltaphistar ) ) { genmindeltaphistar = gendeltaphistar; genmindeltaphistarindex = k; }
+                if ( std::abs( genmindeltaphistar ) > std::abs( gendeltaphistar ) ) { genmindeltaphistar = gendeltaphistar; genmindeltaphistarindex = k + 1; }
             }//k
         }//if gensrc.isValid
 		else 

--- a/Utils/src/DeltaPhiQCD.cc
+++ b/Utils/src/DeltaPhiQCD.cc
@@ -15,7 +15,10 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include <iostream>
 #include <fstream>
-#include <string.h>
+#include <string>
+#include <cmath>
+#include <map>
+#include <utility>
 #include "TLorentzVector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
@@ -26,9 +29,7 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include <DataFormats/Math/interface/deltaR.h>
-#include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
-#include "DataFormats/METReco/interface/MET.h"
 
 
 //
@@ -37,27 +38,26 @@
 
 class DeltaPhiQCD : public edm::EDProducer {
 public:
-      explicit DeltaPhiQCD ( const edm::ParameterSet& ) ;
-      ~DeltaPhiQCD();
-      
-      static void fillDescriptions ( edm::ConfigurationDescriptions& descriptions ) ;
-      
+    explicit DeltaPhiQCD ( const edm::ParameterSet& ) ;
+    ~DeltaPhiQCD();
+    
+    static void fillDescriptions ( edm::ConfigurationDescriptions& descriptions ) ;
+    
 private:
-      virtual void beginJob () ;
-      virtual void produce ( edm::Event&, const edm::EventSetup& ) ;
-      virtual void endJob () ;
-      
-      virtual void beginRun( edm::Run&, edm::EventSetup const& ) ;
-      virtual void endRun( edm::Run&, edm::EventSetup const& ) ;
-      virtual void beginLuminosityBlock ( edm::LuminosityBlock&, edm::EventSetup const& ) ;
-      virtual void endLuminosityBlock ( edm::LuminosityBlock&, edm::EventSetup const& ) ;
-      edm::InputTag JetTagRecoJets_ ;
-      edm::InputTag JetTagGenJets_ ;
-      std::string   btagname_ ;      
-      edm::InputTag GenParticleTag_ ;
-      edm::InputTag metTag_ ;
-
-      // ----------member data ---------------------------
+    virtual void beginJob () ;
+    virtual void produce ( edm::Event&, const edm::EventSetup& ) ;
+    virtual void endJob () ;
+    
+    virtual void beginRun( edm::Run&, edm::EventSetup const& ) ;
+    virtual void endRun( edm::Run&, edm::EventSetup const& ) ;
+    virtual void beginLuminosityBlock ( edm::LuminosityBlock&, edm::EventSetup const& ) ;
+    virtual void endLuminosityBlock ( edm::LuminosityBlock&, edm::EventSetup const& ) ;
+    std::vector<edm::InputTag> JetTagRecoJets_ ;
+    std::vector<edm::InputTag> JetTagGenJets_ ;
+    std::string   btagname_ ;      
+    edm::InputTag GenParticleTag_ ;
+    
+    // ----------member data ---------------------------
 };
 
 //
@@ -77,48 +77,40 @@ DeltaPhiQCD::DeltaPhiQCD ( const edm::ParameterSet& iConfig )
 {
 
 
-      //register your product
-      JetTagRecoJets_ = iConfig.getParameter < edm::InputTag > ( "JetTagRecoJets" ) ;
-      btagname_       = iConfig.getParameter < std::string   > ( "BTagInputTag"   ) ;
-      JetTagGenJets_  = iConfig.getParameter < edm::InputTag > ( "JetTagGenJets"  ) ;
-      GenParticleTag_ = iConfig.getParameter < edm::InputTag > ( "GenParticleTag" ) ;
-      metTag_         = iConfig.getParameter < edm::InputTag > ( "GenMETTag"      ) ;
+    //register your product
+    JetTagRecoJets_ = iConfig.getParameter < std::vector<edm::InputTag> > ( "JetTagRecoJets" ) ;
+    btagname_       = iConfig.getParameter < std::string   > ( "BTagInputTag"   ) ;
+    JetTagGenJets_  = iConfig.getParameter < std::vector<edm::InputTag> > ( "JetTagGenJets"  ) ;
+    GenParticleTag_ = iConfig.getParameter < edm::InputTag > ( "GenParticleTag" ) ;
 
 
-      produces < std::vector < TLorentzVector > > ( "GenLorentzVector"      ) ;
-      produces < std::vector < TLorentzVector > > ( "NeutrinoLorentzVector" ) ;
+    produces < std::vector < TLorentzVector > > ( "NeutrinoLorentzVector" ) ;
 
-      produces < std::vector < double > > ( "GenDeltaPhi"          ) ;
-      produces < std::vector < double > > ( "RJetDeltaPhi"         ) ;
-      produces < std::vector < double > > ( "RJetMinDeltaPhiEta24" ) ;
-      produces < std::vector < double > > ( "RJetMinDeltaPhiEta5"  ) ;
-      produces < std::vector < double > > ( "GenMinDeltaPhiEta24"  ) ;
-      produces < std::vector < double > > ( "GenMinDeltaPhiEta5"   ) ;
+    produces < std::vector < double > > ( "GenDeltaPhi"          ) ;
+    produces < std::vector < double > > ( "RJetDeltaPhi"         ) ;
+    produces < std::vector < double > > ( "RJetMinDeltaPhiEta24" ) ;
+    produces < std::vector < double > > ( "RJetMinDeltaPhiEta5"  ) ;
+    produces < std::vector < double > > ( "GenMinDeltaPhiEta24"  ) ;
+    produces < std::vector < double > > ( "GenMinDeltaPhiEta5"   ) ;
 
-      produces < std::vector < std::string > > ( "minDeltaPhiNames" ) ;
+    produces < std::vector < std::string > > ( "minDeltaPhiNames" ) ;
 
-      produces < std::vector < int > > ( "NeutrinoPdg"               ) ;
-      produces < std::vector < int > > ( "NeutrinoMotherPdg"         ) ;
-      produces < std::vector < int > > ( "RJetMinDeltaPhiIndexEta24" ) ;
-      produces < std::vector < int > > ( "RJetMinDeltaPhiIndexEta5"  ) ;
-      produces < std::vector < int > > ( "GenMinDeltaPhiIndexEta24"  ) ;
-      produces < std::vector < int > > ( "GenMinDeltaPhiIndexEta5"   ) ;
-
-      produces < double > ( "GenMHT"    ) ;
-      produces < double > ( "GenMHTphi" ) ;
-      produces < double > ( "GenMET"    ) ;
-      produces < double > ( "GenMETphi" ) ;
-
+    produces < std::vector < int > > ( "NeutrinoPdg"               ) ;
+    produces < std::vector < int > > ( "NeutrinoMotherPdg"         ) ;
+    produces < std::vector < int > > ( "RJetMinDeltaPhiIndexEta24" ) ;
+    produces < std::vector < int > > ( "RJetMinDeltaPhiIndexEta5"  ) ;
+    produces < std::vector < int > > ( "GenMinDeltaPhiIndexEta24"  ) ;
+    produces < std::vector < int > > ( "GenMinDeltaPhiIndexEta5"   ) ;
 
 }
 
 
 DeltaPhiQCD::~DeltaPhiQCD()
 {
-      
-      // do anything here that needs to be done at desctruction time
-      // (e.g. close files, deallocate resources etc.)
-      
+    
+    // do anything here that needs to be done at desctruction time
+    // (e.g. close files, deallocate resources etc.)
+    
 }
 
 
@@ -129,176 +121,128 @@ DeltaPhiQCD::~DeltaPhiQCD()
 // ------------ method called to produce the data  ------------
 void DeltaPhiQCD::produce ( edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
+    
+    using namespace edm;
+    using namespace std;
+    typedef math::XYZTLorentzVector LorentzVector;
+    
+    std::vector < double >  deltaphi_vector ;
+    std::vector < double >  RJetminDeltaphi5, RJetminDeltaphi24 ;
+    
+    std::vector < int >  RJetminDeltaphiIndex24,  RJetminDeltaphiIndex5;
+    
+    std::vector < std::string > minDeltaphiNames ;
+    
+    edm::Handle < double > var ;
+    
+    
+    std::vector<std::vector<double> > savephi(2,std::vector<double>(8,-9));
+    std::vector<std::vector<double> > saveeta(2,std::vector<double>(8,-9));
+    double recojetseta = -99. , recojetsphi = -99. , deltaphi = -99. ;
+    double mindeltaphi3 = -9, mindeltaphi4 = -9, mindeltaphi5 = -9 ;
+    double mindeltaphistar = -9, deltaphistar = -9 ;
+    double mhtphi ;
+    
+    int mindeltaphi3jetindex = -9, mindeltaphi4jetindex = -9, mindeltaphi5jetindex = -9, mindeltaphistarindex = -9 ;
+    
+    edm::InputTag MHT_Phi ( "MHT" , "Phi" ) ;
+    iEvent.getByLabel ( MHT_Phi , var ) ;
+    if ( var.isValid() ) mhtphi = *var ;
+    else { std::cout << "Warning: Can not retrieve MHTPhi" << std::endl ; mhtphi = -9 ; }
 
-      using namespace edm;
-      using namespace std;
-
-      std::vector < double >  deltaphi_vector ;
-      std::vector < double >  RJetminDeltaphi5, RJetminDeltaphi24 ;
-
-      std::vector < int >  RJetminDeltaphiIndex24,  RJetminDeltaphiIndex5;
-
-      std::vector < std::string > minDeltaphiNames ;
-
-      edm::Handle < double > var ;
-
-
-      double savephi [8][2], saveeta [8][2] ;
-      double recojetseta = -99. , recojetsphi = -99. , deltaphi = -99. ;
-      double mindeltaphi3 = -9, mindeltaphi4 = -9, mindeltaphi5 = -9 ;
-      double mindeltaphistar = -9, deltaphistar = -9 ;
-      double etacut, mhtphi ;
-
-      int mindeltaphi3jetindex = -9, mindeltaphi4jetindex = -9, mindeltaphi5jetindex = -9, mindeltaphistarindex = -9 ;
-
-      reco::MET::LorentzVector mhtLorentzstar ( 0,0,0,0 ) ;
-
-//      edm::InputTag MHT_Pt("MHT","Pt");
-//      iEvent.getByLabel(MHT_Pt,var);
-//      double mhtPt = *var;
-
-      edm::InputTag MHT_Phi ( "MHT" , "Phi" ) ;
-      iEvent.getByLabel ( MHT_Phi , var ) ;
-      if ( var.isValid() ) mhtphi = *var ;
-	else { std::cout << "Warning: Can not retrieve MHTPhi" << std::cout ; mhtphi = -9 ;}
-
-      edm::Handle < edm::View < pat::Jet > > src ;
-      iEvent.getByLabel ( JetTagRecoJets_ , src ) ;
-
-
-
-      for ( unsigned int ii = 0; ii < 2; ii++ )
-      {
-            if ( ii == 0 ) etacut = 5 ;
-            if ( ii == 1 ) etacut = 2.4 ;
-            if ( src.isValid() )
-            {
-            	
+    for ( unsigned int ii = 0; ii < 2; ii++ )
+    {
+        edm::Handle < edm::View < reco::Jet > > src ;
+        iEvent.getByLabel ( JetTagRecoJets_[ii] , src ) ;
+        
+        if ( src.isValid() )
+        {
+            
             mindeltaphi3 = -9; mindeltaphi4 = -9; mindeltaphi5 = -9; mindeltaphi3jetindex = -9; mindeltaphi4jetindex = -9; mindeltaphi5jetindex = -9;
-            unsigned int i = 0 ;
-            for ( unsigned int index = 0; index < 8; ++index )
+            for ( unsigned int index = 0; index < std::min((unsigned)8,(unsigned)src->size()); ++index )
             {
-                  if ( i < src -> size() )
-                        while ( src -> at(i).pt() < 30 || src -> at(i).eta() > etacut || src -> at(i).eta() < (-1)*etacut ) 
-                        {
-                              i++ ;
-                              if ( i >= src -> size())  break ;
-                        }//while
 
-                  if ( i < src -> size() )
-                  {
-                        recojetsphi = src -> at(i).phi() ;
-                        recojetseta = src -> at(i).eta() ;
-                        deltaphi = std::abs( reco::deltaPhi( src -> at(i).phi() , mhtphi ) ) ;
+                recojetsphi = src -> at(index).phi() ;
+                recojetseta = src -> at(index).eta() ;
+                deltaphi = std::abs( reco::deltaPhi( src -> at(index).phi() , mhtphi ) ) ;
 
-                        if (std::abs( mindeltaphi3 ) > std::abs( deltaphi ) && index < 3 ) { mindeltaphi3 = deltaphi; mindeltaphi3jetindex = index+1; }
-                        if (std::abs( mindeltaphi4 ) > std::abs( deltaphi ) && index < 4 ) { mindeltaphi4 = deltaphi; mindeltaphi4jetindex = index+1; }
-                        if (std::abs( mindeltaphi5 ) > std::abs( deltaphi ) && index < 5 ) { mindeltaphi5 = deltaphi; mindeltaphi5jetindex = index+1; }
+                if (std::abs( mindeltaphi3 ) > std::abs( deltaphi ) && index < 3 ) { mindeltaphi3 = deltaphi; mindeltaphi3jetindex = index+1; }
+                if (std::abs( mindeltaphi4 ) > std::abs( deltaphi ) && index < 4 ) { mindeltaphi4 = deltaphi; mindeltaphi4jetindex = index+1; }
+                if (std::abs( mindeltaphi5 ) > std::abs( deltaphi ) && index < 5 ) { mindeltaphi5 = deltaphi; mindeltaphi5jetindex = index+1; }
 
-                        if ( etacut == 5 ) 
-                        {
-                              TLorentzVector dumb_vector;
-                              deltaphi_vector.push_back ( deltaphi ) ;
-                        }
-                        
-                  }//if i
-                  else
-                  {
+                if ( ii == 0 ) deltaphi_vector.push_back ( deltaphi ) ;
 
-                        recojetsphi = -9 ;
-                        recojetseta = -9 ;
-                        deltaphi = -9 ;
-
-                  }//else
-
-                  savephi [index][ii] = recojetsphi ; 
-                  saveeta [index][ii] = recojetseta ;
-                  i++ ;
+                savephi [ii][index] = recojetsphi ; 
+                saveeta [ii][index] = recojetseta ;
 
             }//index
 
 
-            if ( etacut == 5 )
+            if ( ii == 0 )
             {
 
-                  std::auto_ptr < std::vector < double > > deltaphi_vector2  ( new std::vector < double > ( deltaphi_vector ) ) ;
-                  iEvent.put ( deltaphi_vector2 , "RJetDeltaPhi" ) ;
+                std::auto_ptr < std::vector < double > > deltaphi_vector2  ( new std::vector < double > ( deltaphi_vector ) ) ;
+                iEvent.put ( deltaphi_vector2 , "RJetDeltaPhi" ) ;
 
             }
 
-
             mindeltaphistar = -9; mindeltaphistarindex = -9;
+            LorentzVector mhtLorentzstar ( 0,0,0,0 ) ;
+            for ( unsigned int j = 0; j < src -> size(); j++ )
+            {
+                mhtLorentzstar -= src->at(j).p4();
+            }//j
             for ( unsigned int i = 0; i < src -> size(); i++ )
             {
+                LorentzVector mhtLorentzstar2 = mhtLorentzstar + src->at(i).p4();
+                deltaphistar = std::abs( reco::deltaPhi( src->at(i).phi(), mhtLorentzstar2.phi() ) );
 
-                  mhtLorentzstar.SetPxPyPzE ( 0,0,0,0 ) ;
-                  for( unsigned int j = 0; j < src -> size(); j++ )
-                        if ( src -> at(j).pt() >= 30 && src -> at(j).eta() <= etacut && src -> at(j).eta() >= (-1) * etacut && j != i) mhtLorentzstar -= src->at(j).p4();
-                  deltaphistar = std::abs( reco::deltaPhi( src->at(i).phi(), mhtLorentzstar.phi() ) );
-
-                  if ( std::abs ( mindeltaphistar ) > std::abs ( deltaphistar ) ) { mindeltaphistar = deltaphistar; mindeltaphistarindex = i; }
+                if ( std::abs ( mindeltaphistar ) > std::abs ( deltaphistar ) ) { mindeltaphistar = deltaphistar; mindeltaphistarindex = i; }
 
             } //i
 
-            }//if vsrc.isValid
-            else 
-                  std::cout << "Warning Reco Tag not valid: " << JetTagRecoJets_.label() << std::endl ;
+        }//if vsrc.isValid
+        else 
+            std::cout << "Warning Reco Tag not valid: " << JetTagRecoJets_[ii].label() << std::endl ;
 
-            if ( etacut == 5 ) 
-            { 
-
-                  RJetminDeltaphi5     .push_back ( mindeltaphi3         ) ;
-                  RJetminDeltaphi5     .push_back ( mindeltaphi4         ) ;
-                  RJetminDeltaphi5     .push_back ( mindeltaphi5         ) ;
-                  RJetminDeltaphi5     .push_back ( mindeltaphistar      ) ;
-
-                  RJetminDeltaphiIndex5.push_back ( mindeltaphi3jetindex ) ;
-                  RJetminDeltaphiIndex5.push_back ( mindeltaphi4jetindex ) ;
-                  RJetminDeltaphiIndex5.push_back ( mindeltaphi5jetindex ) ;
-                  RJetminDeltaphiIndex5.push_back ( mindeltaphistarindex ) ;
-
-            }
+        if ( ii == 0 ) 
+        { 
+            
+            RJetminDeltaphi5 = { mindeltaphi3, mindeltaphi4, mindeltaphi5, mindeltaphistar } ;        
+            RJetminDeltaphiIndex5 = { mindeltaphi3jetindex, mindeltaphi4jetindex, mindeltaphi5jetindex, mindeltaphistarindex } ;
+            
+        }
 
 
-            if ( etacut == 2.4 ) 
-            {
-
-                  RJetminDeltaphi24     .push_back ( mindeltaphi3         ) ;
-                  RJetminDeltaphi24     .push_back ( mindeltaphi4         ) ;
-                  RJetminDeltaphi24     .push_back ( mindeltaphi5         ) ;
-                  RJetminDeltaphi24     .push_back ( mindeltaphistar      ) ;
-
-                  RJetminDeltaphiIndex24.push_back ( mindeltaphi3jetindex ) ;
-                  RJetminDeltaphiIndex24.push_back ( mindeltaphi4jetindex ) ;
-                  RJetminDeltaphiIndex24.push_back ( mindeltaphi5jetindex ) ;
-                  RJetminDeltaphiIndex24.push_back ( mindeltaphistarindex ) ;
-
-            }
+        else if ( ii == 1 ) 
+        {
+            
+            RJetminDeltaphi24 = { mindeltaphi3, mindeltaphi4, mindeltaphi5, mindeltaphistar } ;
+            RJetminDeltaphiIndex24 = { mindeltaphi3jetindex, mindeltaphi4jetindex, mindeltaphi5jetindex, mindeltaphistarindex } ;
+            
+        }
 
 
-      }//ii
+    }//ii
 
 
-      minDeltaphiNames.push_back ( "Njle3"           ) ; 
-      minDeltaphiNames.push_back ( "Njle4"           ) ;
-      minDeltaphiNames.push_back ( "Njle5"           ) ;
-      minDeltaphiNames.push_back ( "minDeltaPhiStar" ) ;
+    minDeltaphiNames = {"Njle3", "Njle4", "Njle5", "minDeltaPhiStar" } ;
 
 
-      std::auto_ptr < std::vector < double > > RJetminDeltaphi24_2      ( new std::vector < double > ( RJetminDeltaphi24      ) ) ;
-      iEvent.put ( RJetminDeltaphi24_2      , "RJetMinDeltaPhiEta24"      ) ;
+    std::auto_ptr < std::vector < double > > RJetminDeltaphi24_2      ( new std::vector < double > ( RJetminDeltaphi24      ) ) ;
+    iEvent.put ( RJetminDeltaphi24_2      , "RJetMinDeltaPhiEta24"      ) ;
 
-      std::auto_ptr < std::vector < double > > RJetminDeltaphi5_2       ( new std::vector < double > ( RJetminDeltaphi5       ) ) ;
-      iEvent.put ( RJetminDeltaphi5_2       , "RJetMinDeltaPhiEta5"       ) ;
+    std::auto_ptr < std::vector < double > > RJetminDeltaphi5_2       ( new std::vector < double > ( RJetminDeltaphi5       ) ) ;
+    iEvent.put ( RJetminDeltaphi5_2       , "RJetMinDeltaPhiEta5"       ) ;
 
-      std::auto_ptr < std::vector < int    > > RJetminDeltaphiIndex24_2 ( new std::vector < int    > ( RJetminDeltaphiIndex24 ) ) ;
-      iEvent.put ( RJetminDeltaphiIndex24_2 , "RJetMinDeltaPhiIndexEta24" ) ;
+    std::auto_ptr < std::vector < int    > > RJetminDeltaphiIndex24_2 ( new std::vector < int    > ( RJetminDeltaphiIndex24 ) ) ;
+    iEvent.put ( RJetminDeltaphiIndex24_2 , "RJetMinDeltaPhiIndexEta24" ) ;
 
-      std::auto_ptr < std::vector < int    > > RJetminDeltaphiIndex5_2  ( new std::vector < int    > ( RJetminDeltaphiIndex5  ) ) ;
-      iEvent.put ( RJetminDeltaphiIndex5_2  , "RJetMinDeltaPhiIndexEta5"  ) ;
+    std::auto_ptr < std::vector < int    > > RJetminDeltaphiIndex5_2  ( new std::vector < int    > ( RJetminDeltaphiIndex5  ) ) ;
+    iEvent.put ( RJetminDeltaphiIndex5_2  , "RJetMinDeltaPhiIndexEta5"  ) ;
 
-      std::auto_ptr < std::vector < std::string > > minDeltaphiNames_2  ( new std::vector < std::string > ( minDeltaphiNames  ) ) ;
-      iEvent.put ( minDeltaphiNames_2       , "minDeltaPhiNames"          ) ;
+    std::auto_ptr < std::vector < std::string > > minDeltaphiNames_2  ( new std::vector < std::string > ( minDeltaphiNames  ) ) ;
+    iEvent.put ( minDeltaphiNames_2       , "minDeltaPhiNames"          ) ;
 
 
 
@@ -310,312 +254,202 @@ void DeltaPhiQCD::produce ( edm::Event& iEvent, const edm::EventSetup& iSetup )
 
 
 
-      std::vector < TLorentzVector > GenJetVector ;
+    std::vector < TLorentzVector > GenJetVector ;
 
-      std::vector < double >  Gendeltaphi_vector ;
-      std::vector < double >  GenminDeltaphi5, GenminDeltaphi24 ;
+    std::vector < double >  Gendeltaphi_vector ;
+    std::vector < double >  GenminDeltaphi5, GenminDeltaphi24 ;
 
-      std::vector < int >  GenminDeltaphiIndex5, GenminDeltaphiIndex24 ;
+    std::vector < int >  GenminDeltaphiIndex5, GenminDeltaphiIndex24 ;
 
-      double genmindeltaphi3 = -9, genmindeltaphi4 = -9, genmindeltaphi5 = -9 ;
-      double genmindeltaphistar = -9, gendeltaphistar = -9, gendeltaphi = -9 ;
-      double genetacut ;
-      double genjetspt, genjetseta, genjetsphi, mindeltar ;
+    double genmindeltaphi3 = -9, genmindeltaphi4 = -9, genmindeltaphi5 = -9 ;
+    double genmindeltaphistar = -9, gendeltaphistar = -9, gendeltaphi = -9 ;
+    double mindeltar ;
 
-      reco::MET::LorentzVector genmhtLorentz    ( 0,0,0,0 ) ;
-      reco::MET::LorentzVector genmhtLorentzstar( 0,0,0,0 ) ;
+    std::string genname ;
+    int mindeltarindex ;
+    int genmindeltaphi3jetindex = -9, genmindeltaphi4jetindex = -9, genmindeltaphi5jetindex = -9, genmindeltaphistarindex = -9 ;
 
-      std::string genname ;
+    for ( unsigned int ii = 0; ii < 2; ii++ )
+    {
 
-      unsigned int  matchfound [1000] ;
-      int mindeltarindex ;
-      int genmindeltaphi3jetindex = -9, genmindeltaphi4jetindex = -9, genmindeltaphi5jetindex = -9, genmindeltaphistarindex = -9 ;
+        edm::Handle < edm::View < reco::GenJet > > gensrc ;
+        iEvent.getByLabel( JetTagGenJets_[ii],gensrc ) ;
 
-      edm::Handle < edm::View < reco::GenJet > > gensrc ;
-      iEvent.getByLabel( JetTagGenJets_,gensrc ) ;
-
-      if ( gensrc.isValid() )
-           for ( unsigned int l = 0 ; l < gensrc -> size() ; l++ )
-                 if ( gensrc -> at(l).pt() >= 30 && gensrc -> at(l).eta() <= 5 && gensrc -> at(l).eta() >= -5 ) genmhtLorentz -= gensrc -> at(l).p4() ;
-
-
-      for ( unsigned int ii = 0; ii < 2; ii++ )
-      {
-
-            if ( ii == 0 ) genetacut = 5   ;
-            if ( ii == 1 ) genetacut = 2.4 ;
-
-            if ( gensrc.isValid() )
-            {
-            for ( int dumb = 0; dumb < 1000; dumb ++ ) matchfound [dumb] = 0 ;
+        if ( gensrc.isValid() )
+        {
+            std::vector<unsigned int>  matchfound(gensrc->size(),0);
             genmindeltaphi3 = -9; genmindeltaphi4 = -9; genmindeltaphi5 = -9 ; 
             genmindeltaphi3jetindex = -9; genmindeltaphi4jetindex = -9; genmindeltaphi5jetindex = -9;
 
             int onoff = 0 ;
             for ( unsigned int j = 0; j < 8; j++ )
             {
-                  onoff = 0 ;
-                  mindeltar = 100; mindeltarindex = -9;
-                  for ( unsigned int i = 0; i < gensrc -> size(); ++i )
-                  {
-                        if ( deltaR ( gensrc -> at(i).eta() , gensrc -> at(i).phi() , saveeta[j][ii], savephi[j][ii] ) < mindeltar && matchfound [i] == 0 && onoff == 0 && saveeta[j][ii] != -9 && savephi[j][ii] != -9 )
-                        {
-                                    mindeltar = deltaR( gensrc -> at(i).eta(), gensrc -> at(i).phi(), saveeta[j][ii], savephi[j][ii] ) ;
-                                    mindeltarindex = i ;
-//                                    if ( mindeltar < .25 ) onoff = 1;
+                onoff = 0 ;
+                mindeltar = 100; mindeltarindex = -9;
+                for ( unsigned int i = 0; i < gensrc -> size(); ++i )
+                {
+                    if ( deltaR ( gensrc -> at(i).eta() , gensrc -> at(i).phi() , saveeta[ii][j], savephi[ii][j] ) < mindeltar && matchfound [i] == 0 && onoff == 0 && saveeta[ii][j] != -9 && savephi[ii][j] != -9 )
+                    {
+                        mindeltar = deltaR( gensrc -> at(i).eta(), gensrc -> at(i).phi(), saveeta[ii][j], savephi[ii][j] ) ;
+                        mindeltarindex = i ;
+                    //  if ( mindeltar < .25 ) onoff = 1;
 
-                        }//if deltaR
-                  }//i
+                    }//if deltaR
+                }//i
 
-                  if ( mindeltarindex >= 0 && mindeltarindex < (int) gensrc -> size() )
-                  {
+                if ( mindeltarindex >= 0 && mindeltarindex < (int) gensrc -> size() )
+                {
 
-                        matchfound [ mindeltarindex ] = 1 ;
-                        genjetspt  = gensrc -> at( mindeltarindex ).pt()  ;
-                        genjetsphi = gensrc -> at( mindeltarindex ).phi() ;
-                        genjetseta = gensrc -> at( mindeltarindex ).eta() ;
+                    matchfound [ mindeltarindex ] = 1 ;
+                    gendeltaphi = std::abs( reco::deltaPhi ( gensrc -> at ( mindeltarindex ).phi(), mhtphi ) ) ;
 
-                        gendeltaphi = std::abs( reco::deltaPhi ( gensrc -> at ( mindeltarindex ).phi(), mhtphi ) ) ;
+                    if ( std::abs(genmindeltaphi3) > std::abs(gendeltaphi) && j < 3 ) { genmindeltaphi3 = gendeltaphi; genmindeltaphi3jetindex = j + 1; }
+                    if ( std::abs(genmindeltaphi4) > std::abs(gendeltaphi) && j < 4 ) { genmindeltaphi4 = gendeltaphi; genmindeltaphi4jetindex = j + 1; }
+                    if ( std::abs(genmindeltaphi5) > std::abs(gendeltaphi) && j < 5 ) { genmindeltaphi5 = gendeltaphi; genmindeltaphi5jetindex = j + 1; }
 
-                        if ( std::abs(genmindeltaphi3) > std::abs(gendeltaphi) && j < 3 ) { genmindeltaphi3 = gendeltaphi; genmindeltaphi3jetindex = j + 1; }
-                        if ( std::abs(genmindeltaphi4) > std::abs(gendeltaphi) && j < 4 ) { genmindeltaphi4 = gendeltaphi; genmindeltaphi4jetindex = j + 1; }
-                        if ( std::abs(genmindeltaphi5) > std::abs(gendeltaphi) && j < 5 ) { genmindeltaphi5 = gendeltaphi; genmindeltaphi5jetindex = j + 1; }
-                        if ( genetacut == 5 )
-                        {
-
-                              TLorentzVector dumb_vector ;
-                              dumb_vector.SetPtEtaPhiE( genjetspt,genjetseta,genjetsphi,gensrc -> at( mindeltarindex ).energy() ) ;
-                              GenJetVector.push_back( dumb_vector ) ;
-                              Gendeltaphi_vector.push_back ( gendeltaphi ) ;
-      
-                        } // if genetacut
-                  } // if mindeltarindex
+                } // if mindeltarindex
             } //j
 
-            if ( genetacut == 5 )
-            {
-                  std::auto_ptr < double > genmhtpt2  ( new double ( genmhtLorentz.pt()  ) ) ;
-                  iEvent.put ( genmhtpt2 , "GenMHT" ) ;
-                  std::auto_ptr < double > genmhtphi2 ( new double ( genmhtLorentz.phi() ) ) ;
-                  iEvent.put ( genmhtphi2 , "GenMHTphi" ) ;
-            }
-
             genmindeltaphistar = -9; genmindeltaphistarindex = -9;
+            LorentzVector genmhtLorentzstar( 0,0,0,0 ) ;
+            for ( unsigned int l = 0 ; l < gensrc -> size() ; l++ )
+            {
+                genmhtLorentzstar -= gensrc->at(l).p4() ;
+            }//l
             for( unsigned int k = 0; k < gensrc -> size(); k++ )
             {
-                  for ( unsigned int l = 0 ; l < gensrc -> size() ; l++ )
-                        if ( gensrc -> at(l).pt() >= 30 && gensrc -> at(l).eta() <= genetacut && gensrc -> at(l).eta() >= (-1) * genetacut && l != k ) genmhtLorentzstar -= gensrc->at(l).p4() ;
-                  gendeltaphistar = std::abs( reco::deltaPhi( gensrc -> at(k).phi(), genmhtLorentzstar.phi() ) ) ;
-                  if ( std::abs( genmindeltaphistar ) > std::abs( gendeltaphistar ) ) { genmindeltaphistar = gendeltaphistar; genmindeltaphistarindex = k; }
+                LorentzVector genmhtLorentzstar2 = genmhtLorentzstar + gensrc->at(k).p4();
+                gendeltaphistar = std::abs( reco::deltaPhi( gensrc -> at(k).phi(), genmhtLorentzstar2.phi() ) ) ;
+                if ( std::abs( genmindeltaphistar ) > std::abs( gendeltaphistar ) ) { genmindeltaphistar = gendeltaphistar; genmindeltaphistarindex = k; }
             }//k
-            }//if vgensrc.isValid
-            else 
+        }//if gensrc.isValid
+		else 
+			std::cout << "Warning Gen Tag not valid: " << JetTagGenJets_[ii].label() << std::endl ;
+
+        if ( ii == 0 )
+        {
+
+            std::auto_ptr < std::vector < double > > Gendeltaphi_vector2      ( new std::vector < double > ( Gendeltaphi_vector ) ) ;
+            iEvent.put ( Gendeltaphi_vector2 , "GenDeltaPhi" ) ;
+
+        }
+
+
+        if ( ii == 0 )
+        {
+
+            GenminDeltaphi5 = { genmindeltaphi3, genmindeltaphi4, genmindeltaphi5, genmindeltaphistar } ;        
+            GenminDeltaphiIndex5 = { genmindeltaphi3jetindex, genmindeltaphi4jetindex, genmindeltaphi5jetindex, genmindeltaphistarindex } ;
+
+        }
+
+
+        else if ( ii == 1 )
+        {
+            
+            GenminDeltaphi24 = { genmindeltaphi3, genmindeltaphi4, genmindeltaphi5, genmindeltaphistar } ;        
+            GenminDeltaphiIndex24 = { genmindeltaphi3jetindex, genmindeltaphi4jetindex, genmindeltaphi5jetindex, genmindeltaphistarindex } ;
+
+        }
+
+    }//ii
+
+    std::auto_ptr < std::vector < double > > GenminDeltaphi24_2      ( new std::vector < double > ( GenminDeltaphi24      ) ) ;
+    iEvent.put ( GenminDeltaphi24_2      , "GenMinDeltaPhiEta24"      ) ;
+
+    std::auto_ptr < std::vector < double > > GenminDeltaphi5_2       ( new std::vector < double > ( GenminDeltaphi5       ) ) ;
+    iEvent.put ( GenminDeltaphi5_2       , "GenMinDeltaPhiEta5"       ) ;
+
+    std::auto_ptr < std::vector < int    > > GenminDeltaphiIndex24_2 ( new std::vector < int    > ( GenminDeltaphiIndex24 ) ) ;
+    iEvent.put ( GenminDeltaphiIndex24_2 , "GenMinDeltaPhiIndexEta24" ) ;
+
+    std::auto_ptr < std::vector < int    > > GenminDeltaphiIndex5_2  ( new std::vector < int    > ( GenminDeltaphiIndex5  ) ) ;
+    iEvent.put ( GenminDeltaphiIndex5_2  , "GenMinDeltaPhiIndexEta5"  ) ;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    std::vector < TLorentzVector > neutrino_LVector;
+    std::vector < int > neutrino_pdgid_vector, neutrino_mother_pdgid_vector ;
+
+    edm::Handle < edm::View < reco::GenParticle > > genpart ;
+    iEvent.getByLabel ( GenParticleTag_, genpart ) ;
+
+    vector<double> neutrino_pt(6,-9);
+    vector<double> neutrino_eta(6,-9);
+    vector<double> neutrino_phi(6,-9);
+    vector<double> neutrino_energy(6,-9);
+
+    vector<int> neutrino_pdgid(6,0);
+    vector<int> neutrino_mother_pdgid(6,0);
+
+    if ( genpart.isValid () )
+    {
+        //sort gen neutrinos by pT
+        std::multimap<double,size_t> genMap;
+        for( size_t i = 0; i < genpart -> size(); i++ )
+        {
+            if( abs( genpart -> at(i).pdgId () ) == 12 || abs( genpart -> at(i).pdgId () ) == 14 || abs( genpart -> at(i).pdgId () ) == 16 )
             {
-                  std::cout << "Warning Gen Tag not valid: " << JetTagGenJets_.label() << std::endl ;
-
-                  std::auto_ptr < double > genmhtpt2  ( new double ( -9. ) ) ;
-                  iEvent.put ( genmhtpt2 , "GenMHT" ) ;
-                  std::auto_ptr < double > genmhtphi2 ( new double ( -9. ) ) ;
-                  iEvent.put ( genmhtphi2 , "GenMHTphi" ) ;
-
-            }
-
-            if ( genetacut == 5 )
-            {
-                  std::auto_ptr < std::vector < TLorentzVector >  > GenJetVector2   ( new std::vector < TLorentzVector > (GenJetVector) ) ;
-                  iEvent.put ( GenJetVector2 , "GenLorentzVector" ) ;
-
-                  std::auto_ptr < std::vector < double > > Gendeltaphi_vector2      ( new std::vector < double > ( Gendeltaphi_vector ) ) ;
-                  iEvent.put ( Gendeltaphi_vector2 , "GenDeltaPhi" ) ;
-
-            }
-
-
-            if ( genetacut == 5 )
-            {
-
-                  GenminDeltaphi5     .push_back ( genmindeltaphi3         ) ;
-                  GenminDeltaphi5     .push_back ( genmindeltaphi4         ) ;
-                  GenminDeltaphi5     .push_back ( genmindeltaphi5         ) ;
-                  GenminDeltaphi5     .push_back ( genmindeltaphistar      ) ;
-
-                  GenminDeltaphiIndex5.push_back ( genmindeltaphi3jetindex ) ;
-                  GenminDeltaphiIndex5.push_back ( genmindeltaphi4jetindex ) ;
-                  GenminDeltaphiIndex5.push_back ( genmindeltaphi5jetindex ) ;
-                  GenminDeltaphiIndex5.push_back ( genmindeltaphistarindex ) ;
-
-            }
-
-
-            if ( genetacut == 2.4 )
-            {
-
-                  GenminDeltaphi5     .push_back ( genmindeltaphi3         ) ;
-                  GenminDeltaphi5     .push_back ( genmindeltaphi4         ) ;
-                  GenminDeltaphi5     .push_back ( genmindeltaphi5         ) ;
-                  GenminDeltaphi5     .push_back ( genmindeltaphistar      ) ;
-
-                  GenminDeltaphiIndex5.push_back ( genmindeltaphi3jetindex ) ;
-                  GenminDeltaphiIndex5.push_back ( genmindeltaphi4jetindex ) ;
-                  GenminDeltaphiIndex5.push_back ( genmindeltaphi5jetindex ) ;
-                  GenminDeltaphiIndex5.push_back ( genmindeltaphistarindex ) ;
-
-            }
-
-      }//ii
-
-      std::auto_ptr < std::vector < double > > GenminDeltaphi24_2      ( new std::vector < double > ( GenminDeltaphi24      ) ) ;
-      iEvent.put ( GenminDeltaphi24_2      , "GenMinDeltaPhiEta24"      ) ;
-
-      std::auto_ptr < std::vector < double > > GenminDeltaphi5_2       ( new std::vector < double > ( GenminDeltaphi5       ) ) ;
-      iEvent.put ( GenminDeltaphi5_2       , "GenMinDeltaPhiEta5"       ) ;
-
-      std::auto_ptr < std::vector < int    > > GenminDeltaphiIndex24_2 ( new std::vector < int    > ( GenminDeltaphiIndex24 ) ) ;
-      iEvent.put ( GenminDeltaphiIndex24_2 , "GenMinDeltaPhiIndexEta24" ) ;
-
-      std::auto_ptr < std::vector < int    > > GenminDeltaphiIndex5_2  ( new std::vector < int    > ( GenminDeltaphiIndex5  ) ) ;
-      iEvent.put ( GenminDeltaphiIndex5_2  , "GenMinDeltaPhiIndexEta5"  ) ;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-      std::vector < TLorentzVector > neutrino_LVector;
-      std::vector < int > neutrino_pdgid_vector, neutrino_mother_pdgid_vector ;
-
-      edm::Handle < edm::View < reco::GenParticle > > genjets ;
-      iEvent.getByLabel ( GenParticleTag_, genjets ) ;
-
-      double neutrino_pt [6], neutrino_eta [6], neutrino_phi [6], neutrino_energy [6] ;
-
-      int neutrino_pdgid [6], neutrino_mother_pdgid [6], place;
-
-         
-      for ( int i = 1; i < 5; i++ )
-      {
-            neutrino_pt           [i] = -9. ;
-            neutrino_eta          [i] = -9. ;
-            neutrino_phi          [i] = -9. ;
-            neutrino_energy       [i] = -9. ;
-            neutrino_pdgid        [i] =  0  ;
-            neutrino_mother_pdgid [i] =  0  ;
-      }//i
-
-      if ( genjets.isValid () )
-      {
-            for( size_t i = 0; i < genjets -> size(); i++ )
-            {
-                  if( abs( genjets -> at(i).pdgId () ) == 12 || abs( genjets -> at(i).pdgId () ) == 14 || abs( genjets -> at(i).pdgId () ) == 16 )
-                  {
-                        place = 100 ;
-
-                        for ( int j = 1; j < 5; j++ )
-                              if ( genjets -> at(i).pt() > neutrino_pt [j] ) { place = j; break; }
-      
-                        if ( place < 5 )
-                        {
-                              for ( int k = 4; k >= place; k-- )
-                              {
-                                    neutrino_pt           [k + 1] = neutrino_pt           [k] ;
-                                    neutrino_eta          [k + 1] = neutrino_eta          [k] ;
-                                    neutrino_phi          [k + 1] = neutrino_phi          [k] ;
-                                    neutrino_energy       [k + 1] = neutrino_energy       [k] ;
-                                    neutrino_pdgid        [k + 1] = neutrino_pdgid        [k] ;
-                                    neutrino_mother_pdgid [k + 1] = neutrino_mother_pdgid [k] ;
-                              }//k
-
-                              neutrino_pt           [place] = genjets -> at(i).pt();
-                              neutrino_eta          [place] = genjets -> at(i).eta();
-                              neutrino_phi          [place] = genjets -> at(i).phi();
-                              neutrino_energy       [place] = genjets -> at(i).energy();
-                              neutrino_pdgid        [place] = genjets -> at(i).pdgId();
-                              neutrino_mother_pdgid [place] = genjets -> at(i).mother()->pdgId();
-
-                        }//place
-                  }//if abs
-            }//i
-      } //if
-      else std::cout << "Warning Neutrino Tag not valid: " << GenParticleTag_.label() << std::endl ;
-
-      
-      for ( unsigned int i = 1; i < 5; i++ )
-      {
-
+                genMap.insert(std::make_pair(genpart->at(i).pt(),i));
+            }//if abs
+        }//i
+        
+        unsigned i = 0;
+        for ( auto genIt = genMap.rbegin(); genIt != genMap.rend() && i<5; ++genIt, ++i )
+        {
             TLorentzVector dumb_vector ;
-            dumb_vector.SetPtEtaPhiE( neutrino_pt[i], neutrino_eta[i], neutrino_phi[i], neutrino_energy[i] ) ;
-                  
-            neutrino_LVector            .push_back ( dumb_vector               ) ;
-            neutrino_pdgid_vector       .push_back ( neutrino_pdgid [i]        ) ;
-            neutrino_mother_pdgid_vector.push_back ( neutrino_mother_pdgid [i] ) ;
+            dumb_vector.SetPtEtaPhiE(genpart -> at(genIt->second).pt(),
+                                     genpart -> at(genIt->second).eta(),
+                                     genpart -> at(genIt->second).phi(),
+                                     genpart -> at(genIt->second).energy()
+                                    );
 
-       }//i
-
-
-      std::auto_ptr < std::vector < TLorentzVector > > eutrino_LVector2               ( new std::vector < TLorentzVector > ( neutrino_LVector             ) ) ;
-      std::auto_ptr < std::vector < int            > > neutrino_pdgid_vector2         ( new std::vector < int            > ( neutrino_pdgid_vector        ) ) ;
-      std::auto_ptr < std::vector < int            > > neutrino_mother_pdgid_vector2  ( new std::vector < int            > ( neutrino_mother_pdgid_vector ) ) ;
-
-
-      iEvent.put ( eutrino_LVector2             , "NeutrinoLorentzVector" ) ;
-      iEvent.put ( neutrino_pdgid_vector2       , "NeutrinoPdg"           ) ;
-      iEvent.put ( neutrino_mother_pdgid_vector2, "NeutrinoMotherPdg"     ) ;
+            neutrino_LVector            .push_back ( dumb_vector                                  ) ;
+            neutrino_pdgid_vector       .push_back ( genpart -> at(genIt->second).pdgId()         ) ;
+            neutrino_mother_pdgid_vector.push_back ( genpart -> at(genIt->second).mother()->pdgId() ) ;            
+        }//genIt
+        
+    } //if
+    else std::cout << "Warning Neutrino Tag not valid: " << GenParticleTag_.label() << std::endl ;
 
 
+    std::auto_ptr < std::vector < TLorentzVector > > neutrino_LVector2              ( new std::vector < TLorentzVector > ( neutrino_LVector             ) ) ;
+    std::auto_ptr < std::vector < int            > > neutrino_pdgid_vector2         ( new std::vector < int            > ( neutrino_pdgid_vector        ) ) ;
+    std::auto_ptr < std::vector < int            > > neutrino_mother_pdgid_vector2  ( new std::vector < int            > ( neutrino_mother_pdgid_vector ) ) ;
 
 
-      double metpt_=-10., metphi_=-10.;
+    iEvent.put ( neutrino_LVector2            , "NeutrinoLorentzVector" ) ;
+    iEvent.put ( neutrino_pdgid_vector2       , "NeutrinoPdg"           ) ;
+    iEvent.put ( neutrino_mother_pdgid_vector2, "NeutrinoMotherPdg"     ) ;
 
-      edm::Handle < edm::View < pat::MET > > MET ;
-      iEvent.getByLabel ( metTag_, MET ) ;
 
-      reco::MET::LorentzVector metLorentz ( 0,0,0,0 ) ;
-
-      if( MET.isValid() )
-      {
-            const pat::MET patMET( MET -> at (0) ) ;
-            if( patMET.genMET() )
-            {
-
-                  const reco::GenMET* genMET( patMET.genMET () ) ;
-                  metLorentz = genMET -> p4   () ;
-                  metpt_     = metLorentz.pt  ();
-                  metphi_    = metLorentz.phi ();
-
-            } //if patMET      
-      }//if MET
-
-      else std::cout << "GenMETDouble::Invlide Tag: " << metTag_.label () << std::endl ;
-
-      std::auto_ptr < double > htp( new double ( metpt_ ) ) ;
-      iEvent.put ( htp, "GenMET" ) ;
-      std::auto_ptr < double > htp2 ( new double ( metphi_ ) ) ;
-      iEvent.put ( htp2, "GenMETphi" ) ;
-      
 
 }//void DeltaPhiQCD
 

--- a/Utils/src/MhtDouble.cc
+++ b/Utils/src/MhtDouble.cc
@@ -31,6 +31,7 @@
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 //
 // class declaration
 //
@@ -108,7 +109,7 @@ void
 MhtDouble::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   using namespace edm;
-  edm::Handle< edm::View<pat::Jet> > Jets;
+  edm::Handle< reco::CandidateView > Jets;
 	iEvent.getByLabel(JetTag_,Jets);
 	reco::MET::LorentzVector mhtLorentz(0,0,0,0);
 	if( Jets.isValid() ) {
@@ -117,7 +118,7 @@ MhtDouble::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		mhtLorentz -=Jets->at(i).p4();
 		}
   }
-  else std::cout<<"MHTDouble::Invlide Tag: "<<JetTag_.label()<<std::endl;
+  else std::cout<<"MHTDouble::Invalid Tag: "<<JetTag_.label()<<std::endl;
 	std::auto_ptr<double > Pt(new double(mhtLorentz.pt()));
 	std::auto_ptr<double > Phi(new double(mhtLorentz.phi()));
 	iEvent.put(Pt,"Pt");

--- a/Utils/src/SubJetSelection.cc
+++ b/Utils/src/SubJetSelection.cc
@@ -1,9 +1,9 @@
 // -*- C++ -*-
 //
-// Package:    SubJetSelection
-// Class:      SubJetSelection
+// Package:    SubJetSelectionT
+// Class:      SubJetSelectionT
 //
-/**\class SubJetSelection SubJetSelection.cc RA2Classic/SubJetSelection/src/SubJetSelection.cc
+/**\class SubJetSelectionT SubJetSelectionT.cc RA2Classic/SubJetSelectionT/src/SubJetSelectionT.cc
  *
  * Description: [one line class summary]
  *
@@ -30,6 +30,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 #include <DataFormats/Math/interface/deltaR.h>
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -39,10 +40,11 @@
 // class declaration
 //
 
-class SubJetSelection : public edm::EDProducer {
+template <class T>
+class SubJetSelectionT : public edm::EDProducer {
 public:
-   explicit SubJetSelection(const edm::ParameterSet&);
-   ~SubJetSelection();
+   explicit SubJetSelectionT(const edm::ParameterSet&);
+   ~SubJetSelectionT();
    
    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
    
@@ -75,7 +77,9 @@ private:
 // constructors and destructor
 //
 using namespace pat;
-SubJetSelection::SubJetSelection(const edm::ParameterSet& iConfig)
+
+template <class T>
+SubJetSelectionT<T>::SubJetSelectionT(const edm::ParameterSet& iConfig)
 {
    
    JetTag_ = iConfig.getParameter<edm::InputTag>("JetTag");
@@ -93,13 +97,13 @@ SubJetSelection::SubJetSelection(const edm::ParameterSet& iConfig)
     */
    //now do what ever other initialization is needed
    //register your products
-   produces<std::vector<Jet> >();
+   produces<std::vector<T> >();
    // 	produces<std::vector<Float_t> > ("testValue");
    
 }
 
-
-SubJetSelection::~SubJetSelection()
+template <class T>
+SubJetSelectionT<T>::~SubJetSelectionT()
 {
    
    // do anything here that needs to be done at desctruction time
@@ -113,19 +117,18 @@ SubJetSelection::~SubJetSelection()
 //
 
 // ------------ method called to produce the data  ------------
-void
-SubJetSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+template <class T>
+void SubJetSelectionT<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
    using namespace edm;
-   std::auto_ptr<std::vector<Jet> > prodJets(new std::vector<Jet>());
-   // 	std::auto_ptr<std::vector<Float_t> > pFloat(new std::vector<Float_t>());
-   // test
-   edm::Handle< edm::View<Jet> > Jets;
+   std::auto_ptr<std::vector<T> > prodJets(new std::vector<T>());
+
+   edm::Handle< edm::View<T> > Jets;
    iEvent.getByLabel(JetTag_,Jets);
    if(Jets.isValid()) {
       for(unsigned int i=0; i<Jets->size();i++) {
          if(Jets->at(i).pt()>MinPt_ && std::abs(Jets->at(i).eta() ) < MaxEta_) {
-            prodJets->push_back(Jet(Jets->at(i)) );
+            prodJets->push_back(T(Jets->at(i)) );
          }
       }
    }
@@ -138,43 +141,43 @@ SubJetSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void
-SubJetSelection::beginJob()
+template <class T>
+void SubJetSelectionT<T>::beginJob()
 {
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void
-SubJetSelection::endJob() {
+template <class T>
+void SubJetSelectionT<T>::endJob() {
 }
 
 // ------------ method called when starting to processes a run  ------------
-void
-SubJetSelection::beginRun(edm::Run&, edm::EventSetup const&)
+template <class T>
+void SubJetSelectionT<T>::beginRun(edm::Run&, edm::EventSetup const&)
 {
 }
 
 // ------------ method called when ending the processing of a run  ------------
-void
-SubJetSelection::endRun(edm::Run&, edm::EventSetup const&)
+template <class T>
+void SubJetSelectionT<T>::endRun(edm::Run&, edm::EventSetup const&)
 {
 }
 
 // ------------ method called when starting to processes a luminosity block  ------------
-void
-SubJetSelection::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+template <class T>
+void SubJetSelectionT<T>::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
 {
 }
 
 // ------------ method called when ending the processing of a luminosity block  ------------
-void
-SubJetSelection::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+template <class T>
+void SubJetSelectionT<T>::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
 {
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-SubJetSelection::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+template <class T>
+void SubJetSelectionT<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    //The following says we do not know what parameters are allowed so do no validation
    // Please change this to state exactly what you do use, even if it is no parameters
    edm::ParameterSetDescription desc;
@@ -182,5 +185,10 @@ SubJetSelection::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
    descriptions.addDefault(desc);
 }
 
+//typedefs
+typedef SubJetSelectionT<pat::Jet> SubJetSelection;
+typedef SubJetSelectionT<reco::GenJet> SubGenJetSelection;
+
 //define this as a plug-in
 DEFINE_FWK_MODULE(SubJetSelection);
+DEFINE_FWK_MODULE(SubGenJetSelection);


### PR DESCRIPTION
@aminghiasi, I noticed several places where the DeltaPhiQCD code could be better integrated with the rest of TreeMaker or written more efficiently. In the process, I fixed a few bugs.
1. The two categories of jets are: (pT > 30, |eta| < 5.0) and (pT > 30, |eta| < 2.4). We already produce these categories as MHTJets and HTJets, respectively, so it's easier just to use those collections instead of redoing all the cuts. I generalized SubJetSelection to make the same collections for GenJets, also (and then we can just add the GenMHTJets directly to the tree).
2. I added GenMET to the METDouble producer, and made GenMHT from the GenMHTJets collection, further simplifying the DeltaPhiQCD code. (I also fixed a bug where the GenMET didn't get filled when the MET recorrection tool was used.)
3. I simplified the calculation of MHTStar: just calculate the MHT vector from all the jets, then add back each jet separately.
4. The vectors of MinDeltaPhi results can be set using initializer lists (new C++11 feature).
5. It's easier to sort the gen neutrinos by pT using a map, and then just take the highest five entries (using reverse iterators, because maps sort from low to high).
6. Bug fix: for genetacut == 2.4, the Eta5 results vectors were filled again (typo), so the Eta24 vectors were empty.
7. The MHTStar was calculated using only the pT > 30 jets, but it was calculated _for_ all the jets. This seems like it probably wasn't what was intended. Now, using the subjet collection, it can only consider the jets with pT > 30 and the desired eta cut.
8. I wasn't sure if this was a bug, so I didn't address it yet: the mindeltaphiXjetindex is stored as "index+1", where "index" is the collection index. It seems like the +1 shouldn't be there, but maybe I misunderstand how you use the index.

I tested the new code with 100 QCD events and didn't see any unexpected changes. Let me know if I misunderstood anything and if I should fix point 8 before merging.
