### PR TITLE
changed trigger object collection to retrieve lower online HT values

### DIFF
--- a/Utils/src/PrescaleWeightProducer.cc
+++ b/Utils/src/PrescaleWeightProducer.cc
@@ -115,7 +115,7 @@ void PrescaleWeightProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   for (pat::TriggerObjectStandAlone obj : *triggerObjects) 
     {
       obj.unpackPathNames(trigNames);
-      if (!(obj.collection() == "hltPFHT::HLT")) continue;
+      if (!(obj.collection() == "hltPFHTJet30::HLT")) continue;//hltPFHT::HLT
       if ( abs(obj.filterIds()[0]) == 89) 
 	{
 	  ht = obj.pt();


### PR DESCRIPTION
This change appears to be necessary to save the online HT values for events that fired HT triggers below the 600 GeV threshold.
