### PR TITLE
use fixed fork of JetToolbox

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ git cms-merge-topic -u TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from
 git cms-merge-topic -u TreeMaker:MET_942_FixEGdR
 git cms-merge-topic -u TreeMaker:storeJERFactor942
 git cms-merge-topic -u TreeMaker:AddJetAxis1_942
-git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_91X_v1
+git clone git@github.com:TreeMaker/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X
 git clone git@github.com:kpedro88/CondorProduction.git Condor/Production  
 git clone git@github.com:${FORK}/TreeMaker.git -b ${BRANCH}
 scram b -j 8


### PR DESCRIPTION
Fixes errors:
* `python encountered the error: <type ‘exceptions.ImportError’>
cannot import name hepTopTagPFJetsCHS`
* `Illegal parameter found in configuration.  The parameter is named: 'addTagInfos'`

NB, also updated CMSSW branch `TreeMaker:AddJetAxis1_942` to fix a bug. Now it actually runs (at least on a random Summer16 MC file I checked).

attn @fojensen @scarletnorberg @aperloff