### PR TITLE
allow gluon parent photons for minDR

### DIFF
--- a/Utils/src/MinDeltaRDouble.cc
+++ b/Utils/src/MinDeltaRDouble.cc
@@ -44,16 +44,19 @@ void MinDeltaRDouble::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
             break;
          }
       }
-      // try to get the highest pT photon with a quark/lepton as mother (QCD)
+      // try to get the highest pT photon with a parton mother (QCD)
       if (!haveGen) {
          double maxPt = 0.;
          for (auto iG = pruned->begin(); iG != pruned->end(); ++iG) {
-            if (iG->pdgId()==22 && std::abs(iG->mother()->pdgId())>=1 && std::abs(iG->mother()->pdgId())<=6) {
-               if (iG->pt() > maxPt) {
-                  gen = iG->clone();
-                  haveGen = true;
-                  status = gen->status();
-                  maxPt = iG->pt();
+            if (iG->pdgId()==22) {
+               const int motherID = std::abs(iG->mother()->pdgId());
+               if ((motherID>=1 && motherID<=6) || motherID==21) {
+                  if (iG->pt() > maxPt) {
+                     gen = iG->clone();
+                     haveGen = true;
+                     status = gen->status();
+                     maxPt = iG->pt();
+                  }
                }
             }
          }
@@ -76,7 +79,7 @@ void MinDeltaRDouble::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if (haveGen) {
          for (auto iG = pruned->begin(); iG != pruned->end(); ++iG) {
             if (iG->status()==23) {
-               int tempID = std::abs(iG->pdgId());
+               const int tempID = std::abs(iG->pdgId());
                if ((tempID>=1 && tempID<=6) || tempID==21) {
                   double tempDR = deltaR(gen->p4(), iG->p4());
                   if (tempDR < minDR) minDR = tempDR;


### PR DESCRIPTION
When running on the QCD MC, madMinPhotonDeltaR was calculated with the highest pT gen-level photon with a quark parent. This is done for fragmentation studies. But in MINIAODSIM it is seen that some photons have gluon parents. This PR will now also consider gluon parent photons as the true parent was likely lost in particle pruning.

as expected no changes were observed to the GJets sample
as expected there is a very small increase in the total number of events in QCD which have a "usable" photon

attached plots are from QCD HT1500-2000 and HT1000-1500

![particletree](https://cloud.githubusercontent.com/assets/6392809/21015914/f9ade6e0-bd63-11e6-84d4-9e898e0dd6b2.png)
[QCD.deltaRcompare.pdf](https://github.com/TreeMaker/TreeMaker/files/639826/QCD.deltaRcompare.pdf)
[QCD.madMinPhotonDeltaR.compare.pdf](https://github.com/TreeMaker/TreeMaker/files/639828/QCD.madMinPhotonDeltaR.compare.pdf)
[QCD.status.compare.pdf](https://github.com/TreeMaker/TreeMaker/files/639827/QCD.status.compare.pdf)
