### PR TITLE
New jet vars

### DIFF
--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -50,6 +50,9 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     process.JetPropertiesAK8Clean.NsubjettinessTau2 = cms.vstring('NjettinessAK8PuppiClean:tau2')
     process.JetPropertiesAK8Clean.NsubjettinessTau3 = cms.vstring('NjettinessAK8PuppiClean:tau3')
     process.JetPropertiesAK8Clean.subjets = cms.vstring('SoftDrop')
+    # temporarily disable ECFs
+    process.JetPropertiesAK8Clean.properties = cms.vstring([x for x in process.JetPropertiesAK8Clean.properties if "ecf" not in x])
+    self.VectorDouble.setValue([x for x in self.VectorDouble if "JetPropertiesAK8Clean:ecf" not in x])
 
     ### end AK8 detour
 

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -1,35 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from TreeMaker.TreeMaker.addJetInfo import addJetInfo
 
-def makeMHTVars(self, process, JetTag, HTJetsTag, storeProperties, suff, MHTsuff):
-    from TreeMaker.Utils.subJetSelection_cfi import SubJetSelection
-    MHTJets = SubJetSelection.clone(
-        JetTag = JetTag,
-        MinPt  = cms.double(30),
-        MaxEta = cms.double(5.0),
-    )
-    setattr(process,"MHTJets"+MHTsuff+suff,MHTJets)
-    if storeProperties>0: self.VectorBool.extend(['MHTJets'+MHTsuff+suff+':SubJetMask(Jets'+suff+'_MHT'+MHTsuff+'Mask)'])
-    MHTJetsTag = cms.InputTag("MHTJets"+MHTsuff+suff)
-    
-    from TreeMaker.Utils.mhtdouble_cfi import mhtdouble
-    MHT = mhtdouble.clone(
-        JetTag  = MHTJetsTag,
-    )
-    setattr(process,"MHT"+MHTsuff+suff,MHT)
-    self.VarsDouble.extend(['MHT'+MHTsuff+suff+':Pt(MHT'+MHTsuff+suff+')','MHT'+MHTsuff+suff+':Phi(MHTPhi'+MHTsuff+suff+')'])
-    
-    from TreeMaker.Utils.deltaphidouble_cfi import deltaphidouble
-    DeltaPhi = deltaphidouble.clone(
-        DeltaPhiJets = HTJetsTag,
-        MHTPhi       = cms.InputTag('MHT'+MHTsuff+suff+':Phi'),
-    )
-    setattr(process,"DeltaPhi"+MHTsuff+suff,DeltaPhi)
-    self.VarsDouble.extend(['DeltaPhi'+MHTsuff+suff+':DeltaPhi1(DeltaPhi1'+MHTsuff+suff+')','DeltaPhi'+MHTsuff+suff+':DeltaPhi2(DeltaPhi2'+MHTsuff+suff+')',
-                                          'DeltaPhi'+MHTsuff+suff+':DeltaPhi3(DeltaPhi3'+MHTsuff+suff+')','DeltaPhi'+MHTsuff+suff+':DeltaPhi4(DeltaPhi4'+MHTsuff+suff+')'])
-    
-    return process
-
 def makeGoodJets(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInputTag(), jetConeSize=0.4):
     from TreeMaker.TreeMaker.TMEras import TMeras
     from TreeMaker.Utils.goodjetsproducer_cfi import GoodJetsProducer
@@ -135,8 +106,30 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, Skip
     ## ----------------------------------------------------------------------------------------------
     ## MHT, DeltaPhi
     ## ----------------------------------------------------------------------------------------------
-    # MHT, DeltaPhi moved to separate fn (above)
-    process = self.makeMHTVars(process, GoodJetsTag, HTJetsTag, storeProperties, suff, "")
+    MHTJets = SubJetSelection.clone(
+        JetTag = JetTag,
+        MinPt  = cms.double(30),
+        MaxEta = cms.double(5.0),
+    )
+    setattr(process,"MHTJets"+suff,MHTJets)
+    if storeProperties>0: self.VectorBool.extend(['MHTJets'+suff+':SubJetMask(Jets'+suff+'_MHT'+'Mask)'])
+    MHTJetsTag = cms.InputTag("MHTJets"+suff)
+    
+    from TreeMaker.Utils.mhtdouble_cfi import mhtdouble
+    MHT = mhtdouble.clone(
+        JetTag  = MHTJetsTag,
+    )
+    setattr(process,"MHT"+suff,MHT)
+    self.VarsDouble.extend(['MHT'+suff+':Pt(MHT'+suff+')','MHT'+suff+':Phi(MHTPhi'+suff+')'])
+    
+    from TreeMaker.Utils.deltaphidouble_cfi import deltaphidouble
+    DeltaPhi = deltaphidouble.clone(
+        DeltaPhiJets = HTJetsTag,
+        MHTPhi       = cms.InputTag('MHT'+suff+':Phi'),
+    )
+    setattr(process,"DeltaPhi"+suff,DeltaPhi)
+    self.VarsDouble.extend(['DeltaPhi'+suff+':DeltaPhi1(DeltaPhi1'+suff+')','DeltaPhi'+suff+':DeltaPhi2(DeltaPhi2'+suff+')',
+                                          'DeltaPhi'+suff+':DeltaPhi3(DeltaPhi3'+suff+')','DeltaPhi'+suff+':DeltaPhi4(DeltaPhi4'+suff+')'])
 
     ## ----------------------------------------------------------------------------------------------
     ## ISR jets

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -248,6 +248,7 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
             'BasicSubstructure'+suff+':ptD',
             'BasicSubstructure'+suff+':axismajor',
             'BasicSubstructure'+suff+':axisminor',
+            'BasicSubstructure'+suff+':ptdrlog',
         ]
         ak8ints = [
             'BasicSubstructure'+suff+':multiplicity',
@@ -309,6 +310,7 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
                 'axismajor',
                 'axisminor',
                 'multiplicity',
+                'ptdrlog',
 #                'constituents',
             ])
             JetPropertiesAK8.overflow = cms.vstring('BasicSubstructure'+suff+':overflow')
@@ -318,6 +320,7 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
             JetPropertiesAK8.axismajor = cms.vstring('BasicSubstructure'+suff+':axismajor')
             JetPropertiesAK8.axisminor = cms.vstring('BasicSubstructure'+suff+':axisminor')
             JetPropertiesAK8.multiplicity = cms.vstring('BasicSubstructure'+suff+':multiplicity')
+            JetPropertiesAK8.ptdrlog = cms.vstring('BasicSubstructure'+suff+':ptdrlog')
             self.VectorDouble.extend([
                 'JetProperties'+suff+':overflow(Jets'+suff+'_overflow)',
                 'JetProperties'+suff+':girth(Jets'+suff+'_girth)',
@@ -325,6 +328,7 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
                 'JetProperties'+suff+':ptD(Jets'+suff+'_ptD)',
                 'JetProperties'+suff+':axismajor(Jets'+suff+'_axismajor)',
                 'JetProperties'+suff+':axisminor(Jets'+suff+'_axisminor)',
+                'JetProperties'+suff+':ptdrlog(Jets'+suff+'_ptdrlog)',
             ])
             self.VectorInt.extend([
                 'JetProperties'+suff+':multiplicity(Jets'+suff+'_multiplicity)',

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -287,6 +287,10 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
                 "NsubjettinessTau1"     ,
                 "NsubjettinessTau2"     ,
                 "NsubjettinessTau3"     ,
+                "ecfN2b1"               ,
+                "ecfN2b2"               ,
+                "ecfN3b1"               ,
+                "ecfN3b2"               ,
                 "bDiscriminatorCSV"     ,
                 "bJetTagDeepCSVprobb"   ,
                 "bJetTagDeepCSVprobc"   ,
@@ -303,6 +307,10 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
         JetPropertiesAK8.NsubjettinessTau1 = cms.vstring('NjettinessAK8Puppi:tau1')
         JetPropertiesAK8.NsubjettinessTau2 = cms.vstring('NjettinessAK8Puppi:tau2')
         JetPropertiesAK8.NsubjettinessTau3 = cms.vstring('NjettinessAK8Puppi:tau3')
+        JetPropertiesAK8.ecfN2b1 = cms.vstring('ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN2')
+        JetPropertiesAK8.ecfN2b2 = cms.vstring('ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN2')
+        JetPropertiesAK8.ecfN3b1 = cms.vstring('ak8PFJetsPuppiSoftDropValueMap:nb1AK8PuppiSoftDropN3')
+        JetPropertiesAK8.ecfN3b2 = cms.vstring('ak8PFJetsPuppiSoftDropValueMap:nb2AK8PuppiSoftDropN3')
         JetPropertiesAK8.bDiscriminatorCSV = cms.vstring('pfBoostedDoubleSecondaryVertexAK8BJetTags')
         JetPropertiesAK8.subjets = cms.vstring('SoftDropPuppi')
         self.VectorDouble.extend([
@@ -311,7 +319,11 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
             'JetProperties'+suff+':bDiscriminatorCSV(Jets'+suff+'_doubleBDiscriminator)',
             'JetProperties'+suff+':NsubjettinessTau1(Jets'+suff+'_NsubjettinessTau1)',
             'JetProperties'+suff+':NsubjettinessTau2(Jets'+suff+'_NsubjettinessTau2)',
-            'JetProperties'+suff+':NsubjettinessTau3(Jets'+suff+'_NsubjettinessTau3)'
+            'JetProperties'+suff+':NsubjettinessTau3(Jets'+suff+'_NsubjettinessTau3)',
+            'JetProperties'+suff+':ecfN2b1(Jets'+suff+'_ecfN2b1)',
+            'JetProperties'+suff+':ecfN2b2(Jets'+suff+'_ecfN2b2)',
+            'JetProperties'+suff+':ecfN3b1(Jets'+suff+'_ecfN3b1)',
+            'JetProperties'+suff+':ecfN3b2(Jets'+suff+'_ecfN3b2)',
         ])
         self.VectorInt.extend([
             'JetProperties'+suff+':NumBhadrons(Jets'+suff+'_NumBhadrons)',

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -306,14 +306,17 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
         JetPropertiesAK8.bDiscriminatorCSV = cms.vstring('pfBoostedDoubleSecondaryVertexAK8BJetTags')
         JetPropertiesAK8.subjets = cms.vstring('SoftDropPuppi')
         self.VectorDouble.extend([
-                             'JetProperties'+suff+':prunedMass(Jets'+suff+'_prunedMass)',
-                             'JetProperties'+suff+':softDropMass(Jets'+suff+'_softDropMass)',
-                             'JetProperties'+suff+':bDiscriminatorCSV(Jets'+suff+'_doubleBDiscriminator)',
-                             'JetProperties'+suff+':NsubjettinessTau1(Jets'+suff+'_NsubjettinessTau1)',
-                             'JetProperties'+suff+':NsubjettinessTau2(Jets'+suff+'_NsubjettinessTau2)',
-                             'JetProperties'+suff+':NsubjettinessTau3(Jets'+suff+'_NsubjettinessTau3)'])
-        self.VectorInt.extend(['JetProperties'+suff+':NumBhadrons(Jets'+suff+'_NumBhadrons)',
-                          'JetProperties'+suff+':NumChadrons(Jets'+suff+'_NumChadrons)'])
+            'JetProperties'+suff+':prunedMass(Jets'+suff+'_prunedMass)',
+            'JetProperties'+suff+':softDropMass(Jets'+suff+'_softDropMass)',
+            'JetProperties'+suff+':bDiscriminatorCSV(Jets'+suff+'_doubleBDiscriminator)',
+            'JetProperties'+suff+':NsubjettinessTau1(Jets'+suff+'_NsubjettinessTau1)',
+            'JetProperties'+suff+':NsubjettinessTau2(Jets'+suff+'_NsubjettinessTau2)',
+            'JetProperties'+suff+':NsubjettinessTau3(Jets'+suff+'_NsubjettinessTau3)'
+        ])
+        self.VectorInt.extend([
+            'JetProperties'+suff+':NumBhadrons(Jets'+suff+'_NumBhadrons)',
+            'JetProperties'+suff+':NumChadrons(Jets'+suff+'_NumChadrons)'
+        ])
         self.VectorVectorTLorentzVector.extend([
             'JetProperties'+suff+':subjets(Jets'+suff+'_subjets)',
         ])

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -131,6 +131,13 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, Skip
     self.VarsDouble.extend(['DeltaPhi'+suff+':DeltaPhi1(DeltaPhi1'+suff+')','DeltaPhi'+suff+':DeltaPhi2(DeltaPhi2'+suff+')',
                                           'DeltaPhi'+suff+':DeltaPhi3(DeltaPhi3'+suff+')','DeltaPhi'+suff+':DeltaPhi4(DeltaPhi4'+suff+')'])
 
+    # extra HT version using MHT collection w/ |eta| < 5, to filter forward beam halo events
+    HT5 = htdouble.clone(
+        JetTag = MHTJetsTag,
+    )
+    setattr(process,"HT5"+suff,HT5)
+    self.VarsDouble.extend(['HT5'+suff])
+
     ## ----------------------------------------------------------------------------------------------
     ## ISR jets
     ## ----------------------------------------------------------------------------------------------

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -237,6 +237,19 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, Skip
 def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
     # get more substructure
     if self.semivisible:
+        from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+        NjettinessBeta1 = Njettiness.clone(
+            src = JetTag,
+            cone = cms.double(0.8),
+            storeAxes = cms.bool(True),
+            Njets = cms.vuint32(1),
+            beta = cms.double(1.0)
+        )
+        setattr(process,"NjettinessBeta1"+suff,NjettinessBeta1)
+        NjettinessBeta2 = NjettinessBeta1.clone(
+            beta = cms.double(2.0)
+        )
+        setattr(process,"NjettinessBeta2"+suff,NjettinessBeta2)
         BasicSubstructure = cms.EDProducer("BasicSubstructureProducer",
             JetTag = JetTag
         )
@@ -249,6 +262,10 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
             'BasicSubstructure'+suff+':axismajor',
             'BasicSubstructure'+suff+':axisminor',
             'BasicSubstructure'+suff+':ptdrlog',
+            'NjettinessBeta1'+suff+':tau1etaAxis1',
+            'NjettinessBeta1'+suff+':tau1phiAxis1',
+            'NjettinessBeta2'+suff+':tau1etaAxis1',
+            'NjettinessBeta2'+suff+':tau1phiAxis1',
         ]
         ak8ints = [
             'BasicSubstructure'+suff+':multiplicity',
@@ -311,6 +328,7 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
                 'axisminor',
                 'multiplicity',
                 'ptdrlog',
+                'lean',
 #                'constituents',
             ])
             JetPropertiesAK8.overflow = cms.vstring('BasicSubstructure'+suff+':overflow')
@@ -321,6 +339,12 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
             JetPropertiesAK8.axisminor = cms.vstring('BasicSubstructure'+suff+':axisminor')
             JetPropertiesAK8.multiplicity = cms.vstring('BasicSubstructure'+suff+':multiplicity')
             JetPropertiesAK8.ptdrlog = cms.vstring('BasicSubstructure'+suff+':ptdrlog')
+            JetPropertiesAK8.lean = cms.vstring(
+                'NjettinessBeta1'+suff+':tau1etaAxis1',
+                'NjettinessBeta1'+suff+':tau1phiAxis1',
+                'NjettinessBeta2'+suff+':tau1etaAxis1',
+                'NjettinessBeta2'+suff+':tau1phiAxis1',
+            )
             self.VectorDouble.extend([
                 'JetProperties'+suff+':overflow(Jets'+suff+'_overflow)',
                 'JetProperties'+suff+':girth(Jets'+suff+'_girth)',
@@ -329,6 +353,7 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
                 'JetProperties'+suff+':axismajor(Jets'+suff+'_axismajor)',
                 'JetProperties'+suff+':axisminor(Jets'+suff+'_axisminor)',
                 'JetProperties'+suff+':ptdrlog(Jets'+suff+'_ptdrlog)',
+                'JetProperties'+suff+':lean(Jets'+suff+'_lean)',
             ])
             self.VectorInt.extend([
                 'JetProperties'+suff+':multiplicity(Jets'+suff+'_multiplicity)',

--- a/TreeMaker/python/makeTree.py
+++ b/TreeMaker/python/makeTree.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # import functions to be assigned as class methods
 from TreeMaker.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD
-from TreeMaker.TreeMaker.makeJetVars import makeJetVars, makeMHTVars, makeGoodJets, makeJetVarsAK8
+from TreeMaker.TreeMaker.makeJetVars import makeJetVars, makeGoodJets, makeJetVarsAK8
 from TreeMaker.TreeMaker.doHadTauBkg import doHadTauBkg, makeJetVarsHadTau
 from TreeMaker.TreeMaker.doLostLeptonBkg import doLostLeptonBkg
 from TreeMaker.TreeMaker.doZinvBkg import doZinvBkg, reclusterZinv
@@ -130,7 +130,6 @@ class makeTree:
     makeGoodJets = makeGoodJets
     makeJetVars = makeJetVars
     makeJetVarsAK8 = makeJetVarsAK8
-    makeMHTVars = makeMHTVars
     doHadTauBkg = doHadTauBkg
     makeJetVarsHadTau = makeJetVarsHadTau
     doLostLeptonBkg = doLostLeptonBkg

--- a/Utils/src/BasicSubstructureProducer.cc
+++ b/Utils/src/BasicSubstructureProducer.cc
@@ -44,6 +44,7 @@ BasicSubstructureProducer::BasicSubstructureProducer(const edm::ParameterSet& iC
 	produces<edm::ValueMap<float>>("ptD");
 	produces<edm::ValueMap<float>>("axismajor");
 	produces<edm::ValueMap<float>>("axisminor");
+	produces<edm::ValueMap<float>>("ptdrlog");
 }
 
 template <class T>
@@ -62,7 +63,7 @@ void BasicSubstructureProducer::produce(edm::StreamID, edm::Event& iEvent, const
 	edm::Handle<edm::View<pat::Jet>> h_jets;
 	iEvent.getByToken(JetTok_, h_jets);
 
-	std::vector<float> overflow, girth, momenthalf, ptD, axismajor, axisminor;
+	std::vector<float> overflow, girth, momenthalf, ptD, axismajor, axisminor, ptdrlog;
 	std::vector<int> multiplicity;
 
 	for(const auto& i_jet : *(h_jets.product())){
@@ -70,6 +71,7 @@ void BasicSubstructureProducer::produce(edm::StreamID, edm::Event& iEvent, const
 		//calculate jet "overflow": 1 - (scalar sum of pT w/ dR<0.4 over scalar sum of pT w/ dR<0.8)
 		float i_numer = 0.0, i_denom = 0.0;
 		float i_girth = 0.0, i_momenthalf = 0.0;
+		float i_ptdrlog = 0.0;
 		float sumPt = 0.0, sumPt2 = 0.0;
 		float sumDeta = 0.0, sumDphi = 0.0, sumDeta2 = 0.0, sumDphi2 = 0.0, sumDetaDphi = 0.0;
 
@@ -86,6 +88,9 @@ void BasicSubstructureProducer::produce(edm::StreamID, edm::Event& iEvent, const
 				float pT = i_part->pt();
 				if(dR < 0.8) i_denom += pT;
 				if(dR < 0.4) i_numer += pT;
+
+				//ptdrlog
+				i_ptdrlog += std::log(pT/dR);
 
 				//moment calcs
 				i_girth += pT*dR;
@@ -137,6 +142,7 @@ void BasicSubstructureProducer::produce(edm::StreamID, edm::Event& iEvent, const
 		ptD.push_back(i_ptD);
 		axismajor.push_back(i_axis1);
 		axisminor.push_back(i_axis2);
+		ptdrlog.push_back(i_ptdrlog);
 	}
 
 	//make userfloat maps
@@ -147,6 +153,7 @@ void BasicSubstructureProducer::produce(edm::StreamID, edm::Event& iEvent, const
 	helpProduce(iEvent,h_jets,ptD,"ptD");
 	helpProduce(iEvent,h_jets,axismajor,"axismajor");
 	helpProduce(iEvent,h_jets,axisminor,"axisminor");
+	helpProduce(iEvent,h_jets,ptdrlog,"ptdrlog");
 }
 
 DEFINE_FWK_MODULE(BasicSubstructureProducer);

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -97,6 +97,7 @@ DEFAULT_NAMED_PTR(D,NsubjettinessTau3);
 DEFAULT_NAMED_PTR(D,overflow);
 DEFAULT_NAMED_PTR(D,girth);
 DEFAULT_NAMED_PTR(D,momenthalf);
+DEFAULT_NAMED_PTR(D,ptdrlog);
 
 class NamedPtr_I : public NamedPtr<int> {
 	public:

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -24,6 +24,7 @@
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 
 #include "TLorentzVector.h"
 
@@ -238,6 +239,25 @@ class NamedPtr_softDropMass : public NamedPtr<double> {
 		}
 };
 DEFINE_NAMED_PTR(softDropMass);
+
+//deltaR of axes for tau1_beta1, tau1_beta2
+class NamedPtr_lean : public NamedPtr<double> {
+	public:
+		using NamedPtr<double>::NamedPtr;
+		virtual void get_property(const pat::Jet* Jet) {
+			if(extraInfo.size()==4){
+				//eta,phi,eta,phi
+				double eta1 = Jet->userFloat(extraInfo.at(0));
+				double phi1 = Jet->userFloat(extraInfo.at(1));
+				double eta2 = Jet->userFloat(extraInfo.at(2));
+				double phi2 = Jet->userFloat(extraInfo.at(3));
+				double dphi = reco::deltaPhi(phi1,phi2);
+				push_back(std::sqrt(std::pow(eta1-eta2,2)+std::pow(dphi,2)));
+			}
+			else push_back(-10);
+		}
+};
+DEFINE_NAMED_PTR(lean);
 
 //----------------------------------------------------------------------------------------------------------------------------------------
 //ints

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -99,6 +99,10 @@ DEFAULT_NAMED_PTR(D,overflow);
 DEFAULT_NAMED_PTR(D,girth);
 DEFAULT_NAMED_PTR(D,momenthalf);
 DEFAULT_NAMED_PTR(D,ptdrlog);
+DEFAULT_NAMED_PTR(D,ecfN2b1);
+DEFAULT_NAMED_PTR(D,ecfN2b2);
+DEFAULT_NAMED_PTR(D,ecfN3b1);
+DEFAULT_NAMED_PTR(D,ecfN3b2);
 
 class NamedPtr_I : public NamedPtr<int> {
 	public:

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,7 @@ git cms-merge-topic -u TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from
 git cms-merge-topic -u TreeMaker:MET_942_FixEGdR
 git cms-merge-topic -u TreeMaker:storeJERFactor942
 git cms-merge-topic -u TreeMaker:AddJetAxis1_942
+git cms-merge-topic -u TreeMaker:NjettinessAxis_942
 git clone git@github.com:TreeMaker/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X
 git clone git@github.com:kpedro88/CondorProduction.git Condor/Production  
 git clone git@github.com:${FORK}/TreeMaker.git -b ${BRANCH}


### PR DESCRIPTION
for AK8 jets:
* pt_dr_log (new QG tagging variable, see https://github.com/amarini/cmssw/commit/450abc7c5cc5c0973bda94afe77bd78ebf6cdf2e#diff-231f25362bfe19408f30b511a856573eR215)
* jet lean (see https://arxiv.org/abs/1412.7540)
  * required modification to `NjettinessAdder` to store axis info, added to `setup.sh`
* energy correlation functions (included in new miniAOD by default)
  * disabled for Zinv clean jets since jet toolbox appears out of date wrt https://github.com/cms-sw/cmssw/blob/CMSSW_9_4_X/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py

event-level:
* HT calculated from all jets w/ |eta| < 5 (had been computed offline in previous rounds, used for forward beam halo filter)

also did some cleanup in `makeJetVars`