### PR TITLE
update setup script to use branches from TreeMaker/cmssw

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,13 +20,11 @@ cd ${CMSSWVER}/src/
 # cmsenv
 eval `scramv1 runtime -sh`
 git cms-init
-git remote add btv-cmssw https://github.com/cms-btv-pog/cmssw.git
-git fetch btv-cmssw refs/tags/BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_8_0_21
-git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_8_0_21
-git cms-merge-topic -u kpedro88:MET_80X_FixEGdR
-git cms-merge-topic -u kpedro88:METRecipe_8030plus
-git cms-merge-topic -u kpedro88:storeJERFactor8030plus
-git cms-merge-topic -u pastika:AddJetAxis1
+git cms-merge-topic -u TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_8_0_21
+git cms-merge-topic -u TreeMaker:MET_80X_FixEGdR
+git cms-merge-topic -u TreeMaker:METRecipe_8030plus
+git cms-merge-topic -u TreeMaker:storeJERFactor8030plus
+git cms-merge-topic -u TreeMaker:AddJetAxis1
 git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_80X_V3
 git clone git@github.com:kpedro88/CondorProduction.git Condor/Production  
 git clone git@github.com:${FORK}/TreeMaker.git -b ${BRANCH}


### PR DESCRIPTION
To avoid situations where recipes break because external branches get deleted, I created a `cmssw` fork in the TreeMaker organization and copied all\* patch branches to it. The setup script is updated to use this fork exclusively, and this is expected to be maintained in the future.

\* This includes all branches used for installation recipes in previous tagged versions as well, though I haven't gone through to update those recipes. The exception is `cms-met:METCorUnc74X`, which was already deleted (though the orphaned commit can still be found on GitHub: https://github.com/cms-met/cmssw/commits/555a3445bc3b8ac239a17a9c38d8b0917daee128).