### PR TITLE
add top pt reweighting vars

### DIFF
--- a/Production/test/runMakeTreeFromMiniAOD_cfg.py
+++ b/Production/test/runMakeTreeFromMiniAOD_cfg.py
@@ -1,3 +1,5 @@
+import sys
+
 # Read parameters
 from TreeMaker.Utils.CommandLineParams import CommandLineParams
 parameters = CommandLineParams()
@@ -9,6 +11,7 @@ nfiles = parameters.value("nfiles",-1)
 numevents=parameters.value("numevents",-1)
 reportfreq=parameters.value("reportfreq",1000)
 outfile=parameters.value("outfile","test_run")
+dump=parameters.value("dump",False)
 
 # background estimations on by default
 lostlepton=parameters.value("lostlepton", True)
@@ -133,3 +136,8 @@ process = makeTreeFromMiniAOD(process,
 # final tweaks to process
 process.options.SkipEvent = cms.untracked.vstring('ProductNotFound')
 process.TFileService.closeFileFast = cms.untracked.bool(True)
+
+# if requested, dump and exit
+if dump:
+    print process.dumpPython()
+    sys.exit(0)

--- a/README.md
+++ b/README.md
@@ -190,3 +190,4 @@ Extra options in [runMakeTreeFromMiniAOD_cfg.py](./Production/test/runMakeTreeFr
 * `scenarioName`: name of the scenario for the sample, as described above (default="")
 * `era`: CMS detector era for the dataset
 * `redir`: xrootd redirector or storage element address (default=root://cmsxrootd.fnal.gov/)
+* `dump`: equivalent to `edmConfigDump`, but accounts for all command-line settings; exits without running (default=False)

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -177,6 +177,20 @@ pmssm=False
         VectorInt.append("genParticles:Status(GenParticles_Status)")
         VectorInt.append("genParticles:Parent(GenParticles_ParentIdx)")
         VectorInt.append("genParticles:ParentId(GenParticles_ParentId)")
+        
+        # for ttbar pT reweighting
+        # params from: https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopPtReweighting#Run_2_strategy
+        process.load("TopQuarkAnalysis.TopEventProducers.sequences.ttGenEvent_cff")
+        process.initSubset.src = cms.InputTag("prunedGenParticles")
+        process.decaySubset.src = cms.InputTag("prunedGenParticles")
+        process.decaySubset.runMode = cms.string("Run2")
+        process.genTops = cms.EDProducer("GenTopProducer",
+            genEvent = cms.InputTag("genEvt"),
+            a = cms.double(0.0615),
+            b = cms.double(-0.0005)
+        )
+        VectorRecoCand.append("genTops(GenTops)")
+        VarsDouble.append("genTops:weight(GenTopWeight)")
 
     ## ----------------------------------------------------------------------------------------------
     ## JECs

--- a/Utils/BuildFile.xml
+++ b/Utils/BuildFile.xml
@@ -15,6 +15,7 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="Geometry/CaloGeometry"/>
 <use   name="RecoParticleFlow/PFProducer"/>
+<use name="AnalysisDataFormats/TopObjects"/>
 <use name="TreeMaker/Reflex"/>
 <use name="root"/>
 <use name="rootmath"/>

--- a/Utils/src/GenTopProducer.cc
+++ b/Utils/src/GenTopProducer.cc
@@ -1,0 +1,144 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "TLorentzVector.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "AnalysisDataFormats/TopObjects/interface/TtGenEvent.h"
+
+#include <iostream>
+#include <vector>
+#include <cmath>
+
+class GenTopProducer : public edm::EDProducer {
+
+public:
+  explicit GenTopProducer(const edm::ParameterSet&);
+  ~GenTopProducer();
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+private:
+  double getSF(const reco::GenParticle& part);
+  virtual void beginJob() ;
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void endJob() ;
+  
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  
+  // ----------member data ---------------------------
+  
+  double a, b;
+  edm::InputTag genEvtTag;
+  edm::EDGetTokenT<TtGenEvent> genEvtTok;
+};
+
+GenTopProducer::GenTopProducer(const edm::ParameterSet& iConfig):
+  a(iConfig.getParameter<double>("a")),
+  b(iConfig.getParameter<double>("b")),
+  genEvtTag(iConfig.getParameter<edm::InputTag>("genEvent")),
+  genEvtTok(consumes<TtGenEvent>(genEvtTag))
+{
+  produces<std::vector<reco::GenParticle>>();
+  produces<double>("weight");
+}
+
+GenTopProducer::~GenTopProducer()
+{
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+//helper
+double GenTopProducer::getSF(const reco::GenParticle& part){
+  return exp(a+b*part.pt());
+}
+
+// ------------ method called for each event  ------------
+void
+GenTopProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  edm::Handle<TtGenEvent> genEvt;
+  iEvent.getByToken(genEvtTok, genEvt);
+
+  auto genTop_vec = std::make_unique<std::vector<reco::GenParticle>>();
+
+  //store t, then tbar (if present)
+  const reco::GenParticle* tmp = NULL;
+  tmp = genEvt->top();
+  if(tmp) genTop_vec->push_back(*tmp);
+  tmp = genEvt->topBar();
+  if(tmp) genTop_vec->push_back(*tmp);
+  
+  double weight = 1.0;
+  if(genTop_vec->size()==2) {
+    weight = sqrt(getSF(genTop_vec->at(0))*getSF(genTop_vec->at(1)));
+  }
+  auto pWeight = std::make_unique<double>(weight);
+
+  iEvent.put(std::move(genTop_vec));
+  iEvent.put(std::move(pWeight),"weight");
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+
+GenTopProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+GenTopProducer::endJob() 
+{
+}
+
+// ------------ method called when starting to processes a run  ------------
+void 
+GenTopProducer::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a run  ------------
+void 
+GenTopProducer::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when starting to processes a luminosity block  ------------
+void 
+GenTopProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+void 
+GenTopProducer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+GenTopProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+
+  /*
+    edm::ParameterSetDescription desc;
+    desc.setUnknown();
+    descriptions.addDefault(desc);
+  */
+
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(GenTopProducer);


### PR DESCRIPTION
The `GenTops` branch stores at most 2 particles, the top and antitop (in that order) selected by `TtGenEvent`.

NB, to use `GenTopWeight` properly for each event, you must divide it by the average of `GenTopWeight` for the *whole sample* in order to preserve the overall cross section.

This PR also adds an option to dump a command-line-customized runMakeTree config.