### PR TITLE
Btag updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 The following installation instructions assume the user wants to process Spring16 MC (miniAOD v1 or v2 format) or Run2016 data.
 
 ```
-cmsrel CMSSW_8_0_22
-cd CMSSW_8_0_22/src/
+cmsrel CMSSW_8_0_25
+cd CMSSW_8_0_25/src/
 cmsenv
 git cms-init
 git remote add btv-cmssw https://github.com/cms-btv-pog/cmssw.git
-git fetch btv-cmssw BoostedDoubleSVTaggerV3-WithWeightFiles-v1_from-CMSSW_8_0_8_patch1
-git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV3-WithWeightFiles-v1_from-CMSSW_8_0_8_patch1
+git fetch btv-cmssw BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_8_0_21
+git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_8_0_21
 git cms-merge-topic -u kpedro88:METfix8022
 git cms-merge-topic -u cms-met:CMSSW_8_0_X-METFilterUpdate
 git cms-merge-topic -u kpedro88:storeJERFactor8022

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -75,7 +75,7 @@ def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, f
     BTags = btagint.clone(
         JetTag       = HTJetsTag,
         BTagInputTag = cms.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
-        BTagCutValue = cms.double(0.800)
+        BTagCutValue = cms.double(0.8484)
     )
     setattr(process,"BTags"+suff,BTags)
     process.TreeMaker2.VarsInt.extend(['BTags'+suff])
@@ -84,7 +84,7 @@ def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, f
     BTagsMVA = btagint.clone(
         JetTag       = HTJetsTag,
         BTagInputTag = cms.string('pfCombinedMVAV2BJetTags'),
-        BTagCutValue = cms.double(0.185)
+        BTagCutValue = cms.double(0.4432)
     )
     setattr(process,"BTagsMVA"+suff,BTagsMVA)
     process.TreeMaker2.VarsInt.extend(['BTagsMVA'+suff])


### PR DESCRIPTION
Updated WPs according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation80XReReco and double b-tagger training according to https://twiki.cern.ch/twiki/bin/view/CMS/Hbbtagging#V4_training. Also updated CMSSW version to get latest xrootd version (4.5.0).