### PR TITLE
change storage of some MET variables

### DIFF
--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -97,7 +97,7 @@ def doZinvBkg(process,is74X,METTag):
        JetTag = cms.InputTag('MHTJetsclean'),
     )
     process.ZinvClean += process.MHTclean
-    process.TreeMaker2.VarsDouble.extend(['MHTclean:Pt(MHTclean)'])
+    process.TreeMaker2.VarsDouble.extend(['MHTclean:Pt(MHTclean)','MHTclean:Phi(MHT_Phiclean)'])
 
     from TreeMaker.Utils.metdouble_cfi import metdouble
     process.METclean = metdouble.clone(
@@ -106,7 +106,7 @@ def doZinvBkg(process,is74X,METTag):
        cleanTag = cms.untracked.VInputTag(cms.InputTag('LeptonsNew:IdIsoElectron'), cms.InputTag('LeptonsNew:IdIsoMuon'), cms.InputTag('goodPhotons', 'bestPhoton'))
     )
     process.ZinvClean += process.METclean
-    process.TreeMaker2.VarsDouble.extend(['METclean:minDeltaPhiN(minDeltaPhiNclean)', 'METclean:Pt(METPtclean)'])
+    process.TreeMaker2.VarsDouble.extend(['METclean:Pt(METPtclean)','METclean:Phi(METPhiclean)'])
 
     process.AdditionalSequence += process.ZinvClean
     

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -643,12 +643,12 @@ fastsim=False
     from TreeMaker.Utils.metdouble_cfi import metdouble
     process.MET = metdouble.clone(
         METTag = METTag,
-        GenMETTag = cms.InputTag("slimmedMETs","","PAT"), #deliberately hardcoded
+        GenMETTag = cms.InputTag("slimmedMETs","",tagname), #original collection used deliberately here
         JetTag = cms.InputTag('HTJets'),
         geninfo = cms.untracked.bool(geninfo),
     )
     process.Baseline += process.MET
-    VarsDouble.extend(['MET:minDeltaPhiN','MET:DeltaPhiN1','MET:DeltaPhiN2','MET:DeltaPhiN3','MET:Pt(METPt)','MET:Phi(METPhi)'])
+    VarsDouble.extend(['MET:Pt(METPt)','MET:Phi(METPhi)','MET:CaloPt(CaloMETPt)','MET:CaloPhi(CaloMETPhi)'])
     if geninfo:
         VarsDouble.extend(['MET:GenPt(GenMETPt)','MET:GenPhi(GenMETPhi)'])
 

--- a/Utils/src/METDouble.cc
+++ b/Utils/src/METDouble.cc
@@ -97,6 +97,8 @@ METDouble::METDouble(const edm::ParameterSet& iConfig)
    produces<double>("minDeltaPhiN");
    produces<double>("Pt");
    produces<double>("Phi");
+   produces<double>("CaloPt");
+   produces<double>("CaloPhi");
    produces<double>("GenPt");
    produces<double>("GenPhi");
 }
@@ -122,6 +124,7 @@ METDouble::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    using namespace edm;
    double metpt_=0, metphi_=0;
    double genmetpt_=0, genmetphi_=0;
+   double calometpt_=0, calometphi_=0;
    edm::Handle< edm::View<pat::MET> > MET;
    iEvent.getByLabel(metTag_,MET);
 
@@ -145,13 +148,17 @@ METDouble::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
    else std::cout<<"METDouble::Invalid Tag: "<<metTag_.label()<<std::endl;
 
-   if(GenMET.isValid()  && geninfo_ && GenMET->at(0).genMET()){
-      const reco::GenMET* theGenMET( GenMET->at(0).genMET () ) ;
-      genmetpt_     = theGenMET->pt  ();
-      genmetphi_    = theGenMET->phi ();
-      
+   //GenMET is really the original MET collection from the event (re-correction zeroes out some values)
+   if(GenMET.isValid()){
+      if(geninfo_ && GenMET->at(0).genMET()){
+        const reco::GenMET* theGenMET( GenMET->at(0).genMET () ) ;
+        genmetpt_     = theGenMET->pt  ();
+        genmetphi_    = theGenMET->phi ();
+      }
+      calometpt_=GenMET->at(0).caloMETPt();
+      calometphi_=GenMET->at(0).caloMETPhi();      
    }
-   else if(geninfo_ && !GenMET.isValid()) std::cout<<"METDouble::Invalid Tag: "<<genMetTag_.label()<<std::endl;
+   else if(!GenMET.isValid()) std::cout<<"METDouble::Invalid Tag: "<<genMetTag_.label()<<std::endl;
  
    
    // remove particles from MET calculation
@@ -177,7 +184,12 @@ METDouble::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    iEvent.put(htp,"Pt");
    std::auto_ptr<double> htp2(new double(metphi_));
    iEvent.put(htp2,"Phi");
-   
+
+   std::auto_ptr<double> chtp(new double(calometpt_));
+   iEvent.put(chtp,"CaloPt");
+   std::auto_ptr<double> chtp2(new double(calometphi_));
+   iEvent.put(chtp2,"CaloPhi");
+
    if(geninfo_){
        std::auto_ptr<double> ghtp(new double(genmetpt_));
        iEvent.put(ghtp,"GenPt");


### PR DESCRIPTION
Remove some MET-related variables that no longer need to be in the ntuples:
- minDeltaPhiN
- DeltaPhiN1
- DeltaPhiN2
- DeltaPhiN3
- minDeltaPhiNclean

Add some new ones:
- CaloMETPt
- CaloMETPhi
- METPhiclean
- MHT_Phiclean

Note: at this time, CaloMET variables are the raw versions (corrections currently don't exist) and must be taken from the original slimmedMETs collection in the event (the re-corrected collection drops the CaloMET values). Also, currently doesn't work for 2015D when running in CMSSW_7_4_6_patch6 because of changes in the miniAOD format, but this should be remedied in the move to re-miniAOD and 7_4_1X.
