### PR TITLE
new framework for all jet-based variables

### DIFF
--- a/TreeMaker/python/DeltaPhiQCD.py
+++ b/TreeMaker/python/DeltaPhiQCD.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-def DeltaPhiQCD(process, is74X, geninfo):
+def DeltaPhiQCD(process, geninfo):
     process.DeltaPhiQCDSeq = cms.Sequence()
 
     if geninfo:
@@ -34,11 +34,9 @@ def DeltaPhiQCD(process, is74X, geninfo):
     process.DeltaPhiQCD = deltaphiqcd.clone (
         JetTagRecoJets      = cms.VInputTag ( 'MHTJets','HTJets' ) ,
         JetTagGenJets       = cms.VInputTag ( 'GenMHTJets', 'GenHTJets' ) ,
-        BTagInputTag        = cms.string   ( 'combinedInclusiveSecondaryVertexV2BJetTags' ) ,
+        BTagInputTag        = cms.string   ( 'pfCombinedInclusiveSecondaryVertexV2BJetTags' ) ,
         GenParticleTag      = cms.InputTag ( 'prunedGenParticles' ) ,
     )
-    if is74X:
-       process.DeltaPhiQCD.BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags')
     process.DeltaPhiQCDSeq += process.DeltaPhiQCD
     
     process.AdditionalSequence += process.DeltaPhiQCDSeq

--- a/TreeMaker/python/doHadTauBkg.py
+++ b/TreeMaker/python/doHadTauBkg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-def doHadTauBkg(process,is74X,geninfo,residual,JetTag):
+def doHadTauBkg(process,geninfo,residual,JetTag):
     process.load("RecoJets.JetProducers.ak4PFJets_cfi")
     from JetMETCorrections.Configuration.JetCorrectionServices_cff import ak4PFCHSL1FastL2L3,ak4PFCHSL1Fastjet,ak4PFCHSL2Relative,ak4PFCHSL3Absolute
 
@@ -16,41 +16,23 @@ def doHadTauBkg(process,is74X,geninfo,residual,JetTag):
     from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
     jetCorrectionLevels = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute'], 'Type-2')
     if residual: jetCorrectionLevels = ('AK4PFchs', ['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual'], 'Type-2')
-    if is74X:
-        addJetCollection(
-            process,
-            postfix            = "",
-            labelName          = 'AK4PFCHS',
-            jetSource          = cms.InputTag('ak4PFJetsCHS'),
-            pfCandidates       = cms.InputTag('packedPFCandidates'),
-            pvSource           = cms.InputTag('offlineSlimmedPrimaryVertices'),  # 74x
-            svSource           = cms.InputTag('slimmedSecondaryVertices'),       # 74x
-            elSource           = cms.InputTag('slimmedElectrons'),
-            muSource           = cms.InputTag('slimmedMuons'),
-            jetCorrections     = jetCorrectionLevels,
-            btagDiscriminators = [ 'pfCombinedInclusiveSecondaryVertexV2BJetTags' ],  # 74x
-            genJetCollection   = cms.InputTag('ak4GenJets'),
-            genParticles       = cms.InputTag('prunedGenParticles'),
-            algo               = 'AK',
-            rParam             = 0.4
-        )
-    else:
-        addJetCollection(
-            process,
-            postfix            = "",
-            labelName          = 'AK4PFCHS',
-            jetSource          = cms.InputTag('ak4PFJetsCHS'),
-            pfCandidates       = cms.InputTag('packedPFCandidates'),
-            trackSource        = cms.InputTag('unpackedTracksAndVertices'),           # 72x
-            pvSource           = cms.InputTag('unpackedTracksAndVertices'),              # 72x
-            svSource           = cms.InputTag('unpackedTracksAndVertices','secondary'),  # 72x
-            jetCorrections     = jetCorrectionLevels,
-            btagDiscriminators = [ 'combinedInclusiveSecondaryVertexV2BJetTags' ],  # 72x
-            genJetCollection   = cms.InputTag('ak4GenJets'),
-            algo               = 'AK',
-            rParam             = 0.4
-        )
-    # end of if is74X:
+    addJetCollection(
+        process,
+        postfix            = "",
+        labelName          = 'AK4PFCHS',
+        jetSource          = cms.InputTag('ak4PFJetsCHS'),
+        pfCandidates       = cms.InputTag('packedPFCandidates'),
+        pvSource           = cms.InputTag('offlineSlimmedPrimaryVertices'),  # 74x
+        svSource           = cms.InputTag('slimmedSecondaryVertices'),       # 74x
+        elSource           = cms.InputTag('slimmedElectrons'),
+        muSource           = cms.InputTag('slimmedMuons'),
+        jetCorrections     = jetCorrectionLevels,
+        btagDiscriminators = [ 'pfCombinedInclusiveSecondaryVertexV2BJetTags' ],  # 74x
+        genJetCollection   = cms.InputTag('ak4GenJets'),
+        genParticles       = cms.InputTag('prunedGenParticles'),
+        algo               = 'AK',
+        rParam             = 0.4
+    )
 
     # adjust MC matching
     process.patJetsAK4PFCHS.getJetMCFlavour   = False

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-def doZinvBkg(process,is74X,METTag):
+def doZinvBkg(process,METTag):
     ##### add branches for photon studies
     process.TreeMaker2.VectorDouble.append("goodPhotons:isEB(photon_isEB)")
     process.TreeMaker2.VectorDouble.append("goodPhotons:genMatched(photon_genMatched)")
@@ -65,12 +65,9 @@ def doZinvBkg(process,is74X,METTag):
     from TreeMaker.Utils.btagint_cfi import btagint
     process.BTagsclean = btagint.clone(
        JetTag       = cms.InputTag('HTJetsclean'),
-       BTagInputTag = cms.string('combinedInclusiveSecondaryVertexV2BJetTags'),
-       BTagCutValue = cms.double(0.814)
+       BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
+       BTagCutValue = cms.double(0.890)
     )
-    if is74X:
-        process.BTagsclean.BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags')
-        process.BTagsclean.BTagCutValue = cms.double(0.890)
 
     process.ZinvClean += process.BTagsclean
     process.TreeMaker2.VarsInt.extend(['BTagsclean'])

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -39,62 +39,15 @@ def doZinvBkg(process,METTag):
        PhotonR     = cms.double(0.4)
     )
     process.ZinvClean += process.cleanTheJets
-
-    from TreeMaker.Utils.subJetSelection_cfi import SubJetSelection
-    process.HTJetsclean = SubJetSelection.clone(
-       JetTag = cms.InputTag('cleanTheJets', 'GoodJetsclean'),
-       MinPt  = cms.double(30),
-       MaxEta = cms.double(2.4),
-    )
-    process.ZinvClean += process.HTJetsclean
-
-    from TreeMaker.Utils.htdouble_cfi import htdouble
-    process.HTclean = htdouble.clone(
-       JetTag = cms.InputTag('HTJetsclean'),
-    )
-    process.ZinvClean += process.HTclean
-    process.TreeMaker2.VarsDouble.extend(['HTclean'])
-
-    from TreeMaker.Utils.njetint_cfi import njetint
-    process.NJetsclean = njetint.clone(
-       JetTag = cms.InputTag('HTJetsclean'),
-    )
-    process.ZinvClean += process.NJetsclean
-    process.TreeMaker2.VarsInt.extend(['NJetsclean'])
-
-    from TreeMaker.Utils.btagint_cfi import btagint
-    process.BTagsclean = btagint.clone(
-       JetTag       = cms.InputTag('HTJetsclean'),
-       BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
-       BTagCutValue = cms.double(0.890)
-    )
-
-    process.ZinvClean += process.BTagsclean
-    process.TreeMaker2.VarsInt.extend(['BTagsclean'])
-
-    from TreeMaker.Utils.subJetSelection_cfi import SubJetSelection
-    process.MHTJetsclean = SubJetSelection.clone(
-       JetTag = cms.InputTag('cleanTheJets', 'GoodJetsclean'),
-       MinPt = cms.double(30),
-       MaxEta = cms.double(5.0),
-    )
-    process.ZinvClean += process.MHTJetsclean
-
-    from TreeMaker.Utils.deltaphidouble_cfi import deltaphidouble
-    process.DeltaPhiClean = deltaphidouble.clone(
-        DeltaPhiJets  = cms.InputTag('HTJetsclean'),
-        MHTJets  = cms.InputTag("MHTJetsclean"),
-        )
-    process.ZinvClean += process.DeltaPhiClean
-    process.TreeMaker2.VarsDouble.extend(['DeltaPhiClean:DeltaPhi1(DeltaPhi1clean)','DeltaPhiClean:DeltaPhi2(DeltaPhi2clean)','DeltaPhiClean:DeltaPhi3(DeltaPhi3clean)','DeltaPhiClean:DeltaPhi4(DeltaPhi4clean)'])
     
-    from TreeMaker.Utils.subJetSelection_cfi import SubJetSelection
-    from TreeMaker.Utils.mhtdouble_cfi import mhtdouble
-    process.MHTclean = mhtdouble.clone(
-       JetTag = cms.InputTag('MHTJetsclean'),
-    )
-    process.ZinvClean += process.MHTclean
-    process.TreeMaker2.VarsDouble.extend(['MHTclean:Pt(MHTclean)','MHTclean:Phi(MHT_Phiclean)'])
+    CleanJetsTag = cms.InputTag('cleanTheJets', 'GoodJetsclean')
+    from TreeMaker.TreeMaker.makeJetVars import makeJetVars
+    process = makeJetVars(process,
+                          sequence="ZinvClean",
+                          JetTag=CleanJetsTag,
+                          suff='clean',
+                          skipGoodJets=True,
+                          storeProperties=False)
 
     from TreeMaker.Utils.metdouble_cfi import metdouble
     process.METclean = metdouble.clone(

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -1,0 +1,157 @@
+import FWCore.ParameterSet.Config as cms
+
+def makeJetVars(process,sequence,JetTag,suff,skipGoodJets,storeProperties):
+    if hasattr(process,sequence):
+        theSequence = getattr(process,sequence)
+    else:
+        print "Unknown sequence: "+sequence
+        return
+
+    ## ----------------------------------------------------------------------------------------------
+    ## GoodJets
+    ## ----------------------------------------------------------------------------------------------
+    if skipGoodJets:
+        GoodJetsTag = JetTag
+    else:
+        from TreeMaker.Utils.goodjetsproducer_cfi import GoodJetsProducer
+        GoodJets = GoodJetsProducer.clone(
+            TagMode                   = cms.bool(True),
+            JetTag                    = JetTag,
+            maxJetEta                 = cms.double(5.0),
+            minNconstituents          = cms.int32(1),
+            minNneutrals              = cms.int32(10),
+            minNcharged               = cms.int32(0),
+            maxNeutralFraction        = cms.double(0.99),
+            maxPhotonFraction         = cms.double(0.99),
+            maxPhotonFractionHF       = cms.double(0.90),
+            minChargedFraction        = cms.double(0),
+            maxChargedEMFraction      = cms.double(0.99),
+            jetPtFilter               = cms.double(30),
+            ExcludeLepIsoTrackPhotons = cms.bool(True),
+            JetConeSize               = cms.double(0.4),
+            MuonTag                   = cms.InputTag('LeptonsNew:IdIsoMuon'),
+            ElecTag                   = cms.InputTag('LeptonsNew:IdIsoElectron'),
+            IsoElectronTrackTag       = cms.InputTag('IsolatedElectronTracksVeto'),
+            IsoMuonTrackTag           = cms.InputTag('IsolatedMuonTracksVeto'),
+            IsoPionTrackTag           = cms.InputTag('IsolatedPionTracksVeto'),
+            PhotonTag                 = cms.InputTag('goodPhotons','bestPhoton'),
+        )
+        setattr(process,"GoodJets"+suff,GoodJets)
+        theSequence += getattr(process,"GoodJets"+suff)
+        GoodJetsTag = cms.InputTag("GoodJets"+suff)
+        process.TreeMaker2.VarsBool.extend(['GoodJets'+suff+':JetID(JetID'+suff+')'])
+        if storeProperties: process.TreeMaker2.VectorRecoCand.extend(['GoodJets'+suff+'(Jets'+suff+')'])
+    
+    ## ----------------------------------------------------------------------------------------------
+    ## HT
+    ## ----------------------------------------------------------------------------------------------
+    from TreeMaker.Utils.subJetSelection_cfi import SubJetSelection
+    HTJets = SubJetSelection.clone(
+        JetTag = GoodJetsTag,
+        MinPt  = cms.double(30),
+        MaxEta = cms.double(2.4),
+    )
+    setattr(process,"HTJets"+suff,HTJets)
+    theSequence += getattr(process,"HTJets"+suff)
+    if storeProperties: process.TreeMaker2.VectorBool.extend(['HTJets'+suff+':SubJetMask(HTJetsMask'+suff+')'])
+    HTJetsTag = cms.InputTag("HTJets"+suff)
+    
+    from TreeMaker.Utils.htdouble_cfi import htdouble
+    HT = htdouble.clone(
+        JetTag = HTJetsTag,
+    )
+    setattr(process,"HT"+suff,HT)
+    theSequence += getattr(process,"HT"+suff)
+    process.TreeMaker2.VarsDouble.extend(['HT'+suff])
+    
+    ## ----------------------------------------------------------------------------------------------
+    ## NJets
+    ## ----------------------------------------------------------------------------------------------
+    from TreeMaker.Utils.njetint_cfi import njetint
+    NJets = njetint.clone(
+        JetTag = HTJetsTag,
+    )
+    setattr(process,"NJets"+suff,NJets)
+    theSequence += getattr(process,"NJets"+suff)
+    process.TreeMaker2.VarsInt.extend(['NJets'+suff])
+    
+    ## ----------------------------------------------------------------------------------------------
+    ## BTags
+    ## ----------------------------------------------------------------------------------------------
+    from TreeMaker.Utils.btagint_cfi import btagint
+    BTags = btagint.clone(
+        JetTag       = HTJetsTag,
+        BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
+        BTagCutValue = cms.double(0.890)
+    )
+    setattr(process,"BTags"+suff,BTags)
+    theSequence += getattr(process,"BTags"+suff)
+    process.TreeMaker2.VarsInt.extend(['BTags'+suff])
+    
+    ## ----------------------------------------------------------------------------------------------
+    ## MHT
+    ## ----------------------------------------------------------------------------------------------
+    from TreeMaker.Utils.subJetSelection_cfi import SubJetSelection
+    MHTJets = SubJetSelection.clone(
+        JetTag = GoodJetsTag,
+        MinPt  = cms.double(30),
+        MaxEta = cms.double(5.0),
+    )
+    setattr(process,"MHTJets"+suff,MHTJets)
+    theSequence += getattr(process,"MHTJets"+suff)
+    if storeProperties: process.TreeMaker2.VectorBool.extend(['MHTJets'+suff+':SubJetMask(MHTJetsMask'+suff+')'])
+    MHTJetsTag = cms.InputTag("MHTJets"+suff)
+    
+    from TreeMaker.Utils.mhtdouble_cfi import mhtdouble
+    MHT = mhtdouble.clone(
+        JetTag  = MHTJetsTag,
+    )
+    setattr(process,"MHT"+suff,MHT)
+    theSequence += getattr(process,"MHT"+suff)
+    process.TreeMaker2.VarsDouble.extend(['MHT'+suff+':Pt(MHT'+suff+')','MHT'+suff+':Phi(MHT_Phi'+suff+')'])
+
+    ## ----------------------------------------------------------------------------------------------
+    ## DeltaPhi
+    ## ----------------------------------------------------------------------------------------------
+    from TreeMaker.Utils.deltaphidouble_cfi import deltaphidouble
+    DeltaPhi = deltaphidouble.clone(
+        DeltaPhiJets = HTJetsTag,
+        MHTJets      = MHTJetsTag,
+    )
+    setattr(process,"DeltaPhi"+suff,DeltaPhi)
+    theSequence += getattr(process,"DeltaPhi"+suff)
+    process.TreeMaker2.VarsDouble.extend(['DeltaPhi'+suff+':DeltaPhi1(DeltaPhi1'+suff+')','DeltaPhi'+suff+':DeltaPhi2(DeltaPhi2'+suff+')',
+                                          'DeltaPhi'+suff+':DeltaPhi3(DeltaPhi3'+suff+')','DeltaPhi'+suff+':DeltaPhi4(DeltaPhi4'+suff+')'])
+
+    ## ----------------------------------------------------------------------------------------------
+    ## Jet properties
+    ## ----------------------------------------------------------------------------------------------
+    
+    if storeProperties:
+        from TreeMaker.Utils.jetproperties_cfi import jetproperties
+        JetsProperties = jetproperties.clone(
+            JetTag       = GoodJetsTag,
+            BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags')
+        )
+        setattr(process,"JetsProperties"+suff,JetsProperties)
+        theSequence += getattr(process,"JetsProperties"+suff)
+        process.TreeMaker2.VectorDouble.extend(['JetsProperties'+suff+':bDiscriminatorUser(Jets'+suff+'_bDiscriminatorCSV)',
+                                                'JetsProperties'+suff+':bDiscriminatorMVA(Jets'+suff+'_bDiscriminatorMVA)',
+                                                'JetsProperties'+suff+':chargedEmEnergyFraction(Jets'+suff+'_chargedEmEnergyFraction)',
+                                                'JetsProperties'+suff+':chargedHadronEnergyFraction(Jets'+suff+'_chargedHadronEnergyFraction)',
+                                                'JetsProperties'+suff+':jetArea(Jets'+suff+'_jetArea)',
+                                                'JetsProperties'+suff+':muonEnergyFraction(Jets'+suff+'_muonEnergyFraction)',
+                                                'JetsProperties'+suff+':neutralEmEnergyFraction(Jets'+suff+'_neutralEmEnergyFraction)',
+                                                'JetsProperties'+suff+':neutralHadronEnergyFraction(Jets'+suff+'_neutralHadronEnergyFraction)',
+                                                'JetsProperties'+suff+':photonEnergyFraction(Jets'+suff+'_photonEnergyFraction)'])
+        process.TreeMaker2.VectorInt.extend(['JetsProperties'+suff+':chargedHadronMultiplicity(Jets'+suff+'_chargedHadronMultiplicity)',
+                                             'JetsProperties'+suff+':electronMultiplicity(Jets'+suff+'_electronMultiplicity)',
+                                             'JetsProperties'+suff+':muonMultiplicity(Jets'+suff+'_muonMultiplicity)',
+                                             'JetsProperties'+suff+':neutralHadronMultiplicity(Jets'+suff+'_neutralHadronMultiplicity)',
+                                             'JetsProperties'+suff+':photonMultiplicity(Jets'+suff+'_photonMultiplicity)',
+                                             'JetsProperties'+suff+':partonFlavor(Jets'+suff+'_partonFlavor)',
+                                             'JetsProperties'+suff+':hadronFlavor(Jets'+suff+'_hadronFlavor)',
+                                             'JetsProperties'+suff+':chargedMultiplicity(Jets'+suff+'_chargedMultiplicity)',
+                                             'JetsProperties'+suff+':neutralMultiplicity(Jets'+suff+'_neutralMultiplicity)'])
+                                             
+    return process

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -377,35 +377,6 @@ fastsim=False
     VarsInt.append("goodPhotons:NumPhotons")
 
     ## ----------------------------------------------------------------------------------------------
-    ## GoodJets
-    ## ----------------------------------------------------------------------------------------------
-    from TreeMaker.Utils.goodjetsproducer_cfi import GoodJetsProducer
-    process.GoodJets = GoodJetsProducer.clone(
-        TagMode                   = cms.bool(True),
-        JetTag                    = JetTag,
-        maxJetEta                 = cms.double(5.0),
-        minNconstituents          = cms.int32(1),
-        minNneutrals              = cms.int32(10),
-        minNcharged               = cms.int32(0),
-        maxNeutralFraction        = cms.double(0.99),
-        maxPhotonFraction         = cms.double(0.99),
-        maxPhotonFractionHF       = cms.double(0.90),
-        minChargedFraction        = cms.double(0),
-        maxChargedEMFraction      = cms.double(0.99),
-        jetPtFilter               = cms.double(30),
-        ExcludeLepIsoTrackPhotons = cms.bool(True),
-        JetConeSize               = cms.double(0.4),
-        MuonTag                   = cms.InputTag('LeptonsNew:IdIsoMuon'),
-        ElecTag                   = cms.InputTag('LeptonsNew:IdIsoElectron'),
-        IsoElectronTrackTag       = cms.InputTag('IsolatedElectronTracksVeto'),
-        IsoMuonTrackTag           = cms.InputTag('IsolatedMuonTracksVeto'),
-        IsoPionTrackTag           = cms.InputTag('IsolatedPionTracksVeto'),
-        PhotonTag                 = cms.InputTag('goodPhotons','bestPhoton'),
-    )
-    process.Baseline += process.GoodJets
-    VarsBool.extend(['GoodJets:JetID'])
-
-    ## ----------------------------------------------------------------------------------------------
     ## MET Filters
     ## ----------------------------------------------------------------------------------------------
     
@@ -555,64 +526,16 @@ fastsim=False
     VectorString.extend(['TriggerProducer:TriggerNames'])
 
     ## ----------------------------------------------------------------------------------------------
-    ## HT
+    ## Jet variables
     ## ----------------------------------------------------------------------------------------------
-    from TreeMaker.Utils.subJetSelection_cfi import SubJetSelection
-    process.HTJets = SubJetSelection.clone(
-        JetTag = cms.InputTag('GoodJets'),
-        MinPt  = cms.double(30),
-        MaxEta = cms.double(2.4),
-    )
-    process.Baseline += process.HTJets
-    VectorBool.extend(['HTJets:SubJetMask(HTJetsMask)'])
-    
-    from TreeMaker.Utils.htdouble_cfi import htdouble
-    process.HT = htdouble.clone(
-        JetTag = cms.InputTag('HTJets'),
-    )
-    process.Baseline += process.HT
-    VarsDouble.extend(['HT'])
-    
-    ## ----------------------------------------------------------------------------------------------
-    ## NJets
-    ## ----------------------------------------------------------------------------------------------
-    from TreeMaker.Utils.njetint_cfi import njetint
-    process.NJets = njetint.clone(
-        JetTag = cms.InputTag('HTJets'),
-    )
-    process.Baseline += process.NJets
-    VarsInt.extend(['NJets'])
-    
-    ## ----------------------------------------------------------------------------------------------
-    ## BTags
-    ## ----------------------------------------------------------------------------------------------
-    from TreeMaker.Utils.btagint_cfi import btagint
-    process.BTags = btagint.clone(
-        JetTag       = cms.InputTag('HTJets'),
-        BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
-        BTagCutValue = cms.double(0.890)
-    )
-    process.Baseline += process.BTags
-    VarsInt.extend(['BTags'])
-    
-    ## ----------------------------------------------------------------------------------------------
-    ## MHT
-    ## ----------------------------------------------------------------------------------------------
-    from TreeMaker.Utils.subJetSelection_cfi import SubJetSelection
-    process.MHTJets = SubJetSelection.clone(
-        JetTag = cms.InputTag('GoodJets'),
-        MinPt  = cms.double(30),
-        MaxEta = cms.double(5.0),
-    )
-    process.Baseline += process.MHTJets
-    VectorBool.extend(['MHTJets:SubJetMask(MHTJetsMask)'])
-    
-    from TreeMaker.Utils.mhtdouble_cfi import mhtdouble
-    process.MHT = mhtdouble.clone(
-        JetTag  = cms.InputTag('MHTJets'),
-    )
-    process.Baseline += process.MHT
-    VarsDouble.extend(['MHT:Pt(MHT)','MHT:Phi(MHT_Phi)'])
+
+    from TreeMaker.TreeMaker.makeJetVars import makeJetVars
+    process = makeJetVars(process,
+                          sequence="Baseline",
+                          JetTag=JetTag,
+                          suff='',
+                          skipGoodJets=False,
+                          storeProperties=True)
     
     ## ----------------------------------------------------------------------------------------------
     ## Baseline filters
@@ -629,17 +552,6 @@ fastsim=False
     if applybaseline:
         process.Baseline += process.HTFilter
         #process.Baseline += process.MHTFilter
-
-    ## ----------------------------------------------------------------------------------------------
-    ## DeltaPhi
-    ## ----------------------------------------------------------------------------------------------
-    from TreeMaker.Utils.deltaphidouble_cfi import deltaphidouble
-    process.DeltaPhi = deltaphidouble.clone(
-        DeltaPhiJets = cms.InputTag('HTJets'),
-        MHTJets      = cms.InputTag("MHTJets"),
-    )
-    process.Baseline += process.DeltaPhi
-    VarsDouble.extend(['DeltaPhi:DeltaPhi1','DeltaPhi:DeltaPhi2','DeltaPhi:DeltaPhi3','DeltaPhi:DeltaPhi4'])
     
     ## ----------------------------------------------------------------------------------------------
     ## MET
@@ -656,37 +568,6 @@ fastsim=False
     if geninfo:
         VarsDouble.extend(['MET:GenPt(GenMETPt)','MET:GenPhi(GenMETPhi)'])
         VectorDouble.extend(['MET:PtUp(METPtUp)', 'MET:PtDown(METPtDown)', 'MET:PhiUp(METPhiUp)', 'MET:PhiDown(METPhiDown)'])
-
-    ## ----------------------------------------------------------------------------------------------
-    ## Jet properties
-    ## ----------------------------------------------------------------------------------------------
-    
-    from TreeMaker.Utils.jetproperties_cfi import jetproperties
-    process.JetsProperties = jetproperties.clone(
-        JetTag       = cms.InputTag('GoodJets'),
-        BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
-        METTag       = METTag,
-    )
-    process.Baseline += process.JetsProperties
-    process.TreeMaker2.VectorRecoCand.extend(['GoodJets(Jets)'])
-    process.TreeMaker2.VectorDouble.extend(['JetsProperties:bDiscriminatorUser(Jets_bDiscriminatorCSV)',
-                                            'JetsProperties:bDiscriminatorMVA(Jets_bDiscriminatorMVA)',
-                                            'JetsProperties:chargedEmEnergyFraction(Jets_chargedEmEnergyFraction)',
-                                            'JetsProperties:chargedHadronEnergyFraction(Jets_chargedHadronEnergyFraction)',
-                                            'JetsProperties:jetArea(Jets_jetArea)',
-                                            'JetsProperties:muonEnergyFraction(Jets_muonEnergyFraction)',
-                                            'JetsProperties:neutralEmEnergyFraction(Jets_neutralEmEnergyFraction)',
-                                            'JetsProperties:neutralHadronEnergyFraction(Jets_neutralHadronEnergyFraction)',
-                                            'JetsProperties:photonEnergyFraction(Jets_photonEnergyFraction)'])
-    process.TreeMaker2.VectorInt.extend(['JetsProperties:chargedHadronMultiplicity(Jets_chargedHadronMultiplicity)',
-                                         'JetsProperties:electronMultiplicity(Jets_electronMultiplicity)',
-                                         'JetsProperties:muonMultiplicity(Jets_muonMultiplicity)',
-                                         'JetsProperties:neutralHadronMultiplicity(Jets_neutralHadronMultiplicity)',
-                                         'JetsProperties:photonMultiplicity(Jets_photonMultiplicity)',
-                                         'JetsProperties:partonFlavor(Jets_partonFlavor)',
-                                         'JetsProperties:hadronFlavor(Jets_hadronFlavor)',
-                                         'JetsProperties:chargedMultiplicity(Jets_chargedMultiplicity)',
-                                         'JetsProperties:neutralMultiplicity(Jets_neutralMultiplicity)'])
 
     ## ----------------------------------------------------------------------------------------------
     ## ----------------------------------------------------------------------------------------------

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -38,10 +38,6 @@ fastsim=False
     # CMSSW version sniffing
     CMSSWVER = os.getenv("CMSSW_VERSION")
     CMSSWVER_parts = CMSSWVER.split("_")
-    is74X = False
-    if int(CMSSWVER_parts[1])==7 and int(CMSSWVER_parts[2])>=4:
-        is74X = True
-        print "Configuring for 74X"
 
     # define if mt cut should be applied and the value (less than 0 means no cut)
     mtcut = cms.double(100)
@@ -593,12 +589,9 @@ fastsim=False
     from TreeMaker.Utils.btagint_cfi import btagint
     process.BTags = btagint.clone(
         JetTag       = cms.InputTag('HTJets'),
-        BTagInputTag = cms.string('combinedInclusiveSecondaryVertexV2BJetTags'),
-        BTagCutValue = cms.double(0.814)
+        BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
+        BTagCutValue = cms.double(0.890)
     )
-    if is74X:
-        process.BTags.BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags')
-        process.BTags.BTagCutValue = cms.double(0.890)
     process.Baseline += process.BTags
     VarsInt.extend(['BTags'])
     
@@ -671,10 +664,9 @@ fastsim=False
     from TreeMaker.Utils.jetproperties_cfi import jetproperties
     process.JetsProperties = jetproperties.clone(
         JetTag       = cms.InputTag('GoodJets'),
-        BTagInputTag = cms.string('combinedInclusiveSecondaryVertexV2BJetTags'),
+        BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
         METTag       = METTag,
     )
-    if is74X: process.JetsProperties.BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags')
     process.Baseline += process.JetsProperties
     process.TreeMaker2.VectorRecoCand.extend(['GoodJets(Jets)'])
     process.TreeMaker2.VectorDouble.extend(['JetsProperties:bDiscriminatorUser(Jets_bDiscriminatorCSV)',
@@ -710,7 +702,7 @@ fastsim=False
     ## ----------------------------------------------------------------------------------------------
     if hadtau:
         from TreeMaker.TreeMaker.doHadTauBkg import doHadTauBkg
-        process = doHadTauBkg(process,is74X,geninfo,residual,JetTag)
+        process = doHadTauBkg(process,geninfo,residual,JetTag)
 
     ## ----------------------------------------------------------------------------------------------
     ## Shared processes for lost lepton, tag and probe
@@ -743,7 +735,7 @@ fastsim=False
     ## ----------------------------------------------------------------------------------------------
     if doZinv:
         from TreeMaker.TreeMaker.doZinvBkg import doZinvBkg
-        process = doZinvBkg(process,is74X,METTag)
+        process = doZinvBkg(process,METTag)
 
     ## ----------------------------------------------------------------------------------------------
     ## ----------------------------------------------------------------------------------------------
@@ -752,7 +744,7 @@ fastsim=False
     ## ----------------------------------------------------------------------------------------------
     if QCD:
         from TreeMaker.TreeMaker.DeltaPhiQCD import DeltaPhiQCD
-        process = DeltaPhiQCD(process,is74X,geninfo)
+        process = DeltaPhiQCD(process,geninfo)
 
     ## ----------------------------------------------------------------------------------------------
     ## ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Jet-based variables are now created by a function which adds all the necessary processes. This function can be reused with different jet tags, by providing a new suffix which will be appended to all processes and branches.

Also, removed the now-unnecessary is74X flag.
