### PR TITLE
avoid reclustering for zinv if not necessary

### DIFF
--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -259,8 +259,13 @@ def doZinvBkg(self,process):
     )
     
     # do the removal
+    # if putEmpty is set to true, this will output an empty collection if the "veto" collection is empty
+    # this avoids pointless reclustering of an identical candidate collection
+    # "clean" branches in the ntuple will not be filled in this case; (e.g. Jetsclean.size()==0)
+    # the corresponding non-clean branches should be used instead for those events
     process.cleanedCandidates =  cms.EDProducer("PackedCandPtrProjector",
-        src = cms.InputTag("packedPFCandidates"), veto = cms.InputTag("selectedXons")
+        src = cms.InputTag("packedPFCandidates"), veto = cms.InputTag("selectedXons"),
+        putEmpty = cms.bool(True)
     )
     
     # make reclustered jets


### PR DESCRIPTION
1. make the PFCandidate cleaner output an empty PFCandidate collection if it didn't actually clean anything
2. pass empty collection to VirtualJetProducer (it already has a pass-through behavior, where if it gets empty input, it just produces empty output without trying to run fastjet at all)
3. pass these empty collections through all the reco/PAT sequences
4. further pass the empty collections to TreeMaker modules that make output jet branches for the ntuples, to reduce file size: in practice, if Jetsclean is empty, you should use Jets instead

This way, we save both CPU usage and disk space for events that don't have leptons or photons. Tested CPU saving w/ igprof and disk saving w/ https://github.com/manuelfs/babymaker/blob/master/bmaker/genfiles/src/disk_usage.cxx (results will vary depending on the sample). Also validated the cleaned jet pT spectrum before and after this change.