### PR TITLE
add private T2tt diagonal samples

### DIFF
--- a/Production/python/PrivateSamples/SMS-T2tt_mStop-170_mLSP-1_2bd_madgraphMLM-pythia8_13TeV_cff.py
+++ b/Production/python/PrivateSamples/SMS-T2tt_mStop-170_mLSP-1_2bd_madgraphMLM-pythia8_13TeV_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+
+for i in xrange(0,500):
+    readFiles.extend(['/store/group/phys_susy/LHE/private_samples/FSPremix74X/SMS-T2tt/SMS-T2tt_mStop-170_mLSP-1_2bd_madgraphMLM-pythia8_RunIISpring15MiniAODv2-FastAsympt25ns_74X_MINIAODSIM_b%s.root'%(i+1)])
+
+secFiles.extend( [
+               ] )

--- a/Production/python/PrivateSamples/SMS-T2tt_mStop-170_mLSP-1_madgraphMLM-pythia8_13TeV_cff.py
+++ b/Production/python/PrivateSamples/SMS-T2tt_mStop-170_mLSP-1_madgraphMLM-pythia8_13TeV_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+
+for i in xrange(0,500):
+    readFiles.extend(['/store/group/phys_susy/LHE/private_samples/FSPremix74X/SMS-T2tt/SMS-T2tt_mStop-170_mLSP-1_madgraphMLM-pythia8_RunIISpring15MiniAODv2-FastAsympt25ns_74X_MINIAODSIM_b%s.root'%(i+1)])
+
+secFiles.extend( [
+               ] )

--- a/Production/python/PrivateSamples/SMS-T2tt_mStop-172_mLSP-1_madgraphMLM-pythia8_13TeV_cff.py
+++ b/Production/python/PrivateSamples/SMS-T2tt_mStop-172_mLSP-1_madgraphMLM-pythia8_13TeV_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+
+missing = [204,212,216,220,224,228,261]
+
+for i in xrange(0,500):
+    if i in missing: continue
+    readFiles.extend(['/store/group/phys_susy/LHE/private_samples/FSPremix74X/SMS-T2tt/SMS-T2tt_mStop-172_mLSP-1_2bd_madgraphMLM-pythia8_RunIISpring15MiniAODv2-FastAsympt25ns_74X_MINIAODSIM_b%s.root'%(i+1)])
+
+secFiles.extend( [
+               ] )

--- a/Production/python/PrivateSamples/SMS-T2tt_mStop-173_mLSP-1_madgraphMLM-pythia8_13TeV_cff.py
+++ b/Production/python/PrivateSamples/SMS-T2tt_mStop-173_mLSP-1_madgraphMLM-pythia8_13TeV_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+
+for i in xrange(0,500):
+    readFiles.extend(['/store/group/phys_susy/LHE/private_samples/FSPremix74X/SMS-T2tt/SMS-T2tt_mStop-173_mLSP-1_2bd_madgraphMLM-pythia8_RunIISpring15MiniAODv2-FastAsympt25ns_74X_MINIAODSIM_b%s.root'%(i+1)])
+
+secFiles.extend( [
+               ] )

--- a/Production/test/condorSub/looper_priv.sh
+++ b/Production/test/condorSub/looper_priv.sh
@@ -12,10 +12,14 @@ KEEPTAR=$2
 
 SCENARIO=Spring15Fastv2
 
-#### privately generated T1ttbb
+#### privately generated SMS
 SAMPLES=(
 PrivateSamples.SMS-T1ttbb_mGluino-1300_mLSP-5_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff \
 PrivateSamples.SMS-T1ttbb_mGluino-1300_mLSP-10_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff \
+PrivateSamples.SMS-T2tt_mStop-170_mLSP-1_2bd_madgraphMLM-pythia8_13TeV \
+PrivateSamples.SMS-T2tt_mStop-170_mLSP-1_madgraphMLM-pythia8_13TeV \
+PrivateSamples.SMS-T2tt_mStop-172_mLSP-1_madgraphMLM-pythia8_13TeV \
+PrivateSamples.SMS-T2tt_mStop-173_mLSP-1_madgraphMLM-pythia8_13TeV \
 )
 
 for SAMPLE in ${SAMPLES[@]}; do


### PR DESCRIPTION
Notes from Ana:

> We have produced three T2tt points on the top corridor, specifically: mStop = 170, 172, 173 GeV with mLSP = 1 GeV (note that the on-shell top mass is set to the default Pythia 171 GeV with natural width).
> 
> The 170 point is produced in two ways:
> - stop -> chi10 + W + b, i.e. a 3-body decay
> - stop -> chi10 + t*, i.e. a 2-body decay via an off-shell top (this one is tagged by "_2bd" in the filenames and in the model tag in the LHEEventInfoProduct)
> 
> The current scans use the syntax for 3-body decays due to confusion of how the off-shell top decay should be specified in Pythia 8 at the beginning of the 74X production. Unless there is evidence that this has a significant impact, the same LHE will also be used in 80X. The two versions of the mStop=170 point can be used to understand the effect of how the decay is modeled, since the effect should be most pronounced when the top is barely off-shell. In particular, in the 2-body decay scenario, analyses involving top-tagging could be more sensitive to points very near the diagonal since the invariant mass of the W and b is pushed towards 171 GeV.
> 
> The samples (in MiniAODv2) are available on cern eos:
> /eos/cms/store/group/phys_susy/LHE/private_samples/FSPremix74X/SMS-T2tt/
