### PR TITLE
add lepton/photon cleaned AK8 jets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_fr
 git cms-merge-topic -u kpedro88:METfix8022
 git cms-merge-topic -u cms-met:fromCMSSW_8_0_20_postICHEPfilter
 git cms-merge-topic -u kpedro88:storeJERFactor8022
+git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_80X_V3
 git clone git@github.com:TreeMaker/TreeMaker.git -b Run2
 scram b -j 8
 cd TreeMaker/Production/test


### PR DESCRIPTION
for this PR to work the following will need to be added to the TreeMaker installation recipe:
cd CMSSW_8_0_X/src/
git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_80X_V3

for other info reference the JetToolbox twiki:
https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetToolbox

the attached plots show distributions comparing the new electron/muon/photon cleaned AK8 jets to the 'standard' collection of AK8 jets - for events with no electrons, muons, or photons - the agreement is expected

[compareJets.doubleBDiscriminator.pdf](https://github.com/TreeMaker/TreeMaker/files/722244/compareJets.doubleBDiscriminator.pdf)
[compareJets.NJets8.pdf](https://github.com/TreeMaker/TreeMaker/files/722241/compareJets.NJets8.pdf)
[compareJets.pt.pdf](https://github.com/TreeMaker/TreeMaker/files/722242/compareJets.pt.pdf)
[compareJets.puppiSoftDropMass.pdf](https://github.com/TreeMaker/TreeMaker/files/722243/compareJets.puppiSoftDropMass.pdf)