### PR TITLE
change > to >=

### DIFF
--- a/Utils/src/effArea.cc
+++ b/Utils/src/effArea.cc
@@ -39,7 +39,7 @@ public:
     // find the relevant eta range
     for( unsigned int i = 0 ; i < etaHigh.size() ; i++ ){
 
-      if( fabs(eta) < etaHigh[i] && fabs(eta) > etaLow[i] ){
+      if( fabs(eta) < etaHigh[i] && fabs(eta) >= etaLow[i] ){
 	iEta = i;
 	break;
       }


### PR DESCRIPTION
Line 42 changed from 
if( fabs(eta) < etaHigh[i] && fabs(eta) > etaLow[i] ){ 
to
if( fabs(eta) < etaHigh[i] && fabs(eta) >= etaLow[i] ){

For very rare cases in which |eta| = 0,1,2 , it could not match eta region.
Begin processing the 85001st record. Run 275073, Event 93307903, LumiSection 53 at 29-Jun-2017 22:41:44.699 CDT
AHHHHH: couldn't match eta region... eta=2
AHHHHH: couldn't match eta region... eta=2
AHHHHH: couldn't match eta region... eta=2
Begin processing the 86001st record. Run 275073, Event 93650022, LumiSection 53 at 29-Jun-2017 22:46:33.112 CDT