### PR TITLE
CHS-->PUPPI and more b-tag updates

### DIFF
--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -6,7 +6,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
 
     # https://twiki.cern.ch/CMS/JetToolbox
     from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
-    listBTagInfos = ['pfInclusiveSecondaryVertexFinderTagInfos'] 
+    listBTagInfos = ['pfInclusiveSecondaryVertexFinderTagInfos','pfImpactParameterTagInfos'] 
     listBtagDiscriminatorsAK8 = [
          'pfBoostedDoubleSecondaryVertexAK8BJetTags',
     ]

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -8,8 +8,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
     listBTagInfos = ['pfInclusiveSecondaryVertexFinderTagInfos'] 
     listBtagDiscriminatorsAK8 = [
-        'pfCombinedInclusiveSecondaryVertexV2BJetTags',
-        'pfBoostedDoubleSecondaryVertexAK8BJetTags'
+         'pfBoostedDoubleSecondaryVertexAK8BJetTags',
     ]
     jecLevels = ['L1FastJet', 'L2Relative', 'L3Absolute']
     if self.residual: jecLevels.append("L2L3Residual")
@@ -17,7 +16,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         'ak8',
         'jetSequence',
         'out',
-        PUMethod = 'CHS',
+        PUMethod = 'Puppi',
         miniAOD = True,
         runOnMC = self.geninfo,
         postFix='Clean',
@@ -33,7 +32,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         JETCorrLevels = jecLevels,
         subJETCorrLevels = jecLevels,
     )
-    JetAK8CleanTag = cms.InputTag("packedPatJetsAK8PFCHSCleanSoftDrop")
+    JetAK8CleanTag = cms.InputTag("packedPatJetsAK8PFPuppiCleanSoftDrop")
     # temporary bug fix for jet toolbox (see https://github.com/cms-jet/JetToolbox/issues/51)
     if hasattr(process,'out'): del process.out
     if hasattr(process,'endpath'): del process.endpath
@@ -45,11 +44,11 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     )
 
     # update some userfloat names
-    process.JetPropertiesAK8Clean.prunedMass = cms.vstring('ak8PFJetsCHSCleanPrunedMass')
+    process.JetPropertiesAK8Clean.prunedMass = cms.vstring('ak8PFJetsPuppiCleanPrunedMass')
     process.JetPropertiesAK8Clean.softDropMass = cms.vstring('SoftDrop')
-    process.JetPropertiesAK8Clean.NsubjettinessTau1 = cms.vstring('NjettinessAK8CHSClean:tau1')
-    process.JetPropertiesAK8Clean.NsubjettinessTau2 = cms.vstring('NjettinessAK8CHSClean:tau2')
-    process.JetPropertiesAK8Clean.NsubjettinessTau3 = cms.vstring('NjettinessAK8CHSClean:tau3')
+    process.JetPropertiesAK8Clean.NsubjettinessTau1 = cms.vstring('NjettinessAK8PuppiClean:tau1')
+    process.JetPropertiesAK8Clean.NsubjettinessTau2 = cms.vstring('NjettinessAK8PuppiClean:tau2')
+    process.JetPropertiesAK8Clean.NsubjettinessTau3 = cms.vstring('NjettinessAK8PuppiClean:tau3')
     process.JetPropertiesAK8Clean.subjets = cms.vstring('SoftDrop')
 
     ### end AK8 detour

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -286,19 +286,11 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
         JetPropertiesAK8.NsubjettinessTau2 = cms.vstring('NjettinessAK8Puppi:tau2')
         JetPropertiesAK8.NsubjettinessTau3 = cms.vstring('NjettinessAK8Puppi:tau3')
         JetPropertiesAK8.bDiscriminatorCSV = cms.vstring('pfBoostedDoubleSecondaryVertexAK8BJetTags')
-        JetPropertiesAK8.bJetTagDeepCSVprobb = cms.vstring('pfDeepCSVJetTags:probb')
-        JetPropertiesAK8.bJetTagDeepCSVprobc = cms.vstring('pfDeepCSVJetTags:probc')
-        JetPropertiesAK8.bJetTagDeepCSVprobudsg = cms.vstring('pfDeepCSVJetTags:probudsg')
-        JetPropertiesAK8.bJetTagDeepCSVprobbb = cms.vstring('pfDeepCSVJetTags:probbb')
         JetPropertiesAK8.subjets = cms.vstring('SoftDropPuppi')
         self.VectorDouble.extend([
                              'JetProperties'+suff+':prunedMass(Jets'+suff+'_prunedMass)',
                              'JetProperties'+suff+':softDropMass(Jets'+suff+'_softDropMass)',
                              'JetProperties'+suff+':bDiscriminatorCSV(Jets'+suff+'_doubleBDiscriminator)',
-                             'JetProperties'+suff+':bJetTagDeepCSVprobb(Jets'+suff+'_bJetTagDeepCSVprobb)',
-                             'JetProperties'+suff+':bJetTagDeepCSVprobc(Jets'+suff+'_bJetTagDeepCSVprobc)',
-                             'JetProperties'+suff+':bJetTagDeepCSVprobudsg(Jets'+suff+'_bJetTagDeepCSVprobudsg)',
-                             'JetProperties'+suff+':bJetTagDeepCSVprobbb(Jets'+suff+'_bJetTagDeepCSVprobbb)',
                              'JetProperties'+suff+':NsubjettinessTau1(Jets'+suff+'_NsubjettinessTau1)',
                              'JetProperties'+suff+':NsubjettinessTau2(Jets'+suff+'_NsubjettinessTau2)',
                              'JetProperties'+suff+':NsubjettinessTau3(Jets'+suff+'_NsubjettinessTau3)'])


### PR DESCRIPTION
Switch the AK8 jets for the Zinv background from using CHS pileup removal to PUPPI pileup removal. Also remove unnecessary b-tag discrimination values.