### PR TITLE
add samples for T5qqqqZH (and one for WW)

### DIFF
--- a/Production/python/Summer16/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/160C3AF0-68D5-E611-998F-A0369F310374.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/5825E6ED-68D5-E611-815C-00259074AE9A.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/5A07ADDE-68D5-E611-98C7-1866DAEB5D80.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/70C517FA-68D5-E611-9BCE-0025905A60D2.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/84E2BC05-69D5-E611-A1B2-00266CFFA750.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/84E2E9EC-68D5-E611-883A-6CC2173BC2E0.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/887AA800-69D5-E611-82AE-0025905A60BE.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/D0BB5AE3-68D5-E611-9609-02163E013726.root' ] );
+
+
+secFiles.extend( [
+               ] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/04F872F2-C2F7-E611-8171-0CC47A7C3408.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/20EADA64-68F6-E611-A814-0025905B85FC.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/50B6ECEB-C2F7-E611-A3EE-0CC47A4D7666.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/5467D376-ACFB-E611-93DC-02163E00B0DD.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/6CFF6921-73F8-E611-988E-001CC4A65D70.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/7C773C71-87F8-E611-B6FD-0CC47A4C8E14.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/987DF914-ACFB-E611-AA53-FA163EAED918.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/A6CD4611-A4F7-E611-8664-0025904C66A4.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/B23E3ADA-A6F7-E611-B4C7-002590AB3A82.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/B84F6B8D-87F8-E611-9330-0025905B8574.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/F03A446A-00F7-E611-9B75-047D7B2E81BC.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/F6D751C5-A3F7-E611-A962-00145EDD783D.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/48CE8A4B-47F7-E611-8FD7-0CC47A78A30E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/6E025798-7BF5-E611-9896-0025905B85EE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/760CA0A6-4DF6-E611-97A0-0025905B85A2.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/AE2747A9-18F7-E611-9735-5065F37DD491.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/C8EB024F-47F7-E611-A19F-0CC47A4D76D6.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/F2C02763-6BF5-E611-AC63-0CC47A4D7644.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/FA189AA8-4DF6-E611-B0CB-0025905B855E.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/728021A3-EAFC-E611-A0E3-02163E0120DA.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/40CB68F8-9EF7-E611-A50E-02163E014648.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/54F6D68D-01F8-E611-9FC4-02163E01356E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/7A2149EB-08F8-E611-A980-02163E014226.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/8A34C0D5-A7F7-E611-83F3-02163E01A1FC.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/A8C95A30-DBF8-E611-BEE5-02163E019E12.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/AC918DF4-A0F7-E611-BD50-02163E019B80.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/E66A0EA8-EAF7-E611-A2FA-02163E019D95.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/EC618218-FBF6-E611-A8A0-008CFA110C64.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/F09F04C2-8CF7-E611-9956-02163E019E57.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/FE1F7958-CBF7-E611-A87D-02163E019E2C.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/080B466A-CBF6-E611-8741-A0369FD8FDB0.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/12411E76-4CF7-E611-A961-20CF305616E8.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/1E2DBA77-4DF7-E611-A829-1CC1DE192582.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/261BEA02-4CF7-E611-96DB-B499BAAC039C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/3A2CCF6F-4DF7-E611-A8BC-D8D385AE870A.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/4EF6F6E9-28F6-E611-AB12-009C02AAB484.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/504481CC-C0F6-E611-AC0D-00145EDD7389.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/506F6BD9-4DF7-E611-B1AF-0025905C4264.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/58C04808-34F7-E611-935A-047D7B881DB8.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/6EF55E69-86F6-E611-9F87-C4346BC08440.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/748A4997-22F7-E611-8E3A-02163E015DAF.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/7C761234-50F7-E611-9E87-00266CFFCAA4.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/8C018D74-31F7-E611-BAE6-0025904C7F72.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/90864873-4DF7-E611-845A-B083FECFC6ED.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/9C47730B-0EF7-E611-9A95-001E67792650.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/9CB6447B-72F6-E611-9C6A-C4346BC08440.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/A42342AB-4CF7-E611-AB56-0CC47A7C3610.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/AC83BE3B-F6F6-E611-9CB9-3417EBE47FCA.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/D23237AB-4CF7-E611-980C-002590E7D7DE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/D2DFDF1E-4CF7-E611-86E8-FA163EC94B30.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/E42478AD-0AF7-E611-B99C-FA163E23659B.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/FC17E18F-0EF7-E611-84DF-7845C4FC35EA.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/1CDC5946-73F7-E611-AD8B-0CC47A4D7602.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/3EB61D13-96F7-E611-82C2-008CFA110B08.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/424F70DE-A8F7-E611-AE05-0CC47A4C8EEA.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/7AC3B3A4-50F9-E611-B444-0025905A60F4.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/7C353C51-D2F6-E611-AE9E-001E674FCA99.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/80FCCBAC-C0F7-E611-ABCB-02163E0114CE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/885C6F44-2CF8-E611-922B-24BE05CE1E01.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/90BF856B-50F9-E611-9B1F-0CC47A7C34D0.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/AC863597-50F9-E611-8D33-0025905B8590.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/C03F659C-BEF7-E611-9852-00304867FEC3.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/CA9A1E82-9CF7-E611-AA08-001E674FB207.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/D40F2091-BCF7-E611-B731-FA163EAE335B.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/F8760AAE-50F9-E611-ACDA-0025905A6104.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/0E717B04-E5F6-E611-A1DD-00145EDD781B.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/123DD367-04F7-E611-9E81-90B11CBCFFB6.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/240CCC79-0EF7-E611-9B5D-44A842CFC9E6.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/2491CDD0-18F6-E611-98BE-B499BAAC0626.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/3A31C581-09F7-E611-8849-0025905C2D98.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/4018463D-5AF5-E611-9217-0CC47A7C360E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/40E818E5-03F7-E611-B995-180373FF8CD4.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/420E81A7-4DF6-E611-A044-0025905A611C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/46F9AE36-FBF6-E611-BF8F-441EA17344AC.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/48779E0C-5BF7-E611-A09A-0CC47A74524E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/4C1DEA2A-53F5-E611-B049-0CC47A7C357A.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/58AB9627-14F6-E611-9E5D-0025904CF712.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/60074088-59F7-E611-B760-FA163EEB737C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/7EB0588B-5AF5-E611-A23B-0CC47A7452D8.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/8227421D-C2F6-E611-B161-FA163E79E9E7.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/A8A37AA0-C3F6-E611-B5F7-FA163E77B33C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/D8594FDE-62F5-E611-A809-0CC47A78A30E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/F4191A9A-EFF6-E611-8F1C-009C02AAB258.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/FE16B4AA-4DF6-E611-97E4-0025905B85E8.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/069E9938-4BF6-E611-A19A-008CFA111320.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/1A7D66BC-4DF6-E611-BE79-0CC47AD98BC2.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/1C223FDF-C3F6-E611-A075-02163E016482.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/2009B577-70F6-E611-ADE0-34E6D7BEAF0E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/320C2261-0FF6-E611-8752-1866DAEA8230.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/368F930E-C3F6-E611-8F6C-FA163EFFA8F7.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/3C777A7F-1EF6-E611-86D1-0CC47A537688.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/3E499430-47F7-E611-8AB9-0CC47A4C8E96.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/4273D8D0-08F6-E611-9EC1-0025905C3E68.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/4CA168C9-4DF5-E611-A70D-0025905A48C0.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/68424EC1-11F6-E611-9EEE-002481DE4A28.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/70C7653A-34F7-E611-825C-02163E019BB8.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/72D39475-35F6-E611-8ABC-484D7E8DF0D3.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/74A539CF-4FF5-E611-B0F1-0CC47A4D7640.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/7EC93A05-34F7-E611-BC7B-02163E015FFE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/8033213D-18F7-E611-B874-5065F37D7121.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/805A6B84-1AF6-E611-B8F8-7845C4FC3B0C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/96EFBCA4-4DF6-E611-9BBD-0CC47A7C3404.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/B08046F9-28F6-E611-86AC-0023AEEEB226.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/B80B3280-31F7-E611-9A77-C4346BC076D0.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/BC1269A2-2DF6-E611-B7D8-002590D9D976.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/D8541D77-1EF6-E611-BF73-44A842BFA94B.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/ECA00BA9-4DF6-E611-9751-0025905A60D2.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/EEE781F4-10F6-E611-8BDC-5C260AFFFB45.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/F01EB9B3-5AF5-E611-9830-0CC47A4C8E2E.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/323A9A33-E0F7-E611-8FAD-0CC47A7E6980.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/3CF02479-40F8-E611-B21C-02163E013982.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/3E55D3EA-E6F7-E611-88E1-FA163E6BF37A.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/3E7252CD-13F7-E611-BB23-0CC47A7E0134.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/4CD2D99C-17F7-E611-9396-3417EBE64519.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/5837733A-41F8-E611-819D-001E67504F55.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/6A27C141-3FF8-E611-9BFF-A0369F836372.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/6EC0984F-2BF8-E611-A857-C4346BC7EE18.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/70D57D8D-32F8-E611-85D1-00266CFEFE08.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/84F6E740-EAF7-E611-81A9-44A842CFD5F2.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/C8E8DE49-40F8-E611-9A98-FA163ED2118E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/CC93BBD7-D6F7-E611-A2EE-002590A371C4.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/D89D2A8F-3FF8-E611-A518-002590A831B4.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/E2E015C0-3FF8-E611-8B37-3417EBE64CDB.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/F422A3DD-28F7-E611-B7AC-848F69FD4568.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/0A5BC29C-BAF7-E611-885D-02163E01A231.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/22A12361-CDF7-E611-BECB-02163E019C5E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/267A867C-12F8-E611-BFA5-02163E013660.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/26866D5C-E0F7-E611-B632-02163E01A75D.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/60B0456B-6CF8-E611-88A5-02163E01A5D1.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/C0E03EF3-14F8-E611-8038-02163E014418.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/DC391B97-01F8-E611-90CD-02163E019C89.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/F6301D7D-17F8-E611-9CE8-02163E01A49D.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/32AD4E5E-7FF7-E611-8F46-02163E014865.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/4E406141-76F7-E611-BE56-FA163E653CC5.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/5A69D478-82F7-E611-94A4-FA163EB7581E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/5E5CDACC-72F7-E611-B748-FA163E5B9809.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/60EFFB63-6BF7-E611-BA89-FA163ECE7B43.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/9A72BD17-61F7-E611-9DED-001E67C7B165.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/A241CDCE-72F7-E611-BD81-02163E014A0B.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/CC8CB5ED-64F7-E611-967F-02163E0164B6.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/CE63D882-60F7-E611-9F80-FA163E2B94F4.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/1C2B9B84-49F8-E611-8807-02163E01A717.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/2E3E6F69-61F8-E611-AB57-02163E019BD2.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/84A2C8FF-52F8-E611-83E0-02163E013990.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/BC055560-75F8-E611-BA0B-02163E019C90.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/C85514AE-3EF8-E611-B251-02163E01A5FE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/DE684C4A-28F8-E611-825C-02163E01A7A5.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/DE8CCF7A-32F8-E611-A62B-02163E011C5A.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/E4BE7A67-5DF8-E611-A8E2-02163E01A5F6.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/FA8B22C0-65F8-E611-8109-02163E01A1C9.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/12E245B7-A6F7-E611-A92E-008CFA000B68.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/20F6FD88-D8F6-E611-9FD2-F04DA274BB9C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/2807EFC5-A4F7-E611-AB66-002590DE6E86.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/38032394-0100-E711-8E2D-001E67E6F89B.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/3C9F2E5F-F9F5-E611-A146-A0369F6369D2.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/48F9306A-ABFD-E611-A8B2-02163E01A35C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/506AE655-CFFB-E611-8325-FA163E4334BE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/5637F7D0-A6F7-E611-AFDA-0CC47A57D164.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/58BF1B36-D9FC-E611-A352-02163E0143E9.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/621AC8CB-24FB-E611-8530-6CC2173BC370.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/661817BF-D5FB-E611-8B7E-FA163E023ED2.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/66220C22-A5FC-E611-A1B8-002590495244.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/68CC18BA-DCFB-E611-81B3-02163E00AFFC.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/68CD0B5D-A3F8-E611-8440-D8D385AF8AEE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/7E3C39ED-0AF9-E611-AD97-002590DB920C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/9AC1FBCE-A3F7-E611-A15D-0023AEEEB799.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/A4745AAD-C8F6-E611-8044-D8D385AE8BAE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/C2619311-71F6-E611-B7CD-0025905C54B8.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/C85D9161-C1F6-E611-9085-6CC2173D6B10.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/EC88E81B-73F8-E611-97F1-44A842CFD5BE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/F2374204-B4FC-E611-86DC-02163E00CA1E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/110000/F83F704D-C8F9-E611-82C9-C4346BBCB6A8.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/067FA4C8-C8F7-E611-AB91-0090FAA57910.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/64155C61-66F7-E611-B38A-0CC47A7DFF2E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/9C30D2A7-E8F6-E611-BC99-001E67E71BE1.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/A6DB2ECB-3FF7-E611-B976-001E674DA1AD.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/CEDE0880-7BF7-E611-9113-0CC47A78A408.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/E600B860-01F8-E611-830C-6CC2173BBA40.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/130000/FAF1B6C9-B2F7-E611-B480-0025902008CC.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/04CDB2FD-39F7-E611-B3F3-FA163E6EC443.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/22FE6F81-0FF6-E611-9C2E-A4BADB1E6F7A.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/30681DB3-F3F6-E611-B526-00259029E84C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/3E286C7E-11F6-E611-A2FE-5065F381B271.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/4C8782FF-C5F6-E611-8BA1-90B11CBCFF4E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/4E386B0F-16F6-E611-B132-0CC47AD98C86.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/56A07CF2-DDF6-E611-BD6C-0CC47AD98BF0.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/6A172731-FBF6-E611-B2C8-00266CFEFF04.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/7AE68A05-C6F6-E611-89CE-00259021A262.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/808E661D-16F6-E611-A84C-00259029ED1A.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/80E2F85E-11F6-E611-B955-0025905A608A.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/80F7F35F-0FF6-E611-96CC-7CD30ABD2EEA.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/8C794086-C2F6-E611-A56E-6C3BE5B5C0B0.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/8E06868D-40F7-E611-AB7A-0CC47A78A496.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/A6624B90-40F7-E611-B655-0025905B856C.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/AADD338E-C2F6-E611-A8C4-D8D385AF8902.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/B2E88FA8-4EF5-E611-80D6-0CC47A74525A.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/B895B581-14F6-E611-8D58-001E674FCA99.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/C414F171-1CF6-E611-9BAB-7845C4FC3A28.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/C44FA968-3BF7-E611-9468-02163E01A540.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/C8F1EE6A-EFF5-E611-8617-008CFA197480.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/CA590F63-1CF6-E611-9815-0CC47A4D76C6.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/D22F6CEF-22F6-E611-AA97-02163E01A2A4.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/F001B4FA-C5F6-E611-A821-0CC47A1E0DA6.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/F4F940C4-54F7-E611-8C2C-24BE05CEDCD1.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/F8C0AC45-38F7-E611-B145-0025905C3D6A.root',
+] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring() 
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/043CDA7F-4B5E-E711-8CEC-001E67792592.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/126BECF8-735E-E711-B3B4-14187763B811.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/169F6A88-6F5E-E711-B205-141877343E6D.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/18CD2A50-0D5E-E711-AD86-047D7B2E8578.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/1AF67B68-CE5D-E711-8586-FA163EB9735B.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/24457F6C-1D5E-E711-AEDC-A0369F8363EE.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/28D164CA-585E-E711-B037-0242AC110008.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/30BB2CF6-365E-E711-A2AD-0CC47A4C8EC8.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/3406B7C0-335E-E711-9479-002590E7DFFE.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/4C2909EC-0C5E-E711-ABEE-001517F80574.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/50EE02CC-375E-E711-8A86-02163E013029.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/52642D31-535E-E711-82E2-002590FD5E70.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/5CA1D8D7-B95E-E711-81C7-008CFAF554CE.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/60E05728-115E-E711-B1A3-001EC9ADC8BB.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/6CA25FBE-185E-E711-824B-02163E00B6B5.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/88123FEB-075E-E711-BBE4-008CFAFBF576.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/8ED483C1-475E-E711-85E9-0025905A6092.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/9233A76B-9F5D-E711-BAE7-002590D5FFF2.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/A211751A-7F5E-E711-8905-008CFA197D14.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/B2241DA5-2E5E-E711-9796-0CC47AC08C1A.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/B4AD9EDF-B95E-E711-8888-FA163EEE60C7.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/BE981177-7E5E-E711-BF41-00259074AE8A.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/C05CD193-185E-E711-9186-A0369F7F9350.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/CEBD6095-185E-E711-B4E3-BC305B390A32.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/DAFCA762-FF5D-E711-9897-24BE05C63791.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/E0322705-655E-E711-806F-0025907859B8.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/EC90A7AC-0F5E-E711-9AA8-00266CFE7C08.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/EE1C4D91-155E-E711-858E-00266CF32A34.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/F2DBD582-505E-E711-84D0-0025905C3E36.root',
+'/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/F80E0565-655E-E711-99BB-D067E5F91482.root' ] );
+
+
+secFiles.extend( [
+               ] )

--- a/Production/python/Summer16/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
+++ b/Production/python/Summer16/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+readFiles = cms.untracked.vstring()
+secFiles = cms.untracked.vstring()
+source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
+readFiles.extend( [
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/167DF5E6-6EF7-E611-9F32-0025905B8590.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/4A5582D2-A8F7-E611-BE2D-0CC47A4C8F08.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/68427A63-6FF7-E611-AD9B-0CC47A7C340E.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/76C43ADF-0CF7-E611-9EC2-002590D9D8B6.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/963350DE-13F7-E611-AFD5-0CC47A6C14C8.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/A203941B-50F9-E611-8BB8-0025905B8590.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/A86FBBD1-0CF7-E611-B124-1418773425EA.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/ACC2B676-F1F7-E611-8F13-FA163E2CE8FE.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/C042C756-0EF7-E611-94D8-008CFA111330.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/C09DB181-25F7-E611-B7B5-FA163E0EF12F.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/DCF98484-1CF8-E611-A70D-A0000420FE80.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/E63AFE68-6FF7-E611-97EF-0CC47A4D75F2.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/E6AA4801-BDF7-E611-833B-001E67505A2D.root',
+       '/store/mc/RunIISummer16MiniAODv2/SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/FA735DA4-28F7-E611-B985-ECF4BBE1CF30.root',
+] )

--- a/Production/test/condorSub/dict_t5qqqqzh.py
+++ b/Production/test/condorSub/dict_t5qqqqzh.py
@@ -1,0 +1,20 @@
+flist = {
+    "scenario": "Summer16sig",
+    "samples": [
+        ['Summer16.SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+        ['Summer16.SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8'],
+    ]
+}

--- a/WeightProducer/python/getWeightProducer_cff.py
+++ b/WeightProducer/python/getWeightProducer_cff.py
@@ -210,6 +210,21 @@ def getWeightProducer(fileName,fastsim=False, pmssm=False):
         MCSample("SMS-T2tt_mStop-300_mLSP-150_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 249.409, 400314),
         MCSample("SMS-T2tt_mStop-325_mLSP-150_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 249.409, 291078),
         MCSample("SMS-T2tt_mStop-650_mLSP-350_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.107045, 100070),
+        MCSample("SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.00163547, 51188),
+        MCSample("SMS-T5qqqqZH-mGluino750_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 2.26585, 4003007),
+        MCSample("SMS-T5qqqqZH-mGluino1000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.325388, 396239), 
+        MCSample("SMS-T5qqqqZH-mGluino1100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.163491, 413868),
+        MCSample("SMS-T5qqqqZH-mGluino1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.0856418, 400482),
+        MCSample("SMS-T5qqqqZH-mGluino1300_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.0460525, 408233),
+        MCSample("SMS-T5qqqqZH-mGluino1400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.0252977, 400887),
+        MCSample("SMS-T5qqqqZH-mGluino1500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.0141903, 394281),
+        MCSample("SMS-T5qqqqZH-mGluino1600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.00810078, 397668),
+        MCSample("SMS-T5qqqqZH-mGluino1700_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.00470323, 414063),
+        MCSample("SMS-T5qqqqZH-mGluino1800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.00276133, 389625),
+        MCSample("SMS-T5qqqqZH-mGluino1900_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.00163547, 404812),
+        MCSample("SMS-T5qqqqZH-mGluino2000_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.000981077, 417293),
+        MCSample("SMS-T5qqqqZH-mGluino2100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.000591918, 391445),
+        MCSample("SMS-T5qqqqZH-mGluino2200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8", "PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1", "RunIISummer16MiniAODv2", "Constant", 0.000359318, 396083)
     ]
     
     # loop over all samples until we find a match


### PR DESCRIPTION
add necessary items for T5qqqqZH sample for TreeMaker productions

1) add dict_t5qqqqzh.py
2) add SMS-T5qqqqZH-mGluino*_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
3) add SMS-T5qqqqWW_mGluino-1900_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_cff.py
4) add appropriate lines to getWeightProducer_cff.py
