### PR TITLE
add reclustered AK8CHS jets to Zinv

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_fr
 git cms-merge-topic -u kpedro88:METfix8022
 git cms-merge-topic -u cms-met:fromCMSSW_8_0_20_postICHEPfilter
 git cms-merge-topic -u kpedro88:storeJERFactor8022
+git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_80X_V3
 git clone git@github.com:TreeMaker/TreeMaker.git -b Run2
 scram b -j 8
 cd TreeMaker/Production/test

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -1,6 +1,91 @@
 import FWCore.ParameterSet.Config as cms
 
 def reclusterZinv(process, geninfo, residual, cleanedCandidates, suff, fastsim):
+    
+    ### AK8 detour
+
+    # https://twiki.cern.ch/CMS/JetToolbox
+    from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
+    listBTagInfos = ['pfInclusiveSecondaryVertexFinderTagInfos'] 
+    listBtagDiscriminatorsAK8 = [
+        'pfCombinedInclusiveSecondaryVertexV2BJetTags',
+        'pfBoostedDoubleSecondaryVertexAK8BJetTags'
+    ]
+    jecLevels = ['L2Relative', 'L3Absolute']
+    if residual: jecLevels.append("L2L3Residual")
+    jetToolbox(process,
+        'ak8',
+        'jetSequence',
+        'out',
+        PUMethod = 'CHS',
+        miniAOD = True,
+        runOnMC = geninfo,
+        postFix='Clean',
+        newPFCollection = True,
+        nameNewPFCollection = 'cleanedCandidates',
+        Cut = 'pt>170.',
+        addPruning = True,
+        #addSoftDropSubjets = True,
+        addNsub = True,
+        maxTau = 3,
+        bTagInfos = listBTagInfos, 
+        bTagDiscriminators = listBtagDiscriminatorsAK8,
+        JETCorrLevels = jecLevels,
+        subJETCorrLevels = jecLevels,
+    )
+    JetAK8CleanTag = cms.InputTag("selectedPatJetsAK8PFCHSClean")
+
+    from TreeMaker.TreeMaker.makeJetVars import makeJetVars
+    makeJetVars(process,
+        JetTag=JetAK8CleanTag,
+        suff='AK8Clean',
+        skipGoodJets=False,
+        storeProperties=1,
+        geninfo=geninfo,
+        fastsim=fastsim,
+        onlyGoodJets=True
+    )
+    
+    from TreeMaker.Utils.jetproperties_cfi import jetproperties
+    process.JetsPropertiesAK8Clean = jetproperties.clone(
+        JetTag       = JetAK8CleanTag,
+        debug = cms.bool(False),
+        properties = cms.vstring(
+            "prunedMass"    ,
+            "NsubjettinessTau1"    ,
+            "NsubjettinessTau2"    ,
+            "NsubjettinessTau3"    ,
+            #"bDiscriminatorSubjet1",
+            #"bDiscriminatorSubjet2",
+            "bDiscriminatorCSV"    ,
+            "NumBhadrons"          ,
+            "NumChadrons"          ,
+        )
+    )
+    
+    process.JetsPropertiesAK8Clean.prunedMass = cms.vstring('ak8PFJetsCHSCleanPrunedMass')
+    process.JetsPropertiesAK8Clean.NsubjettinessTau1 = cms.vstring('NjettinessAK8CHSClean:tau1')
+    process.JetsPropertiesAK8Clean.NsubjettinessTau2 = cms.vstring('NjettinessAK8CHSClean:tau2')
+    process.JetsPropertiesAK8Clean.NsubjettinessTau3 = cms.vstring('NjettinessAK8CHSClean:tau3')
+    #process.JetsPropertiesAK8Clean.bDiscriminatorSubjet1 = cms.vstring('SoftDrop','pfCombinedInclusiveSecondaryVertexV2BJetTags')
+    #process.JetsPropertiesAK8Clean.bDiscriminatorSubjet2 = cms.vstring('SoftDrop','pfCombinedInclusiveSecondaryVertexV2BJetTags')
+    process.JetsPropertiesAK8Clean.bDiscriminatorCSV = cms.vstring('pfBoostedDoubleSecondaryVertexAK8BJetTags')
+    process.TreeMaker2.VectorDouble.extend([
+        'JetsPropertiesAK8Clean:prunedMass(JetsAK8Clean_prunedMass)',
+        'JetsPropertiesAK8Clean:NsubjettinessTau1(JetsAK8Clean_NsubjettinessTau1)',
+        'JetsPropertiesAK8Clean:NsubjettinessTau2(JetsAK8Clean_NsubjettinessTau2)',
+        'JetsPropertiesAK8Clean:NsubjettinessTau3(JetsAK8Clean_NsubjettinessTau3)',
+        #'JetsPropertiesAK8Clean:bDiscriminatorSubjet1(JetsAK8Clean_bDiscriminatorSubjet1CSV)',
+        #'JetsPropertiesAK8Clean:bDiscriminatorSubjet2(JetsAK8Clean_bDiscriminatorSubjet2CSV)',
+        'JetsPropertiesAK8Clean:bDiscriminatorCSV(JetsAK8Clean_doubleBDiscriminator)'
+    ])
+    process.TreeMaker2.VectorInt.extend([
+        'JetsPropertiesAK8Clean:NumBhadrons(JetsAK8Clean_NumBhadrons)',
+        'JetsPropertiesAK8Clean:NumChadrons(JetsAK8Clean_NumChadrons)'
+    ])
+
+    ### end AK8 detour
+
     # do CHS for jet clustering
     cleanedCandidatesCHS = cms.EDFilter("CandPtrSelector",
         src = cleanedCandidates,

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -11,7 +11,7 @@ def reclusterZinv(process, geninfo, residual, cleanedCandidates, suff, fastsim):
         'pfCombinedInclusiveSecondaryVertexV2BJetTags',
         'pfBoostedDoubleSecondaryVertexAK8BJetTags'
     ]
-    jecLevels = ['L2Relative', 'L3Absolute']
+    jecLevels = ['L1FastJet', 'L2Relative', 'L3Absolute']
     if residual: jecLevels.append("L2L3Residual")
     jetToolbox(process,
         'ak8',
@@ -22,7 +22,7 @@ def reclusterZinv(process, geninfo, residual, cleanedCandidates, suff, fastsim):
         runOnMC = geninfo,
         postFix='Clean',
         newPFCollection = True,
-        nameNewPFCollection = 'cleanedCandidates',
+        nameNewPFCollection = cleanedCandidates.value(),
         Cut = 'pt>170.',
         addPruning = True,
         #addSoftDropSubjets = True,

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -703,7 +703,7 @@ pmssm=False
     process.JetsPropertiesAK8 = jetproperties.clone(
         JetTag       = JetAK8Tag,
         properties = cms.vstring(
-            "PuppiSoftDropMass"    ,
+            "prunedMass"    ,
             "NsubjettinessTau1"    ,
             "NsubjettinessTau2"    ,
             "NsubjettinessTau3"    ,
@@ -715,15 +715,15 @@ pmssm=False
         )
     )
     #specify userfloats
-    process.JetsPropertiesAK8.PuppiSoftDropMass = cms.vstring('SoftDropPuppi') # pass the desired subjet collection
-    process.JetsPropertiesAK8.NsubjettinessTau1 = cms.vstring('ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau1')
-    process.JetsPropertiesAK8.NsubjettinessTau2 = cms.vstring('ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau2')
-    process.JetsPropertiesAK8.NsubjettinessTau3 = cms.vstring('ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3')
+    process.JetsPropertiesAK8.prunedMass = cms.vstring('ak8PFJetsCHSPrunedMass')
+    process.JetsPropertiesAK8.NsubjettinessTau1 = cms.vstring('NjettinessAK8:tau1')
+    process.JetsPropertiesAK8.NsubjettinessTau2 = cms.vstring('NjettinessAK8:tau2')
+    process.JetsPropertiesAK8.NsubjettinessTau3 = cms.vstring('NjettinessAK8:tau3')
     process.JetsPropertiesAK8.bDiscriminatorSubjet1 = cms.vstring('SoftDrop','pfCombinedInclusiveSecondaryVertexV2BJetTags')
     process.JetsPropertiesAK8.bDiscriminatorSubjet2 = cms.vstring('SoftDrop','pfCombinedInclusiveSecondaryVertexV2BJetTags')
     process.JetsPropertiesAK8.bDiscriminatorCSV = cms.vstring('pfBoostedDoubleSecondaryVertexAK8BJetTags')
     #VectorRecoCand.extend([JetAK8Tag.value()+'(JetsAK8)'])
-    VectorDouble.extend(['JetsPropertiesAK8:PuppiSoftDropMass(JetsAK8_puppiSoftDropMass)',
+    VectorDouble.extend(['JetsPropertiesAK8:prunedMass(JetsAK8_prunedMass)',
                          'JetsPropertiesAK8:bDiscriminatorSubjet1(JetsAK8_bDiscriminatorSubjet1CSV)',
                          'JetsPropertiesAK8:bDiscriminatorSubjet2(JetsAK8_bDiscriminatorSubjet2CSV)',
                          'JetsPropertiesAK8:bDiscriminatorCSV(JetsAK8_doubleBDiscriminator)',


### PR DESCRIPTION
1) revert the main AK8 jet collection to pruned mass and standard (CHS?) jettiness variables. i.e. undo https://github.com/TreeMaker/TreeMaker/pull/211

2) add in AK8 CHS reclustered jet collection (no leptons or photons) to the Zinv section - still need to figure out how to get the subjets for subjet b tagging. This PR should be used instead of
https://github.com/TreeMaker/TreeMaker/pull/215
which should now be closed

the attached plots are made from 1000 events of T1ttt16 MC:
python unitTest.py test=2 run=True
with the following cuts
@Electrons->size()==0 && @Muons->size()==0 && @Photons->size()==0

[compareJets.doubleBDiscriminator.pdf](https://github.com/TreeMaker/TreeMaker/files/733035/compareJets.doubleBDiscriminator.pdf)
[compareJets.eta.pdf](https://github.com/TreeMaker/TreeMaker/files/733037/compareJets.eta.pdf)
[compareJets.NJets8.pdf](https://github.com/TreeMaker/TreeMaker/files/733036/compareJets.NJets8.pdf)
[compareJets.phi.pdf](https://github.com/TreeMaker/TreeMaker/files/733039/compareJets.phi.pdf)
[compareJets.prunedMass.pdf](https://github.com/TreeMaker/TreeMaker/files/733038/compareJets.prunedMass.pdf)
[compareJets.pt.pdf](https://github.com/TreeMaker/TreeMaker/files/733040/compareJets.pt.pdf)
