### PR TITLE
change to PUPPI AK8 jets

### DIFF
--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, fastsim, SkipTag=cms.VInputTag(), onlyGoodJets=False):
+def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, fastsim, SkipTag=cms.VInputTag(), onlyGoodJets=False, makeJetBranch=True):
     ## ----------------------------------------------------------------------------------------------
     ## GoodJets
     ## ----------------------------------------------------------------------------------------------
@@ -32,7 +32,8 @@ def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, f
         GoodJetsTag = cms.InputTag("GoodJets"+suff)
         process.TreeMaker2.VarsBool.extend(['GoodJets'+suff+':JetID(JetID'+suff+')'])
         if storeProperties>0:
-            process.TreeMaker2.VectorRecoCand.extend(['GoodJets'+suff+'(Jets'+suff+')'])
+            if makeJetBranch :
+                process.TreeMaker2.VectorRecoCand.extend(['GoodJets'+suff+'(Jets'+suff+')'])
             process.TreeMaker2.VectorBool.extend(['GoodJets'+suff+':JetIDMask(Jets'+suff+'_ID)'])
             if len(SkipTag)>0: process.TreeMaker2.VectorBool.extend(['GoodJets'+suff+':JetLeptonMask(Jets'+suff+'_LeptonMask)'])
         if onlyGoodJets:

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -695,41 +695,36 @@ pmssm=False
                           storeProperties=1,
                           geninfo=geninfo,
                           fastsim=fastsim,
-                          onlyGoodJets=True
+                          onlyGoodJets=True,
+                          makeJetBranch=False
     )
-    
+
+    # puppi jet producer - gets tau variables and softdrop mass from puppi collections
+    from TreeMaker.Utils.puppijetsak8producer_cfi import *
+    process.PuppiJetsAK8Producer = PuppiJetsAK8Producer.clone()
+
     # AK8 jet variables - separate instance of jet properties producer
     from TreeMaker.Utils.jetproperties_cfi import jetproperties
-    process.JetsPropertiesAK8 = jetproperties.clone(
-        JetTag       = JetAK8Tag,
-        properties = cms.vstring(
-            "prunedMass"           ,
-            "NsubjettinessTau1"    ,
-            "NsubjettinessTau2"    ,
-            "NsubjettinessTau3"    ,
-            "bDiscriminatorSubjet1",
-            "bDiscriminatorSubjet2",
-            "bDiscriminatorCSV"    ,
-            "NumBhadrons"          ,
-            "NumChadrons"          ,
-        )
-    )
+    process.JetsPropertiesAK8 = jetproperties.clone(JetTag       = JetAK8Tag,
+                                                    properties = cms.vstring("bDiscriminatorSubjet1",
+                                                                             "bDiscriminatorSubjet2",
+                                                                             "bDiscriminatorCSV"    ,
+                                                                             "NumBhadrons"          ,
+                                                                             "NumChadrons")
+                                                    )
     #specify userfloats
-    process.JetsPropertiesAK8.prunedMass = cms.vstring('ak8PFJetsCHSPrunedMass')
-    process.JetsPropertiesAK8.NsubjettinessTau1 = cms.vstring('NjettinessAK8:tau1')
-    process.JetsPropertiesAK8.NsubjettinessTau2 = cms.vstring('NjettinessAK8:tau2')
-    process.JetsPropertiesAK8.NsubjettinessTau3 = cms.vstring('NjettinessAK8:tau3')
     process.JetsPropertiesAK8.bDiscriminatorSubjet1 = cms.vstring('SoftDrop','pfCombinedInclusiveSecondaryVertexV2BJetTags')
     process.JetsPropertiesAK8.bDiscriminatorSubjet2 = cms.vstring('SoftDrop','pfCombinedInclusiveSecondaryVertexV2BJetTags')
     process.JetsPropertiesAK8.bDiscriminatorCSV = cms.vstring('pfBoostedDoubleSecondaryVertexAK8BJetTags')
     #VectorRecoCand.extend([JetAK8Tag.value()+'(JetsAK8)'])
-    VectorDouble.extend(['JetsPropertiesAK8:prunedMass(JetsAK8_prunedMass)',
+    VectorTLorentzVector.extend(['PuppiJetsAK8Producer(JetsAK8)'])
+    VectorDouble.extend(['PuppiJetsAK8Producer:softDropMass(JetsAK8_softDropMass)',
+                         'PuppiJetsAK8Producer:tau1(JetsAK8_tau1)',
+                         'PuppiJetsAK8Producer:tau2(JetsAK8_tau2)',
+                         'PuppiJetsAK8Producer:tau3(JetsAK8_tau3)',
                          'JetsPropertiesAK8:bDiscriminatorSubjet1(JetsAK8_bDiscriminatorSubjet1CSV)',
                          'JetsPropertiesAK8:bDiscriminatorSubjet2(JetsAK8_bDiscriminatorSubjet2CSV)',
-                         'JetsPropertiesAK8:bDiscriminatorCSV(JetsAK8_doubleBDiscriminator)',
-                         'JetsPropertiesAK8:NsubjettinessTau1(JetsAK8_NsubjettinessTau1)',
-                         'JetsPropertiesAK8:NsubjettinessTau2(JetsAK8_NsubjettinessTau2)',
-                         'JetsPropertiesAK8:NsubjettinessTau3(JetsAK8_NsubjettinessTau3)'])
+                         'JetsPropertiesAK8:bDiscriminatorCSV(JetsAK8_doubleBDiscriminator)'])
     VectorInt.extend(['JetsPropertiesAK8:NumBhadrons(JetsAK8_NumBhadrons)',
                       'JetsPropertiesAK8:NumChadrons(JetsAK8_NumChadrons)'])
 

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -696,7 +696,7 @@ pmssm=False
                           geninfo=geninfo,
                           fastsim=fastsim,
                           onlyGoodJets=True,
-                          makeJetBranch=False
+                          makeJetBranch=True
     )
 
     # puppi jet producer - gets tau variables and softdrop mass from puppi collections
@@ -706,22 +706,28 @@ pmssm=False
     # AK8 jet variables - separate instance of jet properties producer
     from TreeMaker.Utils.jetproperties_cfi import jetproperties
     process.JetsPropertiesAK8 = jetproperties.clone(JetTag       = JetAK8Tag,
-                                                    properties = cms.vstring("bDiscriminatorSubjet1",
+                                                    properties = cms.vstring("NsubjettinessTau1",
+                                                                             "NsubjettinessTau2",
+                                                                             "NsubjettinessTau3",
+                                                                             "bDiscriminatorSubjet1",
                                                                              "bDiscriminatorSubjet2",
                                                                              "bDiscriminatorCSV"    ,
                                                                              "NumBhadrons"          ,
                                                                              "NumChadrons")
                                                     )
     #specify userfloats
+    process.JetsPropertiesAK8.NsubjettinessTau1 = cms.vstring('ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau1')
+    process.JetsPropertiesAK8.NsubjettinessTau2 = cms.vstring('ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau2')
+    process.JetsPropertiesAK8.NsubjettinessTau3 = cms.vstring('ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3')
     process.JetsPropertiesAK8.bDiscriminatorSubjet1 = cms.vstring('SoftDrop','pfCombinedInclusiveSecondaryVertexV2BJetTags')
     process.JetsPropertiesAK8.bDiscriminatorSubjet2 = cms.vstring('SoftDrop','pfCombinedInclusiveSecondaryVertexV2BJetTags')
     process.JetsPropertiesAK8.bDiscriminatorCSV = cms.vstring('pfBoostedDoubleSecondaryVertexAK8BJetTags')
     #VectorRecoCand.extend([JetAK8Tag.value()+'(JetsAK8)'])
     VectorTLorentzVector.extend(['PuppiJetsAK8Producer(JetsAK8)'])
     VectorDouble.extend(['PuppiJetsAK8Producer:softDropMass(JetsAK8_softDropMass)',
-                         'PuppiJetsAK8Producer:tau1(JetsAK8_tau1)',
-                         'PuppiJetsAK8Producer:tau2(JetsAK8_tau2)',
-                         'PuppiJetsAK8Producer:tau3(JetsAK8_tau3)',
+                         'JetsPropertiesAK8:NsubjettinessTau1(JetsAK8_tau1)',
+                         'JetsPropertiesAK8:NsubjettinessTau2(JetsAK8_tau2)',
+                         'JetsPropertiesAK8:NsubjettinessTau3(JetsAK8_tau3)',
                          'JetsPropertiesAK8:bDiscriminatorSubjet1(JetsAK8_bDiscriminatorSubjet1CSV)',
                          'JetsPropertiesAK8:bDiscriminatorSubjet2(JetsAK8_bDiscriminatorSubjet2CSV)',
                          'JetsPropertiesAK8:bDiscriminatorCSV(JetsAK8_doubleBDiscriminator)'])

--- a/Utils/python/puppijetsak8producer_cfi.py
+++ b/Utils/python/puppijetsak8producer_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+PuppiJetsAK8Producer = cms.EDProducer('PuppiJetsAK8Producer',
+                                      JetTag = cms.InputTag("slimmedJetsAK8"),
+                                      SubJetTag = cms.InputTag("slimmedJetsAK8PFPuppiSoftDropPacked"),
+                                      debug = cms.bool(False)
+                                      )

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -42,7 +42,7 @@
 enum JetPropD { d_jetArea, d_chargedHadronEnergyFraction, d_neutralHadronEnergyFraction, d_chargedEmEnergyFraction, d_neutralEmEnergyFraction,
 				d_electronEnergyFraction, d_photonEnergyFraction, d_muonEnergyFraction, d_bDiscriminatorCSV, d_bDiscriminatorMVA,
 				d_jecFactor, d_jecUnc, d_jerFactor, d_jerFactorUp, d_jerFactorDown, d_qgLikelihood, d_qgPtD, d_qgAxis2,
-				d_prunedMass, d_bDiscriminatorSubjet1, d_bDiscriminatorSubjet2, d_NsubjettinessTau1, d_NsubjettinessTau2, d_NsubjettinessTau3 }; //AK8 properties
+				d_prunedMass, d_softDropMass, d_bDiscriminatorSubjet1, d_bDiscriminatorSubjet2, d_NsubjettinessTau1, d_NsubjettinessTau2, d_NsubjettinessTau3 }; //AK8 properties
 enum JetPropI { i_chargedHadronMultiplicity, i_neutralHadronMultiplicity, i_electronMultiplicity, i_photonMultiplicity,
 				i_muonMultiplicity, i_NumBhadrons, i_NumChadrons, i_chargedMultiplicity, i_neutralMultiplicity, i_partonFlavor, i_hadronFlavor, i_qgMult };
 
@@ -192,6 +192,7 @@ JetProperties::JetProperties(const edm::ParameterSet& iConfig)
 		else if(p=="qgPtD"                      ) { DoublePtrs_.push_back(new NamedPtrD<d_qgPtD>                      ("qgPtD",this)                      ); checkExtraInfo(iConfig, p, DoublePtrs_.back()); }
 		else if(p=="qgAxis2"                    ) { DoublePtrs_.push_back(new NamedPtrD<d_qgAxis2>                    ("qgAxis2",this)                    ); checkExtraInfo(iConfig, p, DoublePtrs_.back()); }
 		else if(p=="prunedMass"                 ) { DoublePtrs_.push_back(new NamedPtrD<d_prunedMass>                 ("prunedMass",this)                 ); checkExtraInfo(iConfig, p, DoublePtrs_.back()); }
+        else if(p=="softDropMass"                 ) { DoublePtrs_.push_back(new NamedPtrD<d_softDropMass>             ("softDropMass",this)                 ); checkExtraInfo(iConfig, p, DoublePtrs_.back()); }
 		else if(p=="NsubjettinessTau1"          ) { DoublePtrs_.push_back(new NamedPtrD<d_NsubjettinessTau1>          ("NsubjettinessTau1",this)          ); checkExtraInfo(iConfig, p, DoublePtrs_.back()); }
 		else if(p=="NsubjettinessTau2"          ) { DoublePtrs_.push_back(new NamedPtrD<d_NsubjettinessTau2>          ("NsubjettinessTau2",this)          ); checkExtraInfo(iConfig, p, DoublePtrs_.back()); }
 		else if(p=="NsubjettinessTau3"          ) { DoublePtrs_.push_back(new NamedPtrD<d_NsubjettinessTau3>          ("NsubjettinessTau3",this)          ); checkExtraInfo(iConfig, p, DoublePtrs_.back()); }

--- a/Utils/src/PuppiJetsAK8Producer.cc
+++ b/Utils/src/PuppiJetsAK8Producer.cc
@@ -1,0 +1,192 @@
+// -*- C++ -*-
+//
+// Package:    PuppiJetsAK8Producer
+// Class:      PuppiJetsAK8Producer
+// 
+/**\class PuppiJetsAK8Producer PuppiJetsAK8Producer.cc RA2Classic/PuppiJetsAK8Producer/src/PuppiJetsAK8Producer.cc
+ * 
+ * Description: [one line class summary]
+ * 
+ * Implementation:
+ *     [Notes on implementation]
+ */
+//
+// Original Author:  Andrew Whitbeck
+//         Created:  January 19, 2017
+// $Id$
+//
+//
+
+// root include files
+#include "TLorentzVector.h"
+
+// system include files
+#include <memory>
+#include <string>
+#include <vector>
+#include <iostream>
+#include <algorithm>
+#include <iterator>
+#include <map>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+class PuppiJetsAK8Producer : public edm::EDProducer {
+public:
+	explicit PuppiJetsAK8Producer(const edm::ParameterSet&);
+	~PuppiJetsAK8Producer();
+	
+	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+	
+private:
+	virtual void beginJob() ;
+	virtual void produce(edm::Event&, const edm::EventSetup&);
+	virtual void endJob() ;
+	
+	virtual void beginRun(edm::Run&, edm::EventSetup const&);
+	virtual void endRun(edm::Run&, edm::EventSetup const&);
+	virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+	virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+		
+	edm::InputTag JetTag_;
+	edm::InputTag SubJetTag_;
+	edm::EDGetTokenT<edm::View<pat::Jet>> JetTok_;
+	edm::EDGetTokenT<edm::View<pat::Jet>> SubJetTok_;
+	bool debug;
+};
+
+//
+// constructors and destructor
+//
+PuppiJetsAK8Producer::PuppiJetsAK8Producer(const edm::ParameterSet& iConfig)
+{
+    
+	JetTag_ = iConfig.getParameter<edm::InputTag>("JetTag");
+	JetTok_ = consumes<edm::View<pat::Jet>>(JetTag_);
+	SubJetTag_ = iConfig.getParameter<edm::InputTag>("SubJetTag");
+	SubJetTok_ = consumes<edm::View<pat::Jet>>(SubJetTag_);
+	debug = iConfig.getParameter<bool>("debug");
+
+    produces< std::vector< TLorentzVector > >();
+    produces< std::vector< double > >("tau3");
+    produces< std::vector< double > >("tau2");
+    produces< std::vector< double > >("tau1");
+    produces< std::vector< double > >("softDropMass");
+    
+}
+
+PuppiJetsAK8Producer::~PuppiJetsAK8Producer()
+{
+	
+	// do anything here that needs to be done at desctruction time
+	// (e.g. close files, deallocate resources etc.)
+	
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+PuppiJetsAK8Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+    auto puppiJets = std::make_unique<std::vector<TLorentzVector> >();
+    auto puppiTau1 = std::make_unique<std::vector<double> >();
+    auto puppiTau2 = std::make_unique<std::vector<double> >();
+    auto puppiTau3 = std::make_unique<std::vector<double> >();
+    auto puppiSoftDropMass = std::make_unique<std::vector<double> >();
+
+    TLorentzVector tempJet(0.,0.,0.,0.);
+	edm::Handle< edm::View<pat::Jet> > Jets;
+	iEvent.getByToken(JetTok_,Jets);
+
+	if( Jets.isValid() ) {
+		for(auto Jet = Jets->begin();  Jet != Jets->end(); ++Jet){
+            tempJet.SetPtEtaPhiE(Jet->userFloat("ak8PFJetsPuppiValueMap:pt"),
+                                 Jet->userFloat("ak8PFJetsPuppiValueMap:eta"),
+                                 Jet->userFloat("ak8PFJetsPuppiValueMap:phi"),
+                                 Jet->userFloat("ak8PFJetsPuppiValueMap:mass")
+                                 );
+            
+            puppiJets->push_back(tempJet);
+            puppiTau1->push_back(Jet->userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau1"));
+            puppiTau2->push_back(Jet->userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau2"));
+            puppiTau3->push_back(Jet->userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3"));
+
+            TLorentzVector puppi_softdrop, puppi_softdrop_subjet;
+            auto const & sdSubjetsPuppi = Jet->subjets("SoftDropPuppi");
+            for ( auto const & it : sdSubjetsPuppi ) {
+                puppi_softdrop_subjet.SetPtEtaPhiM(it->pt(),it->eta(),it->phi(),it->mass());
+                puppi_softdrop+=puppi_softdrop_subjet;
+            }
+            puppiSoftDropMass->push_back(puppi_softdrop.M());
+		}
+	}
+
+    iEvent.put(std::move(puppiJets));
+    iEvent.put(std::move(puppiTau1),"tau1");
+    iEvent.put(std::move(puppiTau2),"tau2");
+    iEvent.put(std::move(puppiTau3),"tau3");
+    iEvent.put(std::move(puppiSoftDropMass),"softDropMass");
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+PuppiJetsAK8Producer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+PuppiJetsAK8Producer::endJob() 
+{
+}
+
+// ------------ method called when starting to processes a run  ------------
+void 
+PuppiJetsAK8Producer::beginRun(edm::Run&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a run  ------------
+void 
+PuppiJetsAK8Producer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when starting to processes a luminosity block  ------------
+void 
+PuppiJetsAK8Producer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+void 
+PuppiJetsAK8Producer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+PuppiJetsAK8Producer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+	//The following says we do not know what parameters are allowed so do no validation
+	// Please change this to state exactly what you do use, even if it is no parameters
+	edm::ParameterSetDescription desc;
+	desc.setUnknown();
+	descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(PuppiJetsAK8Producer);

--- a/Utils/src/PuppiJetsAK8Producer.cc
+++ b/Utils/src/PuppiJetsAK8Producer.cc
@@ -77,9 +77,6 @@ PuppiJetsAK8Producer::PuppiJetsAK8Producer(const edm::ParameterSet& iConfig)
 	debug = iConfig.getParameter<bool>("debug");
 
     produces< std::vector< TLorentzVector > >();
-    produces< std::vector< double > >("tau3");
-    produces< std::vector< double > >("tau2");
-    produces< std::vector< double > >("tau1");
     produces< std::vector< double > >("softDropMass");
     
 }
@@ -103,9 +100,6 @@ PuppiJetsAK8Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
     auto puppiJets = std::make_unique<std::vector<TLorentzVector> >();
-    auto puppiTau1 = std::make_unique<std::vector<double> >();
-    auto puppiTau2 = std::make_unique<std::vector<double> >();
-    auto puppiTau3 = std::make_unique<std::vector<double> >();
     auto puppiSoftDropMass = std::make_unique<std::vector<double> >();
 
     TLorentzVector tempJet(0.,0.,0.,0.);
@@ -121,9 +115,6 @@ PuppiJetsAK8Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                                  );
             
             puppiJets->push_back(tempJet);
-            puppiTau1->push_back(Jet->userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau1"));
-            puppiTau2->push_back(Jet->userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau2"));
-            puppiTau3->push_back(Jet->userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3"));
 
             TLorentzVector puppi_softdrop, puppi_softdrop_subjet;
             auto const & sdSubjetsPuppi = Jet->subjets("SoftDropPuppi");
@@ -136,9 +127,6 @@ PuppiJetsAK8Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	}
 
     iEvent.put(std::move(puppiJets));
-    iEvent.put(std::move(puppiTau1),"tau1");
-    iEvent.put(std::move(puppiTau2),"tau2");
-    iEvent.put(std::move(puppiTau3),"tau3");
     iEvent.put(std::move(puppiSoftDropMass),"softDropMass");
 }
 


### PR DESCRIPTION
…ts and their corresponding substructure properties.  Main TreeMaker configuration changed so that old CHS AK8 jet properties are replaced with new puppi AK8 jet properties.  Jet mass is now the softdrop mass instead of the pruned jet mass.  Minor change to makeJetVars so that user can opt out of automatically getting the vector<TLorentzVector> branch for the corresponding jet collection.