### PR TITLE
Store MET uncertainty variations in vectors

### DIFF
--- a/Production/test/condorSub/looper_fastsim.sh
+++ b/Production/test/condorSub/looper_fastsim.sh
@@ -57,7 +57,7 @@ Spring15Fastv2.SMS-T1bbbb_mGluino-850-875_mLSP-725to825-650to825_TuneCUETP8M1_13
 Spring15Fastv2.SMS-T1bbbb_mGluino-875-900-925_mLSP-850-1to875-700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8 \
 Spring15Fastv2.SMS-T1bbbb_mGluino-925-950_mLSP-725to900-400to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8 \
 Spring15Fastv2.SMS-T1bbbb_mGluino-950-975_mLSP-825to925-750to925_TuneCUETP8M1_13TeV-madgraphMLM-pythia8 \
-Spring15Fastv2.SMS-T1bbbb_mGluino-975_mLSP-950_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py \
+Spring15Fastv2.SMS-T1bbbb_mGluino-975_mLSP-950_TuneCUETP8M1_13TeV-madgraphMLM-pythia8 \
 )
 
 for SAMPLE in ${SAMPLES[@]}; do

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -658,8 +658,7 @@ fastsim=False
     VarsDouble.extend(['MET:Pt(METPt)','MET:Phi(METPhi)','MET:CaloPt(CaloMETPt)','MET:CaloPhi(CaloMETPhi)'])
     if geninfo:
         VarsDouble.extend(['MET:GenPt(GenMETPt)','MET:GenPhi(GenMETPhi)'])
-        VarsDouble.extend(['MET:metType1PtJetResUp', 'MET:metType1PtJetResDown', 'MET:metType1PtJetEnUp', 'MET:metType1PtJetEnDown', 'MET:metType1PtMuonEnUp', 'MET:metType1PtMuonEnDown', 'MET:metType1PtElectronEnUp', 'MET:metType1PtElectronEnDown', 'MET:metType1PtTauEnUp', 'MET:metType1PtTauEnDown', 'MET:metType1PtUnclusteredEnUp', 'MET:metType1PtUnclusteredEnDown', 'MET:metType1PtPhotonEnUp', 'MET:metType1PtPhotonEnDown'])
-        VarsDouble.extend(['MET:metType1PhiJetResUp', 'MET:metType1PhiJetResDown', 'MET:metType1PhiJetEnUp', 'MET:metType1PhiJetEnDown', 'MET:metType1PhiMuonEnUp', 'MET:metType1PhiMuonEnDown', 'MET:metType1PhiElectronEnUp', 'MET:metType1PhiElectronEnDown', 'MET:metType1PhiTauEnUp', 'MET:metType1PhiTauEnDown', 'MET:metType1PhiUnclusteredEnUp', 'MET:metType1PhiUnclusteredEnDown', 'MET:metType1PhiPhotonEnUp', 'MET:metType1PhiPhotonEnDown'])
+        VectorDouble.extend(['MET:PtUp(METPtUp)', 'MET:PtDown(METPtDown)', 'MET:PhiUp(METPhiUp)', 'MET:PhiDown(METPhiDown)'])
 
     ## ----------------------------------------------------------------------------------------------
     ## Jet properties


### PR DESCRIPTION
Order of the variations, as indicated in the code:

JetRes, JetEn, MuonEn, ElectronEn, TauEn, UnclusteredEn, PhotonEn

also fix typo in looper script
