### PR TITLE
make MinDeltaRDouble useful for fragmentation, fix Z status bug

### DIFF
--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -182,12 +182,11 @@ def doZinvBkg(process,tagname,geninfo,residual,fastsim):
     process.TreeMaker2.VectorBool.append("goodPhotons:nonPrompt(Photons_nonPrompt)")
     process.TreeMaker2.VectorBool.append("goodPhotons:fullID(Photons_fullID)")
 
-    ## add MadGraph-level deltaR between photon or Z and partons
-    ## mainly used to make GJets and GJets0p4 MC samples orthogonal
-    ## if no photon is found (Zinv/DY MC) the Z boson is chosen
+    ## add MadGraph-level deltaR between photon or Z and status 23 partons
     if geninfo:
         process.madMinPhotonDeltaR = cms.EDProducer("MinDeltaRDouble")
-        process.TreeMaker2.VarsDouble.extend(['madMinPhotonDeltaR'])
+        process.TreeMaker2.VarsDouble.extend(['madMinPhotonDeltaR:madMinPhotonDeltaR(madMinPhotonDeltaR)'])
+        process.TreeMaker2.VarsInt.extend([   'madMinPhotonDeltaR:madMinDeltaRStatus(madMinDeltaRStatus)'])
 
     from TreeMaker.Utils.zproducer_cfi import ZProducer
     process.makeTheZs = ZProducer.clone(


### PR DESCRIPTION
added a status int to allow what sort of photon or Z is chosen to calculate deltaR with - for example, for fragmentation we would like to use photons that are radiated from quarks, not from meson decay

fix bug where I initially assumed the hard process Z had status 23, it in fact has status 22

for expected output on MC samples relevant to Zinv, see:
http://www-hep.colorado.edu/~fjensen/28102016_deltaRVerify/
