### PR TITLE
reorganize python files for makeTree (easier to add and share params)

### DIFF
--- a/Production/test/runMakeTreeFromMiniAOD_cfg.py
+++ b/Production/test/runMakeTreeFromMiniAOD_cfg.py
@@ -3,148 +3,56 @@ import sys
 # Read parameters
 from TreeMaker.Utils.CommandLineParams import CommandLineParams
 parameters = CommandLineParams()
-scenarioName=parameters.value("scenario","")
-inputFilesConfig=parameters.value("inputFilesConfig","")
-dataset=parameters.value("dataset",[])
-nstart = parameters.value("nstart",0)
-nfiles = parameters.value("nfiles",-1)
-numevents=parameters.value("numevents",-1)
+
+from TreeMaker.TreeMaker.makeTree import makeTree
+maker = makeTree(parameters)
+
+# run-only parameters
 reportfreq=parameters.value("reportfreq",1000)
-outfile=parameters.value("outfile","test_run")
 dump=parameters.value("dump",False)
 mp=parameters.value("mp",False)
 threads=parameters.value("threads",1)
 streams=parameters.value("streams",0)
 tmi=parameters.value("tmi",False)
 
-# background estimations on by default
-lostlepton=parameters.value("lostlepton", True)
-hadtau=parameters.value("hadtau", True)
-hadtaurecluster=parameters.value("hadtaurecluster", 1)
-doZinv=parameters.value("doZinv", True)
-
-# compute the PDF weights
-doPDFs=parameters.value("doPDFs", True);
-
-# other options off by default
-debugtracks=parameters.value("debugtracks", False)
-applybaseline=parameters.value("applybaseline", False)
-gridcontrol=parameters.value("gridcontrol", False)
-
-# auto configuration for different scenarios
-from TreeMaker.Production.scenarios import Scenario
-scenario = Scenario(scenarioName)
-
-# take command line input (w/ defaults from scenario if specified)
-globaltag=parameters.value("globaltag",scenario.globaltag)
-tagname=parameters.value("tagname",scenario.tagname)
-geninfo=parameters.value("geninfo",scenario.geninfo)
-pmssm=parameters.value("pmssm",scenario.pmssm)
-fastsim=parameters.value("fastsim",scenario.fastsim)
-signal=parameters.value("signal",scenario.signal)
-jsonfile=parameters.value("jsonfile",scenario.jsonfile)
-jecfile=parameters.value("jecfile",scenario.jecfile)
-residual=parameters.value("residual",scenario.residual)
-jerfile=parameters.value("jerfile",scenario.jerfile)
-pufile=parameters.value("pufile",scenario.pufile)
-era=parameters.value("era",scenario.era)
-
-#temporary redirector fix
-#fastsim signal is phedexed to LPC Tier3
-redir=parameters.value("redir", "root://cmseos.fnal.gov/" if fastsim and signal else "root://cmsxrootd.fnal.gov/")
-
-# The process needs to be defined AFTER reading sys.argv,
-# otherwise edmConfigHash fails
-import FWCore.ParameterSet.Config as cms
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process("RA2EventSelection")
-if len(era)>0:
-    process = cms.Process("RA2EventSelection",getattr(eras,era))
-
-# configure geometry & conditions
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
-
-# Load input files
-readFiles = cms.untracked.vstring()
-
-if inputFilesConfig!="" :
-    if nfiles==-1:
-        process.load("TreeMaker.Production."+inputFilesConfig+"_cff")
-        readFiles.extend( process.source.fileNames )
-    else:
-        readFilesImport = getattr(__import__("TreeMaker.Production."+inputFilesConfig+"_cff",fromlist=["readFiles"]),"readFiles")
-        readFiles.extend( readFilesImport[nstart:(nstart+nfiles)] )
-
-if dataset!=[] :    
-    readFiles.extend( [dataset] )
-
-for f,val in enumerate(readFiles):
-    if readFiles[f][0:6]=="/store":
-        readFiles[f] = redir+readFiles[f]
-    
 # print out settings
 print "***** SETUP ************************************"
-print " dataset: "+str(readFiles)
-print " outfile: "+outfile+"_RA2AnalysisTree"
-print " "
-print " storing lostlepton variables: "+str(lostlepton)
-print " storing hadtau variables: "+str(hadtau)+" w/ reclustering "+str(hadtaurecluster)
-print " storing Zinv variables: "+str(doZinv)
-print " "
-print " storing PDF weights: "+str(doPDFs)
-print " "
-print " storing track debugging variables: "+str(debugtracks)
-print " Applying baseline selection filter: "+str(applybaseline)
-print " "
-print " scenario: "+scenarioName
-print " global tag: "+globaltag
-print " Instance name of tag information: "+tagname
-print " Including gen-level information: "+str(geninfo)
-print " Including pMSSM-related information: "+str(pmssm)
-print " Using fastsim settings: "+str(fastsim)
-print " Running signal uncertainties: "+str(signal)
-if len(jsonfile)>0: print " JSON file applied: "+jsonfile
-if len(jecfile)>0: print " JECs applied: "+jecfile+(" (residuals)" if residual else "")
-if len(jerfile)>0: print " JERs applied: "+jerfile
-if len(pufile)>0: print " PU weights stored: "+pufile
-print " era of this dataset: "+era
+maker.printSetup()
 if mp: print " running memory profile"
 if threads>1:
     print " threads: "+str(threads)
     if streams>0: print " streams: "+str(streams)
 print "************************************************"
 
-from TreeMaker.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD
-process = makeTreeFromMiniAOD(process,
-    outfile=outfile+"_RA2AnalysisTree",
-    reportfreq=reportfreq,
-    dataset=readFiles,
-    globaltag=globaltag,
-    numevents=numevents,
-    hadtau=hadtau,
-    hadtaurecluster=hadtaurecluster,
-    lostlepton=lostlepton,
-    applybaseline=applybaseline,
-    doZinv=doZinv,
-    debugtracks=debugtracks,
-    geninfo=geninfo,
-    pmssm=pmssm,
-    tagname=tagname,
-    jsonfile=jsonfile,
-    jecfile=jecfile,
-    residual=residual,
-    jerfile=jerfile,
-    pufile=pufile,
-    doPDFs=doPDFs,
-    fastsim=fastsim,
-    signal=signal,
-    scenario=scenarioName
+# The process needs to be defined AFTER reading sys.argv,
+# otherwise edmConfigHash fails
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+process = cms.Process("RA2EventSelection")
+if len(maker.era)>0:
+    process = cms.Process("RA2EventSelection",getattr(eras,maker.era))
+
+# configure geometry & conditions
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+process.GlobalTag.globaltag = maker.globaltag
+
+# log output
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = reportfreq
+process.MessageLogger.categories.append('TreeMaker')
+process.MessageLogger.cerr.TreeMaker = cms.untracked.PSet(
+    optionalPSet = cms.untracked.bool(True),
+    limit = cms.untracked.int32(10000000),
+)
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True),
+    SkipEvent = cms.untracked.vstring('ProductNotFound'),
 )
 
-# final tweaks to process
-process.options.SkipEvent = cms.untracked.vstring('ProductNotFound')
-process.TFileService.closeFileFast = cms.untracked.bool(True)
+# memory profiling
 if mp:
     process.IgProfService = cms.Service("IgProfService",
         reportEventInterval = cms.untracked.int32(1),
@@ -158,10 +66,14 @@ if threads>1:
     process.options.numberOfThreads = cms.untracked.uint32(threads)
     process.options.numberOfStreams = cms.untracked.uint32(streams if streams>0 else 0)
 
+# simpler profiling
 if tmi:
     from Validation.Performance.TimeMemoryInfo import customise
     process = customise(process)
 
+# setup makeTree modules
+process = maker.makeTreeFromMiniAOD(process)
+    
 # if requested, dump and exit
 if dump:
     print process.dumpPython()

--- a/Production/test/runMakeTreeFromMiniAOD_cfg.py
+++ b/Production/test/runMakeTreeFromMiniAOD_cfg.py
@@ -158,14 +158,11 @@ if threads>1:
     process.options.numberOfThreads = cms.untracked.uint32(threads)
     process.options.numberOfStreams = cms.untracked.uint32(streams if streams>0 else 0)
 
+if tmi:
+    from Validation.Performance.TimeMemoryInfo import customise
+    process = customise(process)
+
 # if requested, dump and exit
 if dump:
     print process.dumpPython()
     sys.exit(0)
-
-#process.add_(cms.Service("StallMonitor", fileName = cms.untracked.string("stallMonitor.log")))
-#process.add_(cms.Service("Tracer", printTimestamps = cms.untracked.bool(True)))
-
-if tmi:
-    from Validation.Performance.TimeMemoryInfo import customise
-    process = customise(process)

--- a/README.md
+++ b/README.md
@@ -183,37 +183,40 @@ python get_py.py dict=dictNLO.py py=False
 
 ## Options
 
-Brief explanation of the options in [makeTreeFromMiniAOD_cff.py](./TreeMaker/python/makeTreeFromMiniAOD_cff.py)
-* `dataset`: name of the miniAOD input file(s)
-* `numevents`: number of input events to process, -1 processes all events (default=1000)
-* `reportfreq`: frequency of CMSSW log output (default=1000)
-* `outfile`: name of the ROOT output file that will be created by the TFileService (automatically appended with "_RA2AnalysisTree.root" when passed from [runMakeTreeFromMiniAOD_cfg.py](./Production/test/runMakeTreeFromMiniAOD_cfg.py))
-* `lostlepton`: switch to enable the lost lepton background estimation processes (default=False)
-* `hadtau`: switch to enable the hadronic tau background estimation processes (default=False)
+Brief explanation of the options in [makeTree.py](./TreeMaker/python/makeTree.py)
+* `scenario`: the scenario name, in case of special requirements (default="")
+* `inputFilesConfig`: name of the python file with a list of ROOT files for a sample, used for Condor production (automatically appended with "_cff") (default="")
+* `nstart`: first file to use in above file list (default=0)
+* `nfiles`: number of files to use in above file list, -1 includes all files (default=-1)
+* `dataset`: direct list of input files (alternative to above 3 parameters) (default=[])
+* `numevents`: number of input events to process, -1 processes all events (default=-1)
+* `outfile`: name of the ROOT output file that will be created by the TFileService (appended with `outfilesuff` below) (default="test_run")
+* `outfilesuff`: suffix to append to `outfile` above (default="_RA2AnalysisTree")
+* `treename`: name of output ROOT TTree (default="PreSelection")
+* `lostlepton`: switch to enable the lost lepton background estimation processes (default=True)
+* `hadtau`: switch to enable the hadronic tau background estimation processes (default=True)
 * `hadtaurecluster`: switch to enable the hadronic tau reclustering to include jets with pT < 10 GeV, options: 0 = never, 1 = only TTJets/WJets MC, 2 = all MC, 3 = always (default=1)
-* `doZinv`: switch to enable the Z->invisible background estimation processes (default=False)
-* `doPDFs`: switch to enable the storage of PDF weights and scale variation weights from LHEEventInfo (default=False)  
+* `doZinv`: switch to enable the Z->invisible background estimation processes (default=True)
+* `doPDFs`: switch to enable the storage of PDF weights and scale variation weights from LHEEventInfo (default=True)  
   The scale variations stored are: [mur=1, muf=1], [mur=1, muf=2], [mur=1, muf=0.5], [mur=2, muf=1], [mur=2, muf=2], [mur=2, muf=0.5], [mur=0.5, muf=1], [mur=0.5, muf=2], [mur=0.5, muf=0.5]
 * `debugtracks`: store information for all PF candidates in every event (default=False) (use with caution, increases run time and output size by ~10x)
 * `applybaseline`: switch to apply the baseline HT selection (default=False)
-* `gridcontrol`: switch to apply special settings for grid control submission (default=False)
+The following parameters take their default values from the specified scenario:
 * `globaltag`: global tag for CMSSW database conditions (ref. [FrontierConditions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions))
-* `tagname`: tag name for collections that can have different tags for data or MC (default="PAT")
-* `geninfo`: switch to enable use of generator information, should only be used for MC (default=True)
-* `fastsim`: switch to enable special settings for SUSY signal scans produced with FastSim (default=False)
-* `pmssm`: switch to enable special settings for pMSSM signal scans (default=False)
-* `signal`: switch to enable assessment of signal systematics (default=False) (currently unused)
+* `tagname`: tag name for collections that can have different tags for data or MC
+* `geninfo`: switch to enable use of generator information, should only be used for MC
+* `fastsim`: switch to enable special settings for SUSY signal scans produced with FastSim
+* `pmssm`: switch to enable special settings for pMSSM signal scans
+* `signal`: switch to enable assessment of signal systematics (currently unused)
 * `jsonfile`: name of JSON file to apply to data
-* `jecfile`: name of a database file from which to get JECs (default="")
-* `jerfile`: name of a database file from which to get JERs (default="")
-* `residual`: switch to enable residual JECs for data (default=False)
-* `scenario`: the scenario name, in case of special requirements (default="")
+* `jecfile`: name of a database file from which to get JECs
+* `jerfile`: name of a database file from which to get JERs
+* `residual`: switch to enable residual JECs for data
+* `era`: CMS detector era for the dataset
+* `redir`: xrootd redirector or storage element address (default="root://cmsxrootd.fnal.gov/") (`fastsim` default="root://cmseos.fnal.gov/")
 
 Extra options in [runMakeTreeFromMiniAOD_cfg.py](./Production/test/runMakeTreeFromMiniAOD_cfg.py):
-* `inputFilesConfig`: name of the python file with a list of ROOT files for a sample, used for Condor production (default="", automatically appended with "_cff.py")
-* `scenarioName`: name of the scenario for the sample, as described above (default="")
-* `era`: CMS detector era for the dataset
-* `redir`: xrootd redirector or storage element address (default=root://cmsxrootd.fnal.gov/)
+* `reportfreq`: frequency of CMSSW log output (default=1000)
 * `dump`: equivalent to `edmConfigDump`, but accounts for all command-line settings; exits without running (default=False)
 * `mp`: enable igprof hooks for memory profiling (default=False)
 * `threads`: run in multithreaded mode w/ specified number of threads (default=1)

--- a/TreeMaker/python/doLostLeptonBkg.py
+++ b/TreeMaker/python/doLostLeptonBkg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-def doLostLeptonBkg(process,geninfo,METTag):
-    if geninfo:
+def doLostLeptonBkg(self,process,METTag):
+    if self.geninfo:
         from TreeMaker.Utils.genLeptonRecoCand_cfi import genLeptonRecoCand
         process.GenLeptons = genLeptonRecoCand.clone(
             PrunedGenParticleTag  = cms.InputTag("prunedGenParticles"),
@@ -75,7 +75,7 @@ def doLostLeptonBkg(process,geninfo,METTag):
             METTag              = METTag
             )
 
-    if geninfo:
+    if self.geninfo:
         process.GenMuonMiniIso = isolationproducer.clone(
             LeptonTag = cms.InputTag('GenLeptons:Muon'), 
             LeptonType = cms.string('gen'),
@@ -127,7 +127,7 @@ def doLostLeptonBkg(process,geninfo,METTag):
     process.TreeMaker2.VectorDouble.extend(['TAPPionTracks:pfcandsactivity(TAPPionTracks_activity)'])
     process.TreeMaker2.VectorDouble.extend(['TAPPionTracks:pfcandsmT(TAPPionTracks_mT)'])
     process.TreeMaker2.VectorInt.extend(['TAPPionTracks:pfcandschg(TAPPionTracks_charge)'])
-    if geninfo: # gen information on leptons
+    if self.geninfo: # gen information on leptons
         process.TreeMaker2.VectorRecoCand.extend(['GenLeptons:Muon(GenMuons)','GenLeptons:Electron(GenElectrons)','GenLeptons:Tau(GenTaus)'])
         process.TreeMaker2.VectorDouble.extend(['GenMuonMiniIso:MT2Activity(GenMuons_MT2Activity)','GenElectronMiniIso:MT2Activity(GenElectrons_MT2Activity)', 'GenTauMiniIso:MT2Activity(GenTaus_MT2Activity)'])
         process.TreeMaker2.VectorDouble.extend(['GenLeptons:MuonGenRecoD3(GenMuons_RecoTrkd3)','GenLeptons:ElectronGenRecoD3(GenElectrons_RecoTrkd3)'])

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -29,7 +29,7 @@ def makeMHTVars(process, JetTag, HTJetsTag, storeProperties, suff, MHTsuff):
     
     return process
 
-def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, fastsim, scenario, SkipTag=cms.VInputTag(), onlyGoodJets=False):
+def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, SkipTag=cms.VInputTag(), onlyGoodJets=False):
     ## ----------------------------------------------------------------------------------------------
     ## GoodJets
     ## ----------------------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, f
             SaveAllJetsId             = True,
             SaveAllJetsPt             = False, # exclude low pt jets from good collection
         )
-        if fastsim: GoodJets.jetPtFilter = cms.double(20)
+        if self.fastsim: GoodJets.jetPtFilter = cms.double(20)
         setattr(process,"GoodJets"+suff,GoodJets)
         GoodJetsTag = cms.InputTag("GoodJets"+suff)
         process.TreeMaker2.VarsBool.extend(['GoodJets'+suff+':JetID(JetID'+suff+')'])
@@ -123,7 +123,7 @@ def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, f
     ## ----------------------------------------------------------------------------------------------
     # MHT, DeltaPhi moved to separate fn (above) because of stupid egamma slew corrections
     MHTOrig = ""
-    if scenario=="2016ReMiniAOD03Feb":
+    if self.scenario=="2016ReMiniAOD03Feb":
         MHTOrig = "Orig"
         from TreeMaker.Utils.patjetfix_cfi import patjetfix
         PatJetFix = patjetfix.clone(
@@ -136,7 +136,7 @@ def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, f
     ## ----------------------------------------------------------------------------------------------
     ## ISR jets
     ## ----------------------------------------------------------------------------------------------
-    if geninfo:
+    if self.geninfo:
         from TreeMaker.Utils.isrjet_cfi import ISRJetProducer
         ISRJets = ISRJetProducer.clone(
             JetTag = GoodJetsTag,
@@ -164,7 +164,7 @@ def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, f
         JetsProperties.bDiscriminatorMVA = cms.vstring('pfCombinedMVAV2BJetTags')
         if storeProperties==1: 
             JetsProperties.properties = cms.vstring("bDiscriminatorCSV","bDiscriminatorMVA","muonEnergyFraction","chargedHadronEnergyFraction","partonFlavor","hadronFlavor")
-        if storeProperties>1 and geninfo:
+        if storeProperties>1 and self.geninfo:
             JetsProperties.properties.extend(["jerFactor", "jerFactorUp","jerFactorDown"])
         setattr(process,"JetsProperties"+suff,JetsProperties)
         process.TreeMaker2.VectorDouble.extend(['JetsProperties'+suff+':bDiscriminatorCSV(Jets'+suff+'_bDiscriminatorCSV)',
@@ -183,7 +183,7 @@ def makeJetVars(process, JetTag, suff, skipGoodJets, storeProperties, geninfo, f
                                                     'JetsProperties'+suff+':qgLikelihood(Jets'+suff+'_qgLikelihood)',
                                                     'JetsProperties'+suff+':qgPtD(Jets'+suff+'_qgPtD)',
                                                     'JetsProperties'+suff+':qgAxis2(Jets'+suff+'_qgAxis2)'])
-            if geninfo:
+            if self.geninfo:
                 process.TreeMaker2.VectorDouble.extend(['JetsProperties'+suff+':jerFactor(Jets'+suff+'_jerFactor)',
                                                         'JetsProperties'+suff+':jerFactorUp(Jets'+suff+'_jerFactorUp)',
                                                         'JetsProperties'+suff+':jerFactorDown(Jets'+suff+'_jerFactorDown)'])

--- a/TreeMaker/python/makeTree.py
+++ b/TreeMaker/python/makeTree.py
@@ -1,0 +1,110 @@
+import FWCore.ParameterSet.Config as cms
+
+# import functions to be assigned as class methods
+from TreeMaker.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD
+from TreeMaker.TreeMaker.makeJetVars import makeJetVars
+from TreeMaker.TreeMaker.doHadTauBkg import doHadTauBkg, makeJetVarsHadTau
+from TreeMaker.TreeMaker.doLostLeptonBkg import doLostLeptonBkg
+from TreeMaker.TreeMaker.doZinvBkg import doZinvBkg, reclusterZinv
+
+class makeTree:
+    def __init__(self,parameters):
+        # auto configuration for different scenarios
+        self.scenarioName=parameters.value("scenario","")
+        from TreeMaker.Production.scenarios import Scenario
+        self.scenario = Scenario(self.scenarioName)
+        
+        self.getParamDefault(parameters,"inputFilesConfig","")
+        self.getParamDefault(parameters,"dataset",[])
+        self.getParamDefault(parameters,"nstart",0)
+        self.getParamDefault(parameters,"nfiles",-1)
+        self.getParamDefault(parameters,"numevents",-1)
+        self.getParamDefault(parameters,"outfile","test_run")
+        outfilesuff=parameters.value("outfilesuff","_RA2AnalysisTree")
+        self.outfile += outfilesuff
+        self.getParamDefault(parameters,"treename","PreSelection")
+        
+        # background estimations on by default
+        self.getParamDefault(parameters,"lostlepton", True)
+        self.getParamDefault(parameters,"hadtau", True)
+        self.getParamDefault(parameters,"hadtaurecluster", 1)
+        self.getParamDefault(parameters,"doZinv", True)
+        
+        # compute the PDF weights
+        self.getParamDefault(parameters,"doPDFs", True);
+        
+        # other options off by default
+        self.getParamDefault(parameters,"debugtracks", False)
+        self.getParamDefault(parameters,"applybaseline", False)
+        
+        # take command line input (w/ defaults from scenario if specified)
+        self.getParamDefault(parameters,"globaltag",self.scenario.globaltag)
+        self.getParamDefault(parameters,"tagname",self.scenario.tagname)
+        self.getParamDefault(parameters,"geninfo",self.scenario.geninfo)
+        self.getParamDefault(parameters,"pmssm",self.scenario.pmssm)
+        self.getParamDefault(parameters,"fastsim",self.scenario.fastsim)
+        self.getParamDefault(parameters,"signal",self.scenario.signal)
+        self.getParamDefault(parameters,"jsonfile",self.scenario.jsonfile)
+        self.getParamDefault(parameters,"jecfile",self.scenario.jecfile)
+        self.getParamDefault(parameters,"residual",self.scenario.residual)
+        self.getParamDefault(parameters,"jerfile",self.scenario.jerfile)
+        self.getParamDefault(parameters,"pufile",self.scenario.pufile)
+        self.getParamDefault(parameters,"era",self.scenario.era)
+        
+        # temporary redirector fix
+        # fastsim signal is phedexed to LPC Tier3
+        self.getParamDefault(parameters,"redir", "root://cmseos.fnal.gov/" if self.fastsim and self.signal else "root://cmsxrootd.fnal.gov/")
+        
+        # Load input files
+        self.readFiles = cms.untracked.vstring()
+
+        if self.inputFilesConfig!="" :
+            readFilesImport = getattr(__import__("TreeMaker.Production."+self.inputFilesConfig+"_cff",fromlist=["readFiles"]),"readFiles")
+            if self.nfiles==-1:
+                self.readFiles.extend( readFilesImport )
+            else:
+                self.readFiles.extend( readFilesImport[self.nstart:(self.nstart+self.nfiles)] )
+
+        if self.dataset!=[] :    
+            self.readFiles.extend( [self.dataset] )
+
+        self.readFiles = [(self.redir if val[0:6]=="/store" else "")+val for val in self.readFiles]
+        
+    def getParamDefault(self,parameters,param,default):
+        setattr(self,param,parameters.value(param,default))
+        
+    def printSetup(self):
+        print " dataset: "+str(self.readFiles)
+        print " outfile: "+self.outfile
+        print " treename: "+self.treename
+        print " "
+        print " storing lostlepton variables: "+str(self.lostlepton)
+        print " storing hadtau variables: "+str(self.hadtau)+" w/ reclustering "+str(self.hadtaurecluster)
+        print " storing Zinv variables: "+str(self.doZinv)
+        print " "
+        print " storing PDF weights: "+str(self.doPDFs)
+        print " "
+        print " storing track debugging variables: "+str(self.debugtracks)
+        print " Applying baseline selection filter: "+str(self.applybaseline)
+        print " "
+        print " scenario: "+self.scenarioName
+        print " global tag: "+self.globaltag
+        print " Instance name of tag information: "+self.tagname
+        print " Including gen-level information: "+str(self.geninfo)
+        print " Including pMSSM-related information: "+str(self.pmssm)
+        print " Using fastsim settings: "+str(self.fastsim)
+        print " Running signal uncertainties: "+str(self.signal)
+        if len(self.jsonfile)>0: print " JSON file applied: "+self.jsonfile
+        if len(self.jecfile)>0: print " JECs applied: "+self.jecfile+(" (residuals)" if self.residual else "")
+        if len(self.jerfile)>0: print " JERs applied: "+self.jerfile
+        if len(self.pufile)>0: print " PU weights stored: "+self.pufile
+        print " era of this dataset: "+self.era
+
+    # assign class methods from functions
+    makeTreeFromMiniAOD = makeTreeFromMiniAOD
+    makeJetVars = makeJetVars
+    doHadTauBkg = doHadTauBkg
+    makeJetVarsHadTau = makeJetVarsHadTau
+    doLostLeptonBkg = doLostLeptonBkg
+    doZinvBkg = doZinvBkg
+    reclusterZinv = reclusterZinv

--- a/TreeMaker/python/makeTree.py
+++ b/TreeMaker/python/makeTree.py
@@ -74,7 +74,7 @@ class makeTree:
         setattr(self,param,parameters.value(param,default))
         
     def printSetup(self):
-        print " dataset: "+str(self.readFiles)
+        print " readFiles: "+str(self.readFiles)
         print " outfile: "+self.outfile
         print " treename: "+self.treename
         print " "

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -17,7 +17,7 @@ def makeTreeFromMiniAOD(self,process):
         input = cms.untracked.int32(self.numevents)
     )
     process.source = cms.Source("PoolSource",
-        fileNames = cms.untracked.vstring(self.dataset),
+        fileNames = cms.untracked.vstring(self.readFiles),
         inputCommands = cms.untracked.vstring('keep *','drop LHERunInfoProduct_*_*_*'),
     )
     if len(self.jsonfile)>0: process.source.lumisToProcess = LumiList.LumiList(filename = self.jsonfile).getVLuminosityBlockRange()


### PR DESCRIPTION
So far in TreeMaker, run parameters have been rather disorganized. Different default values were present in `runMakeTreeFromMiniAOD` and `makeTreeFromMiniAOD`, along with some different names for the same parameters. Process modifications were scattered all over. Also, when one wanted to access a parameter in a background estimation function, it was sometimes necessary to modify multiple function signatures to pass it through. Adding an entirely new parameter could be even more painful.

Now:
1. Introduce `makeTree` object which keeps track of its own parameters as member variables - all parameter definitions in one place
2. `runMakeTreeFromMiniAOD` still has a few separate parameters that are not used by (and have no dependence on anything in) `makeTree` - typically for debugging purposes
3. All the generic (always required by CMSSW) process additions done in `runMakeTreeFromMiniAOD`, everything else in `makeTree`
4. To pass parameters around more easily, jet and background estimation functions set up as member functions of `makeTree` - simplify interfaces
5. Default values synchronized, descriptions updated in README
6. Made a few more things configurable (output file suffix, output tree name)
7. Cleaned out some unused stuff