### PR TITLE
Code checks

### DIFF
--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -46,13 +46,13 @@ class TreeObjectBase;
 class TreeMaker : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 	public:
 		explicit TreeMaker(const edm::ParameterSet&);
-		~TreeMaker();
+		~TreeMaker() override;
 		static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 	private:
-		virtual void beginJob() override;
-		virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-		virtual void endJob() override;
+		void beginJob() override;
+		void analyze(const edm::Event&, const edm::EventSetup&) override;
+		void endJob() override;
 		// ----------member data ---------------------------
 		edm::Service<TFileService> fs;
 		string treeName;
@@ -62,9 +62,9 @@ class TreeMaker : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 		vector<TreeTypes> VarTypes;
 		map<string,unsigned> nameCache;
 		// general event information
-		UInt_t runNum;
-		UInt_t lumiBlockNum;
-		ULong64_t evtNum;
+		UInt_t runNum{};
+		UInt_t lumiBlockNum{};
+		ULong64_t evtNum{};
 		vector<TreeObjectBase*> variables;
 };
 
@@ -73,7 +73,7 @@ class TreeObjectBase {
 	public:
 		//constructor
 		TreeObjectBase() : tempFull(""), branchType("") {}
-		TreeObjectBase(string tempFull_) : tempFull(tempFull_), nameInTree(tempFull_), tagName(tempFull_), tree(NULL) {}
+		TreeObjectBase(string tempFull_) : tempFull(tempFull_), nameInTree(tempFull_), tagName(tempFull_), tree(nullptr) {}
 		//destructor
 		virtual ~TreeObjectBase() {}
 		//functions
@@ -104,7 +104,7 @@ class TreeObjectBase {
 	protected:
 		//member variables
 		string tempFull, nameInTree, tagName, branchType;
-		TTree* tree;
+		TTree* tree{};
 		edm::InputTag tag;
 };
 
@@ -129,9 +129,9 @@ class TreeObject : public TreeObjectBase {
 		TreeObject() : TreeObjectBase() {}
 		TreeObject(string tempFull_) : TreeObjectBase(tempFull_) {}
 		//destructor
-		virtual ~TreeObject() {}
+		~TreeObject() override {}
 		//functions
-		virtual void Initialize(map<string,unsigned>& nameCache, edm::ConsumesCollector && iC, stringstream& message) {
+		void Initialize(map<string,unsigned>& nameCache, edm::ConsumesCollector && iC, stringstream& message) override {
 			//case 1: x      -> tag = x,   name = x
 			//case 2: x:y    -> tag = x:y, name = y
 			//case 3: x(y)   -> tag = x,   name = y
@@ -165,7 +165,7 @@ class TreeObject : public TreeObjectBase {
 		virtual void SetConsumes(edm::ConsumesCollector && iC){
 			tok = iC.consumes<T>(tag);
 		}
-		virtual void FillTree(const edm::Event& iEvent){
+		void FillTree(const edm::Event& iEvent) override{
 			SetDefault();
 			edm::Handle<T> var;
 			iEvent.getByToken(tok,var);
@@ -177,8 +177,8 @@ class TreeObject : public TreeObjectBase {
 			}
 		}
 		//these will be implemented below for specializations
-		virtual void AddBranch() {}
-		virtual void SetDefault() {}
+		void AddBranch() override {}
+		void SetDefault() override {}
 		
 	protected:
 		//member variables
@@ -242,13 +242,13 @@ class TreeRecoCand : public TreeObject<vector<TLorentzVector> > {
 		TreeRecoCand() : TreeObject<vector<TLorentzVector> >() {}
 		TreeRecoCand(string tempFull_, bool doLorentz_=true) : TreeObject<vector<TLorentzVector> >(tempFull_), doLorentz(doLorentz_) {}
 		//destructor
-		virtual ~TreeRecoCand() {}
+		~TreeRecoCand() override {}
 		
 		//functions
-		virtual void SetConsumes(edm::ConsumesCollector && iC){
+		void SetConsumes(edm::ConsumesCollector && iC) override{
 			candTok = iC.consumes<edm::View<reco::Candidate>>(tag);
 		}
-		virtual void FillTree(const edm::Event& iEvent){
+		void FillTree(const edm::Event& iEvent) override{
 			SetDefault();
 			edm::Handle< edm::View<reco::Candidate> > cands;
 			iEvent.getByToken(candTok,cands);
@@ -276,7 +276,7 @@ class TreeRecoCand : public TreeObject<vector<TLorentzVector> > {
 				edm::LogWarning("TreeMaker") << "WARNING ... " << tagName << " is NOT valid?!";
 			}
 		}
-		virtual void AddBranch() {
+		void AddBranch() override {
 			if(tree){
 				if(doLorentz){
 					tree->Branch(nameInTree.c_str(),"vector<TLorentzVector>",&value,32000,0);
@@ -289,7 +289,7 @@ class TreeRecoCand : public TreeObject<vector<TLorentzVector> > {
 				}
 			}
 		}
-		virtual void SetDefault() {
+		void SetDefault() override {
 			if(doLorentz){
 				value.clear();
 			}
@@ -304,6 +304,6 @@ class TreeRecoCand : public TreeObject<vector<TLorentzVector> > {
 	protected:
 		//member variables
 		edm::EDGetTokenT<edm::View<reco::Candidate>> candTok;
-		bool doLorentz;
+		bool doLorentz{};
 		vector<double> pt, eta, phi, energy;
 };

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -45,7 +45,7 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig)
 	for(unsigned v = 0; v < VarTypeNames.size(); ++v){
 		vector<string> VarNames = iConfig.getParameter< vector<string> >(VarTypeNames.at(v));
 		message << VarTypeNames.at(v) << ":" << "\n";
-		for(auto & VarName : VarNames){
+		for(const auto & VarName : VarNames){
 			//check for an exact repeat of an existing name
 			if(nameSet.find(VarName)!=nameSet.end()){
 				skipMessage << VarName << "\n";

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -28,7 +28,7 @@ using namespace pat;
 // constructors and destructor
 //
 TreeMaker::TreeMaker(const edm::ParameterSet& iConfig)
-: tree(0),
+: tree(nullptr),
   VarTypeNames{"VarsBool","VarsInt","VarsDouble","VarsString","VarsTLorentzVector","VectorBool","VectorInt","VectorDouble","VectorString","VectorTLorentzVector","VectorVectorTLorentzVector","VectorRecoCand"},
   VarTypes{t_bool,t_int,t_double,t_string,t_lorentz,t_vbool,t_vint,t_vdouble,t_vstring,t_vlorentz,t_vvlorentz,t_recocand}
 {
@@ -45,28 +45,28 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig)
 	for(unsigned v = 0; v < VarTypeNames.size(); ++v){
 		vector<string> VarNames = iConfig.getParameter< vector<string> >(VarTypeNames.at(v));
 		message << VarTypeNames.at(v) << ":" << "\n";
-		for(unsigned t = 0; t < VarNames.size(); ++t){
+		for(auto & VarName : VarNames){
 			//check for an exact repeat of an existing name
-			if(nameSet.find(VarNames[t])!=nameSet.end()){
-				skipMessage << VarNames[t] << "\n";
+			if(nameSet.find(VarName)!=nameSet.end()){
+				skipMessage << VarName << "\n";
 				continue;
 			}
-			else nameSet.emplace(VarNames[t]);
+			else nameSet.emplace(VarName);
 			//check for the right type
-			TreeObjectBase* tmp = NULL;
+			TreeObjectBase* tmp = nullptr;
 			switch(VarTypes[v]){
-				case TreeTypes::t_bool     : tmp = new TreeObject<bool>(VarNames[t]); break;
-				case TreeTypes::t_int      : tmp = new TreeObject<int>(VarNames[t]); break;
-				case TreeTypes::t_double   : tmp = new TreeObject<double>(VarNames[t]); break;
-				case TreeTypes::t_string   : tmp = new TreeObject<string>(VarNames[t]); break;
-				case TreeTypes::t_lorentz  : tmp = new TreeObject<TLorentzVector>(VarNames[t]); break;
-				case TreeTypes::t_vbool    : tmp = new TreeObject<vector<bool> >(VarNames[t]); break;
-				case TreeTypes::t_vint     : tmp = new TreeObject<vector<int> >(VarNames[t]); break;
-				case TreeTypes::t_vdouble  : tmp = new TreeObject<vector<double> >(VarNames[t]); break;
-				case TreeTypes::t_vstring  : tmp = new TreeObject<vector<string> >(VarNames[t]); break;
-				case TreeTypes::t_vlorentz : tmp = new TreeObject<vector<TLorentzVector> >(VarNames[t]); break;
-				case TreeTypes::t_vvlorentz: tmp = new TreeObject<vector<vector<TLorentzVector>>>(VarNames[t]); break;
-				case TreeTypes::t_recocand : tmp = new TreeRecoCand(VarNames[t],doLorentz); break;
+				case TreeTypes::t_bool     : tmp = new TreeObject<bool>(VarName); break;
+				case TreeTypes::t_int      : tmp = new TreeObject<int>(VarName); break;
+				case TreeTypes::t_double   : tmp = new TreeObject<double>(VarName); break;
+				case TreeTypes::t_string   : tmp = new TreeObject<string>(VarName); break;
+				case TreeTypes::t_lorentz  : tmp = new TreeObject<TLorentzVector>(VarName); break;
+				case TreeTypes::t_vbool    : tmp = new TreeObject<vector<bool> >(VarName); break;
+				case TreeTypes::t_vint     : tmp = new TreeObject<vector<int> >(VarName); break;
+				case TreeTypes::t_vdouble  : tmp = new TreeObject<vector<double> >(VarName); break;
+				case TreeTypes::t_vstring  : tmp = new TreeObject<vector<string> >(VarName); break;
+				case TreeTypes::t_vlorentz : tmp = new TreeObject<vector<TLorentzVector> >(VarName); break;
+				case TreeTypes::t_vvlorentz: tmp = new TreeObject<vector<vector<TLorentzVector>>>(VarName); break;
+				case TreeTypes::t_recocand : tmp = new TreeRecoCand(VarName,doLorentz); break;
 			}
 			//if a known type was found, initialize and store the object
 			if(tmp) {
@@ -96,14 +96,14 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	evtNum = 0;
 
 	// Event information
-	edm::EventAuxiliary aux = iEvent.eventAuxiliary();
+	const edm::EventAuxiliary& aux = iEvent.eventAuxiliary();
 	runNum       = aux.run();
 	lumiBlockNum = aux.luminosityBlock();
 	evtNum       = aux.event();
 	
 	// get all variable values
-	for(unsigned t = 0; t < variables.size(); ++t){
-		variables[t]->FillTree(iEvent);
+	for(auto & variable : variables){
+		variable->FillTree(iEvent);
 	}
 	
 	tree->Fill();
@@ -127,9 +127,9 @@ TreeMaker::beginJob()
 	if(sortBranches) sort(variables.begin(),variables.end(),TreeObjectComp());
 	
 	//add branches to tree
-	for(unsigned t = 0; t < variables.size(); ++t){
-		variables[t]->SetTree(tree);
-		variables[t]->AddBranch();
+	for(auto & variable : variables){
+		variable->SetTree(tree);
+		variable->AddBranch();
 	}
 }
 
@@ -137,8 +137,8 @@ TreeMaker::beginJob()
 void 
 TreeMaker::endJob() {
 	//memory management
-	for(unsigned t = 0; t < variables.size(); ++t){
-		delete (variables[t]);
+	for(auto & variable : variables){
+		delete variable;
 	}
 	variables.clear();
 

--- a/Utils/interface/mht.h
+++ b/Utils/interface/mht.h
@@ -8,8 +8,8 @@ namespace utils {
 	//for MHT calculation
 	inline reco::MET::LorentzVector calculateMHT(const edm::View<reco::Candidate>* Jets){
 		reco::MET::LorentzVector mhtLorentz(0,0,0,0);
-		for(unsigned i = 0; i < Jets->size(); ++i){
-			mhtLorentz -= Jets->at(i).p4();
+		for(const auto & Jet : *Jets){
+			mhtLorentz -= Jet.p4();
 		}
 		return mhtLorentz;
 	}

--- a/Utils/src/BTagInt.cc
+++ b/Utils/src/BTagInt.cc
@@ -37,12 +37,12 @@
 class BTagInt : public edm::global::EDProducer<> {
 public:
 	explicit BTagInt(const edm::ParameterSet&);
-	~BTagInt();
+	~BTagInt() override;
 	
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-	virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+	void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
 	edm::InputTag JetTag_;
 	edm::EDGetTokenT<edm::View<pat::Jet>> JetTok_;
@@ -112,9 +112,9 @@ BTagInt::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetu
 	edm::Handle< edm::View<pat::Jet> > Jets;
 	iEvent.getByToken(JetTok_,Jets);
 	if( Jets.isValid() ) {
-		for(unsigned int i=0; i<Jets->size();i++)
+		for(const auto & i : *Jets)
 		{
-		  if(Jets->at(i).bDiscriminator(btagname_) >btagvalue_)BTags++;
+		  if(i.bDiscriminator(btagname_) >btagvalue_)BTags++;
 		}
 	}
 	else edm::LogWarning("TreeMaker")<<"BTagInt::Invalid Tag: "<<JetTag_.label();

--- a/Utils/src/BTagInt.cc
+++ b/Utils/src/BTagInt.cc
@@ -112,9 +112,9 @@ BTagInt::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetu
 	edm::Handle< edm::View<pat::Jet> > Jets;
 	iEvent.getByToken(JetTok_,Jets);
 	if( Jets.isValid() ) {
-		for(const auto & i : *Jets)
+		for(const auto & iJet : *Jets)
 		{
-		  if(i.bDiscriminator(btagname_) >btagvalue_)BTags++;
+		  if(iJet.bDiscriminator(btagname_) >btagvalue_)BTags++;
 		}
 	}
 	else edm::LogWarning("TreeMaker")<<"BTagInt::Invalid Tag: "<<JetTag_.label();

--- a/Utils/src/BasicSubstructureProducer.cc
+++ b/Utils/src/BasicSubstructureProducer.cc
@@ -26,7 +26,7 @@ class BasicSubstructureProducer : public edm::global::EDProducer<> {
 	public:
 		explicit BasicSubstructureProducer(const edm::ParameterSet&);
 	private:
-		virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+		void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 		template <class T>
 		void helpProduce(edm::Event& iEvent, const edm::Handle<edm::View<pat::Jet>>& jets, const std::vector<T>& vec, std::string name) const;
 		edm::InputTag JetTag_;

--- a/Utils/src/CandPtrPrefer.cc
+++ b/Utils/src/CandPtrPrefer.cc
@@ -17,9 +17,9 @@
 class CandPtrPrefer : public edm::global::EDProducer<> {
   public:
     explicit CandPtrPrefer(const edm::ParameterSet & iConfig);
-    ~CandPtrPrefer();
+    ~CandPtrPrefer() override;
 
-    virtual void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
+    void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
 
   private:
     edm::EDGetTokenT<edm::View<reco::Candidate> > firstSrcToken_;
@@ -47,7 +47,7 @@ CandPtrPrefer::produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup
   iEvent.getByToken(secondSrcToken_, secondGroup);
 
   auto result = std::make_unique<PtrVector<reco::Candidate>>();
-  if(firstGroup->size()==0){
+  if(firstGroup->empty()){
     for(size_t i = 0; i< secondGroup->size();  ++i) {
         result->push_back(secondGroup->ptrAt(i));
     }  

--- a/Utils/src/DeltaPhiDouble.cc
+++ b/Utils/src/DeltaPhiDouble.cc
@@ -40,12 +40,12 @@
 class DeltaPhiDouble : public edm::global::EDProducer<> {
 public:
    explicit DeltaPhiDouble(const edm::ParameterSet&);
-   ~DeltaPhiDouble();
+   ~DeltaPhiDouble() override;
    
    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
    
 private:
-   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
    
    edm::InputTag MHTPhiTag_, MHTJetTag_, DeltaPhiJetTag_;
    edm::EDGetTokenT<edm::View<reco::Candidate>> MHTJetTok_, DeltaPhiJetTok_;
@@ -72,7 +72,7 @@ DeltaPhiDouble::DeltaPhiDouble(const edm::ParameterSet& iConfig) :
    MHTPhiTag_(iConfig.getParameter<edm::InputTag>("MHTPhi")),
    MHTJetTag_(iConfig.getParameter<edm::InputTag>("MHTJets")),
    DeltaPhiJetTag_(iConfig.getParameter<edm::InputTag>("DeltaPhiJets")),
-   usePhi(MHTPhiTag_.label().size()>0)
+   usePhi(!MHTPhiTag_.label().empty())
 {
    //register your products
    if(usePhi) MHTPhiTok_ = consumes<double>(MHTPhiTag_);

--- a/Utils/src/DoubleFilter.cc
+++ b/Utils/src/DoubleFilter.cc
@@ -36,12 +36,12 @@
 class DoubleFilter : public edm::global::EDFilter<> {
 public:
 	explicit DoubleFilter(const edm::ParameterSet&);
-	~DoubleFilter();
+	~DoubleFilter() override;
 	
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-	virtual bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+	bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
 	// ----------member data ---------------------------
 	edm::InputTag DoubleTag_;

--- a/Utils/src/EventListFilter.cc
+++ b/Utils/src/EventListFilter.cc
@@ -39,12 +39,12 @@ typedef std::unordered_set<Triple,triple_hash> TripleSet;
 class EventListFilter : public edm::global::EDFilter<> {
 public:
 	explicit EventListFilter(const edm::ParameterSet&);
-	~EventListFilter();
+	~EventListFilter() override;
 	
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-	virtual bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;	
+	bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;	
 
 	// ----------member data ---------------------------
 	std::string inputFileList_;
@@ -60,7 +60,7 @@ EventListFilter::EventListFilter(const edm::ParameterSet& iConfig) :
 	TagMode_(iConfig.getParameter<bool>("TagMode"))
 {
 	//initialize the set of events
-	if(inputFileList_.size()>0){
+	if(!inputFileList_.empty()){
 		std::ifstream infile(inputFileList_.c_str());
 		if(infile.is_open()){
 			std::string line;

--- a/Utils/src/ExtrapolationProducer.cc
+++ b/Utils/src/ExtrapolationProducer.cc
@@ -26,7 +26,7 @@
 class ExtrapolationProducer : public edm::global::EDProducer<> {
 public:
   explicit ExtrapolationProducer(const edm::ParameterSet&);
-  ~ExtrapolationProducer();
+  ~ExtrapolationProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
@@ -65,7 +65,7 @@ public:
   }
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
   edm::InputTag MuonTag_, ElecTag_, MHTPtTag_, MHTPhiTag_;
   edm::EDGetTokenT<edm::View<pat::Muon>> MuonTok_;
@@ -126,10 +126,10 @@ void ExtrapolationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm
   edm::Handle<edm::View<pat::Muon> > muonHandle;
   iEvent.getByToken(MuonTok_, muonHandle);
   if(muonHandle.isValid()) {
-    for(unsigned int m=0; m<muonHandle->size(); ++m)
+    for(const auto & m : *muonHandle)
       {
-	muPTW->push_back(GetWVec(MHT, MHTPhi, muonHandle->at(m).pt(), muonHandle->at(m).phi()).Mod());
-	muCDTT->push_back(GetCDTT(MHT, MHTPhi, muonHandle->at(m).pt(), muonHandle->at(m).phi()));
+	muPTW->push_back(GetWVec(MHT, MHTPhi, m.pt(), m.phi()).Mod());
+	muCDTT->push_back(GetCDTT(MHT, MHTPhi, m.pt(), m.phi()));
       }
   }
 
@@ -137,10 +137,10 @@ void ExtrapolationProducer::produce(edm::StreamID, edm::Event& iEvent, const edm
   iEvent.getByToken(ElecTok_, eleHandle);
   if(eleHandle.isValid())
     {
-      for(unsigned int e=0; e<eleHandle->size(); ++e)
+      for(const auto & e : *eleHandle)
 	{
-	  elecPTW->push_back(GetWVec(MHT, MHTPhi, eleHandle->at(e).pt(), eleHandle->at(e).phi()).Mod());
-	  elecCDTT->push_back(GetCDTT(MHT, MHTPhi, eleHandle->at(e).pt(), eleHandle->at(e).phi()));
+	  elecPTW->push_back(GetWVec(MHT, MHTPhi, e.pt(), e.phi()).Mod());
+	  elecCDTT->push_back(GetCDTT(MHT, MHTPhi, e.pt(), e.phi()));
 	}
     }
 

--- a/Utils/src/FilterDecisionProducer.cc
+++ b/Utils/src/FilterDecisionProducer.cc
@@ -45,12 +45,12 @@
 class FilterDecisionProducer : public edm::global::EDProducer<> {
 public:
   explicit FilterDecisionProducer(const edm::ParameterSet&);
-  ~FilterDecisionProducer();
+  ~FilterDecisionProducer() override;
 	
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
   // ----------member data ---------------------------
   edm::InputTag trigResultsTag_;

--- a/Utils/src/GenHTProducer.cc
+++ b/Utils/src/GenHTProducer.cc
@@ -25,12 +25,12 @@
 class GenHTProducer : public edm::global::EDProducer<> {
 public:
   explicit GenHTProducer(const edm::ParameterSet&);
-  ~GenHTProducer();
+  ~GenHTProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
   // ----------member data ---------------------------
   edm::GetterOfProducts<LHEEventProduct> getterOfProducts_;

--- a/Utils/src/GenJetProperties.cc
+++ b/Utils/src/GenJetProperties.cc
@@ -28,12 +28,12 @@
 class GenJetProperties : public edm::global::EDProducer<> {
 public:
   explicit GenJetProperties(const edm::ParameterSet&);
-  ~GenJetProperties();
+  ~GenJetProperties() override;
 	
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
   edm::InputTag GenJetTag;
   edm::EDGetTokenT<edm::View<reco::GenJet>> GenJetTok;

--- a/Utils/src/GenLeptonRecoCand.cc
+++ b/Utils/src/GenLeptonRecoCand.cc
@@ -45,12 +45,12 @@
 class GenLeptonRecoCand : public edm::global::EDProducer<> {
 public:
   explicit GenLeptonRecoCand(const edm::ParameterSet&);
-  ~GenLeptonRecoCand();
+  ~GenLeptonRecoCand() override;
 	
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
   edm::InputTag PrunedGenParticleTag_;
   edm::InputTag pfCandsTag_;
@@ -190,7 +190,7 @@ GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSe
 	      if(abs(FinalBoson->daughter(ii)->pdgId())== 11) 
 		{
 		  selectedElectron->push_back(*((reco::GenParticle*) FinalBoson->daughter(ii) ));
-		  selectedElectronTauDecay->push_back(0);
+		  selectedElectronTauDecay->push_back(false);
 		  int matchedPFCand(MatchToPFCand(pfcands, &selectedElectron->back()));
 		  selectedElectronGenRecoD3->push_back(GetGenRecoD3(pfcands, matchedPFCand, &selectedElectron->back()));
 		  float trkiso = 0.;
@@ -202,7 +202,7 @@ GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSe
 	      if(abs(FinalBoson->daughter(ii)->pdgId())== 13) 
 		{
 		  selectedMuon->push_back(*((reco::GenParticle*) FinalBoson->daughter(ii) ));
-		  selectedMuonTauDecay->push_back(0);
+		  selectedMuonTauDecay->push_back(false);
 		  int matchedPFCand(MatchToPFCand(pfcands, &selectedMuon->back()));
 		  selectedMuonGenRecoD3->push_back(GetGenRecoD3(pfcands, matchedPFCand, &selectedMuon->back()));
 		  float trkiso = 0.;
@@ -254,13 +254,13 @@ GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSe
 		      }
 		    }
 
-		  bool hadTauDecay=1;
+		  bool hadTauDecay=true;
 		  for(size_t iii=0; iii<FinalTauDecay->numberOfDaughters();iii++)
 		    {
 		      if(abs(FinalTauDecay->daughter(iii)->pdgId())== 11) 
 			{
 			  selectedElectron->push_back(*((reco::GenParticle*) FinalTauDecay->daughter(iii) ));
-			  selectedElectronTauDecay->push_back(1);
+			  selectedElectronTauDecay->push_back(true);
 			  int matchedPFCand(MatchToPFCand(pfcands, &selectedElectron->back()));
 			  selectedElectronGenRecoD3->push_back(GetGenRecoD3(pfcands, matchedPFCand, &selectedElectron->back()));
 			  float trkiso = 0.;
@@ -268,12 +268,12 @@ GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSe
 			  GetTrkIso(pfcands, matchedPFCand, trkiso, activity);
 			  selectedElectronTrkIso->push_back(trkiso);
 			  selectedElectronTrkAct->push_back(activity);
-			  hadTauDecay=0;
+			  hadTauDecay=false;
 			}
 		      else if(abs(FinalTauDecay->daughter(iii)->pdgId())== 13) 
 			{
 			  selectedMuon->push_back(*((reco::GenParticle*) FinalTauDecay->daughter(iii) ));
-			  selectedMuonTauDecay->push_back(1);
+			  selectedMuonTauDecay->push_back(true);
 			  int matchedPFCand(MatchToPFCand(pfcands, &selectedMuon->back()));
 			  selectedMuonGenRecoD3->push_back(GetGenRecoD3(pfcands, matchedPFCand, &selectedMuon->back()));
 			  float trkiso = 0.;
@@ -281,7 +281,7 @@ GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSe
 			  GetTrkIso(pfcands, matchedPFCand, trkiso, activity);
 			  selectedMuonTrkIso->push_back(trkiso);
 			  selectedMuonTrkAct->push_back(activity);
-			  hadTauDecay=0;
+			  hadTauDecay=false;
 			}
 		      // store all decay productes of the tau in a new colleciton
           }
@@ -317,10 +317,10 @@ GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSe
       // find the leading track
       double maxPt(0.);
       int leadTrk(0);
-      for (unsigned int itk(0); itk<tau_trks.size(); itk++) {
-  	if (selectedTauDecayCands->at(tau_trks[itk]).pt()>maxPt) {
-  	  maxPt=tau_trks[itk];
-  	  leadTrk=tau_trks[itk];
+      for (int tau_trk : tau_trks) {
+  	if (selectedTauDecayCands->at(tau_trk).pt()>maxPt) {
+  	  maxPt=tau_trk;
+  	  leadTrk=tau_trk;
   	}
       }
       TLorentzVector p4(selectedTauDecayCands->at(leadTrk).px(),selectedTauDecayCands->at(leadTrk).py(),selectedTauDecayCands->at(leadTrk).pz(),selectedTauDecayCands->at(leadTrk).energy());

--- a/Utils/src/GenParticlesProducer.cc
+++ b/Utils/src/GenParticlesProducer.cc
@@ -96,27 +96,27 @@ GenParticlesProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
     edm::LogInfo("TreeMaker")<< "======new event============"<<"\n"
       <<"idx\t"<<"pdgId\t"<<"status\t"<<"parId\t"<<"parIdx\t";
   }
-  for(View<reco::GenParticle>::const_iterator iPart = genPartCands->begin(); iPart != genPartCands->end(); ++iPart)
+  for(const auto& iPart : *genPartCands)
     {
-      bool typicalChild=(typicalChildIds.find(abs(iPart->pdgId()))!=typicalChildIds.end());
-      bool typicalParent=(typicalParentIds.find(abs(iPart->pdgId()))!=typicalParentIds.end());
+      bool typicalChild=(typicalChildIds.find(abs(iPart.pdgId()))!=typicalChildIds.end());
+      bool typicalParent=(typicalParentIds.find(abs(iPart.pdgId()))!=typicalParentIds.end());
       if (!(typicalChild || typicalParent)) continue;
 
-      int status = abs(iPart->status());
-      bool acceptableParent = typicalParent && (iPart->isLastCopy() || status==21);
+      int status = abs(iPart.status());
+      bool acceptableParent = typicalParent && (iPart.isLastCopy() || status==21);
       //bool acceptableChild = typicalChild && (status==1 || status==2 || (status>20 && status<30));
-      bool acceptableChild = typicalChild && iPart->isLastCopy();
+      bool acceptableChild = typicalChild && iPart.isLastCopy();
       if (!(acceptableChild || acceptableParent)) continue;
 
       TLorentzVector temp;
-      temp.SetPxPyPzE(iPart->px(), iPart->py(), iPart->pz(), iPart->energy());
+      temp.SetPxPyPzE(iPart.px(), iPart.py(), iPart.pz(), iPart.energy());
       genParticle_vec->push_back(temp);
-      PdgId_vec->push_back(iPart->pdgId());
+      PdgId_vec->push_back(iPart.pdgId());
       Status_vec->push_back(status);
       TLorentzVector parent; parent.SetPxPyPzE(0,0,0,0);
       int parentid = 0;
       const reco::GenParticle *Parent;
-      Parent = static_cast<const reco::GenParticle *>(iPart->mother());
+      Parent = static_cast<const reco::GenParticle *>(iPart.mother());
       while(true)
         {
           if(!(Parent)) break;

--- a/Utils/src/GenParticlesProducer.cc
+++ b/Utils/src/GenParticlesProducer.cc
@@ -27,12 +27,12 @@ class GenParticlesProducer : public edm::global::EDProducer<> {
 
 public:
   explicit GenParticlesProducer(const edm::ParameterSet&);
-  ~GenParticlesProducer();
+  ~GenParticlesProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
 

--- a/Utils/src/GenTopProducer.cc
+++ b/Utils/src/GenTopProducer.cc
@@ -15,13 +15,13 @@ class GenTopProducer : public edm::global::EDProducer<> {
 
 public:
   explicit GenTopProducer(const edm::ParameterSet&);
-  ~GenTopProducer();
+  ~GenTopProducer() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
   double getSF(const reco::GenParticle& part) const;
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
   // ----------member data ---------------------------
   
@@ -65,7 +65,7 @@ GenTopProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup
   auto genTop_vec = std::make_unique<std::vector<reco::GenParticle>>();
 
   //store t, then tbar (if present)
-  const reco::GenParticle* tmp = NULL;
+  const reco::GenParticle* tmp = nullptr;
   tmp = genEvt->top();
   if(tmp) genTop_vec->push_back(*tmp);
   tmp = genEvt->topBar();

--- a/Utils/src/GoodJetsProducer.cc
+++ b/Utils/src/GoodJetsProducer.cc
@@ -165,26 +165,26 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
       prodJets->reserve(Jets->size());
       jetsMask->reserve(Jets->size());
       leptonMask->reserve(Jets->size());
-      for(const auto & i : *Jets)
+      for(const auto & iJet : *Jets)
       {
-         if (std::abs(i.eta())>maxEta_) continue;
+         if (std::abs(iJet.eta())>maxEta_) continue;
          if (!saveAllPt_ &&
-              ( (!invertJetPtFilter_ && i.pt() <= jetPtFilter_) ||
-                (invertJetPtFilter_ && i.pt() > jetPtFilter_) ) ) continue;
-         float neufrac=i.neutralHadronEnergyFraction();//gives raw energy in the denominator
-         float phofrac=i.neutralEmEnergyFraction();//gives raw energy in the denominator
-         float chgfrac=i.chargedHadronEnergyFraction();
-         float chgEMfrac=i.chargedEmEnergyFraction();
-         int chgmulti=i.chargedMultiplicity();
-         int neumulti=i.neutralMultiplicity();
+              ( (!invertJetPtFilter_ && iJet.pt() <= jetPtFilter_) ||
+                (invertJetPtFilter_ && iJet.pt() > jetPtFilter_) ) ) continue;
+         float neufrac=iJet.neutralHadronEnergyFraction();//gives raw energy in the denominator
+         float phofrac=iJet.neutralEmEnergyFraction();//gives raw energy in the denominator
+         float chgfrac=iJet.chargedHadronEnergyFraction();
+         float chgEMfrac=iJet.chargedEmEnergyFraction();
+         int chgmulti=iJet.chargedMultiplicity();
+         int neumulti=iJet.neutralMultiplicity();
          int nconstit=chgmulti+neumulti;
          bool skip=false;
          if(ExcludeLeptonIsoTrackPhotons_ && !excludeHandles.empty())
          {
             for(auto & excludeHandle : excludeHandles){
                 for(unsigned ih=0; ih<excludeHandle->size(); ++ih){
-                    if(std::abs(i.pt() - excludeHandle->at(ih).pt() ) / excludeHandle->at(ih).pt() < 1 && 
-                       deltaR(i.p4(),excludeHandle->at(ih).p4()) < JetConeSize_ )
+                    if(std::abs(iJet.pt() - excludeHandle->at(ih).pt() ) / excludeHandle->at(ih).pt() < 1 && 
+                       deltaR(iJet.p4(),excludeHandle->at(ih).p4()) < JetConeSize_ )
                     {
                        skip=true;
                        break;
@@ -194,7 +194,7 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
             }
             if(skip)
             {
-               prodJets->push_back(Jet(i));
+               prodJets->push_back(Jet(iJet));
                jetsMask->push_back(true);
                leptonMask->push_back(true);
                continue;
@@ -203,11 +203,11 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
          }
          else leptonMask->push_back(false);
          bool good = true;
-         if (std::abs(i.eta()) <= 2.7){
+         if (std::abs(iJet.eta()) <= 2.7){
             good = neufrac<maxNeutralFraction_ && phofrac<maxPhotonFraction_ && nconstit>minNconstituents_;
-            if(std::abs(i.eta()) < 2.4) good &= chgfrac>minChargedFraction_ && chgmulti>minNcharged_ && chgEMfrac<maxChargedEMFraction_;
+            if(std::abs(iJet.eta()) < 2.4) good &= chgfrac>minChargedFraction_ && chgmulti>minNcharged_ && chgEMfrac<maxChargedEMFraction_;
          }
-         else if(std::abs(i.eta()) <= 3.0){
+         else if(std::abs(iJet.eta()) <= 3.0){
             good = phofrac>minPhotonFractionHE_ && phofrac<maxPhotonFractionHE_ && neufrac<maxNeutralFractionHE_ && neumulti>minNneutralsHE_;
          }
          else {
@@ -215,12 +215,12 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
          }
         //save good jets, potentially regardless of id or pt
         if (good || saveAllId_) {
-           prodJets->push_back(Jet(i));
+           prodJets->push_back(Jet(iJet));
            jetsMask->push_back(good);
         } 
         //calculate event filter only for jets that pass pT cut
-        if ( (!invertJetPtFilter_ && i.pt() > jetPtFilter_) ||
-                (invertJetPtFilter_ && i.pt() <= jetPtFilter_) ) {
+        if ( (!invertJetPtFilter_ && iJet.pt() > jetPtFilter_) ||
+                (invertJetPtFilter_ && iJet.pt() <= jetPtFilter_) ) {
            if(!good && !TagMode_) return false;
            result &= good;
         }

--- a/Utils/src/GoodJetsProducer.cc
+++ b/Utils/src/GoodJetsProducer.cc
@@ -46,12 +46,12 @@
 class GoodJetsProducer : public edm::global::EDFilter<> {
 public:
    explicit GoodJetsProducer(const edm::ParameterSet&);
-   ~GoodJetsProducer();
+   ~GoodJetsProducer() override;
    
    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
    
 private:
-   virtual bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
    
    edm::InputTag JetTag_;
    std::vector<edm::InputTag> SkipTag_;
@@ -139,7 +139,7 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
    // load to be excluded leptons, isotracks and photons
    std::vector<edm::Handle<edm::View<reco::Candidate>>> excludeHandles;
    excludeHandles.reserve(SkipTag_.size());
-   if(ExcludeLeptonIsoTrackPhotons_ && SkipTag_.size()){
+   if(ExcludeLeptonIsoTrackPhotons_ && !SkipTag_.empty()){
       // loop over each edm::InputTag
       for (unsigned iC = 0; iC < SkipTag_.size(); ++iC) {
          // get each collection the edm::InputTag corresponds to
@@ -165,26 +165,26 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
       prodJets->reserve(Jets->size());
       jetsMask->reserve(Jets->size());
       leptonMask->reserve(Jets->size());
-      for(unsigned int i=0; i<Jets->size();i++)
+      for(const auto & i : *Jets)
       {
-         if (std::abs(Jets->at(i).eta())>maxEta_) continue;
+         if (std::abs(i.eta())>maxEta_) continue;
          if (!saveAllPt_ &&
-              ( (!invertJetPtFilter_ && Jets->at(i).pt() <= jetPtFilter_) ||
-                (invertJetPtFilter_ && Jets->at(i).pt() > jetPtFilter_) ) ) continue;
-         float neufrac=Jets->at(i).neutralHadronEnergyFraction();//gives raw energy in the denominator
-         float phofrac=Jets->at(i).neutralEmEnergyFraction();//gives raw energy in the denominator
-         float chgfrac=Jets->at(i).chargedHadronEnergyFraction();
-         float chgEMfrac=Jets->at(i).chargedEmEnergyFraction();
-         int chgmulti=Jets->at(i).chargedMultiplicity();
-         int neumulti=Jets->at(i).neutralMultiplicity();
+              ( (!invertJetPtFilter_ && i.pt() <= jetPtFilter_) ||
+                (invertJetPtFilter_ && i.pt() > jetPtFilter_) ) ) continue;
+         float neufrac=i.neutralHadronEnergyFraction();//gives raw energy in the denominator
+         float phofrac=i.neutralEmEnergyFraction();//gives raw energy in the denominator
+         float chgfrac=i.chargedHadronEnergyFraction();
+         float chgEMfrac=i.chargedEmEnergyFraction();
+         int chgmulti=i.chargedMultiplicity();
+         int neumulti=i.neutralMultiplicity();
          int nconstit=chgmulti+neumulti;
          bool skip=false;
-         if(ExcludeLeptonIsoTrackPhotons_ && excludeHandles.size())
+         if(ExcludeLeptonIsoTrackPhotons_ && !excludeHandles.empty())
          {
-            for(unsigned h=0; h<excludeHandles.size(); ++h){
-                for(unsigned ih=0; ih<excludeHandles[h]->size(); ++ih){
-                    if(std::abs(Jets->at(i).pt() - excludeHandles[h]->at(ih).pt() ) / excludeHandles[h]->at(ih).pt() < 1 && 
-                       deltaR(Jets->at(i).p4(),excludeHandles[h]->at(ih).p4()) < JetConeSize_ )
+            for(auto & excludeHandle : excludeHandles){
+                for(unsigned ih=0; ih<excludeHandle->size(); ++ih){
+                    if(std::abs(i.pt() - excludeHandle->at(ih).pt() ) / excludeHandle->at(ih).pt() < 1 && 
+                       deltaR(i.p4(),excludeHandle->at(ih).p4()) < JetConeSize_ )
                     {
                        skip=true;
                        break;
@@ -194,7 +194,7 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
             }
             if(skip)
             {
-               prodJets->push_back(Jet(Jets->at(i)));
+               prodJets->push_back(Jet(i));
                jetsMask->push_back(true);
                leptonMask->push_back(true);
                continue;
@@ -203,11 +203,11 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
          }
          else leptonMask->push_back(false);
          bool good = true;
-         if (std::abs(Jets->at(i).eta()) <= 2.7){
+         if (std::abs(i.eta()) <= 2.7){
             good = neufrac<maxNeutralFraction_ && phofrac<maxPhotonFraction_ && nconstit>minNconstituents_;
-            if(std::abs(Jets->at(i).eta()) < 2.4) good &= chgfrac>minChargedFraction_ && chgmulti>minNcharged_ && chgEMfrac<maxChargedEMFraction_;
+            if(std::abs(i.eta()) < 2.4) good &= chgfrac>minChargedFraction_ && chgmulti>minNcharged_ && chgEMfrac<maxChargedEMFraction_;
          }
-         else if(std::abs(Jets->at(i).eta()) <= 3.0){
+         else if(std::abs(i.eta()) <= 3.0){
             good = phofrac>minPhotonFractionHE_ && phofrac<maxPhotonFractionHE_ && neufrac<maxNeutralFractionHE_ && neumulti>minNneutralsHE_;
          }
          else {
@@ -215,12 +215,12 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
          }
         //save good jets, potentially regardless of id or pt
         if (good || saveAllId_) {
-           prodJets->push_back(Jet(Jets->at(i)));
+           prodJets->push_back(Jet(i));
            jetsMask->push_back(good);
         } 
         //calculate event filter only for jets that pass pT cut
-        if ( (!invertJetPtFilter_ && Jets->at(i).pt() > jetPtFilter_) ||
-                (invertJetPtFilter_ && Jets->at(i).pt() <= jetPtFilter_) ) {
+        if ( (!invertJetPtFilter_ && i.pt() > jetPtFilter_) ||
+                (invertJetPtFilter_ && i.pt() <= jetPtFilter_) ) {
            if(!good && !TagMode_) return false;
            result &= good;
         }

--- a/Utils/src/GoodJetsProducer.cc
+++ b/Utils/src/GoodJetsProducer.cc
@@ -181,10 +181,10 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
          bool skip=false;
          if(ExcludeLeptonIsoTrackPhotons_ && !excludeHandles.empty())
          {
-            for(auto & excludeHandle : excludeHandles){
-                for(unsigned ih=0; ih<excludeHandle->size(); ++ih){
-                    if(std::abs(iJet.pt() - excludeHandle->at(ih).pt() ) / excludeHandle->at(ih).pt() < 1 && 
-                       deltaR(iJet.p4(),excludeHandle->at(ih).p4()) < JetConeSize_ )
+            for(const auto & excludeHandle : excludeHandles){
+                for(const auto & exclude : *excludeHandle){
+                    if(std::abs(iJet.pt() - exclude.pt() ) / exclude.pt() < 1 && 
+                       deltaR(iJet.p4(),exclude.p4()) < JetConeSize_ )
                     {
                        skip=true;
                        break;

--- a/Utils/src/HiddenSectorProducer.cc
+++ b/Utils/src/HiddenSectorProducer.cc
@@ -26,7 +26,7 @@ class HiddenSectorProducer : public edm::global::EDProducer<> {
 	public:
 		explicit HiddenSectorProducer(const edm::ParameterSet&);
 	private:
-		virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+		void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 		//helper
 		double TransverseMass(double px1, double py1, double m1, double px2, double py2, double m2) const;
 		edm::InputTag JetTag_, MetTag_, GenTag_;

--- a/Utils/src/HtDouble.cc
+++ b/Utils/src/HtDouble.cc
@@ -37,12 +37,12 @@
 class HTDouble : public edm::global::EDProducer<> {
 public:
 	explicit HTDouble(const edm::ParameterSet&);
-	~HTDouble();
+	~HTDouble() override;
 	
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-	virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+	void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
 	// ----------member data ---------------------------
 	edm::InputTag JetTag_;
@@ -85,9 +85,9 @@ HTDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSet
 	edm::Handle< reco::CandidateView > Jets;
 	iEvent.getByToken(JetTok_,Jets);
 	if( Jets.isValid() ) {
-		for(unsigned int i=0; i<Jets->size();i++)
+		for(const auto & i : *Jets)
 		{
-			ht_ +=Jets->at(i).pt();
+			ht_ +=i.pt();
 		}
 	}
 	else edm::LogWarning("TreeMaker")<<"HTDouble::Invalid Tag: "<<JetTag_.label();

--- a/Utils/src/HtDouble.cc
+++ b/Utils/src/HtDouble.cc
@@ -85,9 +85,9 @@ HTDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSet
 	edm::Handle< reco::CandidateView > Jets;
 	iEvent.getByToken(JetTok_,Jets);
 	if( Jets.isValid() ) {
-		for(const auto & i : *Jets)
+		for(const auto & iJet : *Jets)
 		{
-			ht_ +=i.pt();
+			ht_ += iJet.pt();
 		}
 	}
 	else edm::LogWarning("TreeMaker")<<"HTDouble::Invalid Tag: "<<JetTag_.label();

--- a/Utils/src/ISRJetProducer.cc
+++ b/Utils/src/ISRJetProducer.cc
@@ -26,7 +26,7 @@ class ISRJetProducer : public edm::global::EDProducer<> {
 	public:
 		explicit ISRJetProducer(const edm::ParameterSet&);
 	private:
-		virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+		void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 		edm::InputTag GenPartTag_; 
 		edm::EDGetTokenT<edm::View<reco::GenParticle>> GenPartTok_; 
 		edm::InputTag JetTag_;

--- a/Utils/src/IntFilter.cc
+++ b/Utils/src/IntFilter.cc
@@ -39,12 +39,12 @@
 class IntFilter : public edm::global::EDFilter<> {
 public:
 	explicit IntFilter(const edm::ParameterSet&);
-	~IntFilter();
+	~IntFilter() override;
 	
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-	virtual bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+	bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
 	// ----------member data ---------------------------
 	

--- a/Utils/src/IsolationProducer.cc
+++ b/Utils/src/IsolationProducer.cc
@@ -28,13 +28,13 @@
 class IsolationProducer : public edm::global::EDProducer<> {
 public:
   explicit IsolationProducer(const edm::ParameterSet&);
-  ~IsolationProducer();
+  ~IsolationProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
     
   edm::InputTag LeptonTag_, PFCandTag_, JetTag_, RhoTag_;
   edm::EDGetTokenT<edm::View<reco::Candidate>> LeptonTok_;

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -60,7 +60,7 @@ class NamedPtr : public NamedPtrBase {
 			edprod->produces<std::vector<T>>(name);
 		}
 		//destructor
-		virtual ~NamedPtr() {}
+		~NamedPtr() override {}
 		//accessors
 		void put(edm::Event& iEvent) override { iEvent.put(std::move(ptr),name); }
 		void reset() override { ptr.reset(new std::vector<T>()); }
@@ -81,7 +81,7 @@ class NamedPtr_D : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
 		//default for user floats
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->userFloat(extraInfo.at(0))); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->userFloat(extraInfo.at(0))); }
 };
 DEFAULT_NAMED_PTR(D,jecUnc);
 DEFAULT_NAMED_PTR(D,jerFactor);
@@ -108,7 +108,7 @@ class NamedPtr_I : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
 		//default for user ints
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->userInt(extraInfo.at(0))); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->userInt(extraInfo.at(0))); }
 };
 DEFAULT_NAMED_PTR(I,multiplicity);
 
@@ -120,77 +120,77 @@ DEFAULT_NAMED_PTR(I,multiplicity);
 class NamedPtr_jetArea : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->jetArea()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->jetArea()); }
 };
 DEFINE_NAMED_PTR(jetArea);
 
 class NamedPtr_chargedHadronEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->chargedHadronEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->chargedHadronEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(chargedHadronEnergyFraction);
 
 class NamedPtr_neutralHadronEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->neutralHadronEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->neutralHadronEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(neutralHadronEnergyFraction);
 
 class NamedPtr_chargedEmEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->chargedEmEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->chargedEmEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(chargedEmEnergyFraction);
 
 class NamedPtr_neutralEmEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->neutralEmEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->neutralEmEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(neutralEmEnergyFraction);
 
 class NamedPtr_electronEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->electronEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->electronEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(electronEnergyFraction);
 
 class NamedPtr_photonEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->photonEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->photonEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(photonEnergyFraction);
 
 class NamedPtr_muonEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->muonEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->muonEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(muonEnergyFraction);
 
 class NamedPtr_hfEMEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->HFEMEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->HFEMEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(hfEMEnergyFraction);
 
 class NamedPtr_hfHadronEnergyFraction : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->HFHadronEnergyFraction()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->HFHadronEnergyFraction()); }
 };
 DEFINE_NAMED_PTR(hfHadronEnergyFraction);
 
 class NamedPtr_bDiscriminator : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->bDiscriminator(extraInfo.at(0))); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->bDiscriminator(extraInfo.at(0))); }
 };
 DEFAULT_NAMED_PTR(bDiscriminator,bDiscriminatorCSV);
 DEFAULT_NAMED_PTR(bDiscriminator,bDiscriminatorMVA);
@@ -211,7 +211,7 @@ DEFAULT_NAMED_PTR(bDiscriminator,bJetTagDeepFlavourprobuds);
 class NamedPtr_jecFactor : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->jecFactor(Jet->availableJECLevels().back())/Jet->jecFactor("Uncorrected")); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->jecFactor(Jet->availableJECLevels().back())/Jet->jecFactor("Uncorrected")); }
 };
 DEFINE_NAMED_PTR(jecFactor);
 
@@ -219,21 +219,21 @@ DEFINE_NAMED_PTR(jecFactor);
 class NamedPtr_bDiscriminatorSubjet1 : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->subjets(extraInfo.at(0)).size() > 0 ? Jet->subjets(extraInfo.at(0)).at(0)->bDiscriminator(extraInfo.at(1)) : -10.); }
+		void get_property(const pat::Jet* Jet) override { push_back(!Jet->subjets(extraInfo.at(0)).empty() ? Jet->subjets(extraInfo.at(0)).at(0)->bDiscriminator(extraInfo.at(1)) : -10.); }
 };
 DEFINE_NAMED_PTR(bDiscriminatorSubjet1);
 
 class NamedPtr_bDiscriminatorSubjet2 : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->subjets(extraInfo.at(0)).size() > 1 ? Jet->subjets(extraInfo.at(0)).at(1)->bDiscriminator(extraInfo.at(1)) : -10.); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->subjets(extraInfo.at(0)).size() > 1 ? Jet->subjets(extraInfo.at(0)).at(1)->bDiscriminator(extraInfo.at(1)) : -10.); }
 };
 DEFINE_NAMED_PTR(bDiscriminatorSubjet2);
 
 class NamedPtr_softDropMass : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) {
+		void get_property(const pat::Jet* Jet) override {
 			LorentzVector fatJet;
 			auto const & subjets = Jet->subjets(extraInfo.at(0));
 			for ( auto const & it : subjets ) {
@@ -248,7 +248,7 @@ DEFINE_NAMED_PTR(softDropMass);
 class NamedPtr_lean : public NamedPtr<double> {
 	public:
 		using NamedPtr<double>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) {
+		void get_property(const pat::Jet* Jet) override {
 			if(extraInfo.size()==4){
 				//eta,phi,eta,phi
 				double eta1 = Jet->userFloat(extraInfo.at(0));
@@ -269,77 +269,77 @@ DEFINE_NAMED_PTR(lean);
 class NamedPtr_chargedHadronMultiplicity : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->chargedHadronMultiplicity()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->chargedHadronMultiplicity()); }
 };
 DEFINE_NAMED_PTR(chargedHadronMultiplicity);
 
 class NamedPtr_neutralHadronMultiplicity : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->neutralHadronMultiplicity()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->neutralHadronMultiplicity()); }
 };
 DEFINE_NAMED_PTR(neutralHadronMultiplicity);
 
 class NamedPtr_electronMultiplicity : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->electronMultiplicity()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->electronMultiplicity()); }
 };
 DEFINE_NAMED_PTR(electronMultiplicity);
 
 class NamedPtr_photonMultiplicity : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->photonMultiplicity()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->photonMultiplicity()); }
 };
 DEFINE_NAMED_PTR(photonMultiplicity);
 
 class NamedPtr_muonMultiplicity : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->muonMultiplicity()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->muonMultiplicity()); }
 };
 DEFINE_NAMED_PTR(muonMultiplicity);
 
 class NamedPtr_chargedMultiplicity : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->chargedMultiplicity()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->chargedMultiplicity()); }
 };
 DEFINE_NAMED_PTR(chargedMultiplicity);
 
 class NamedPtr_neutralMultiplicity : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->neutralMultiplicity()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->neutralMultiplicity()); }
 };
 DEFINE_NAMED_PTR(neutralMultiplicity);
 
 class NamedPtr_partonFlavor : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->partonFlavour()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->partonFlavour()); }
 };
 DEFINE_NAMED_PTR(partonFlavor);
 
 class NamedPtr_hadronFlavor : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->hadronFlavour()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->hadronFlavour()); }
 };
 DEFINE_NAMED_PTR(hadronFlavor);
 
 class NamedPtr_NumBhadrons : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->jetFlavourInfo().getbHadrons().size()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->jetFlavourInfo().getbHadrons().size()); }
 };
 DEFINE_NAMED_PTR(NumBhadrons);
 
 class NamedPtr_NumChadrons : public NamedPtr<int> {
 	public:
 		using NamedPtr<int>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) { push_back(Jet->jetFlavourInfo().getcHadrons().size()); }
+		void get_property(const pat::Jet* Jet) override { push_back(Jet->jetFlavourInfo().getcHadrons().size()); }
 };
 DEFINE_NAMED_PTR(NumChadrons);
 
@@ -349,7 +349,7 @@ DEFINE_NAMED_PTR(NumChadrons);
 class NamedPtr_constituents : public NamedPtr<std::vector<TLorentzVector>> {
 	public:
 		using NamedPtr<std::vector<TLorentzVector>>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) {
+		void get_property(const pat::Jet* Jet) override {
 			std::vector<TLorentzVector> partvecs;
 			for(unsigned k = 0; k < Jet->numberOfDaughters(); ++k){
 				const reco::Candidate* part = Jet->daughter(k);
@@ -369,7 +369,7 @@ DEFINE_NAMED_PTR(constituents);
 class NamedPtr_subjets : public NamedPtr<std::vector<TLorentzVector>> {
 	public:
 		using NamedPtr<std::vector<TLorentzVector>>::NamedPtr;
-		virtual void get_property(const pat::Jet* Jet) {
+		void get_property(const pat::Jet* Jet) override {
 			std::vector<TLorentzVector> subvecs;
 			auto const & subjets = Jet->subjets(extraInfo.at(0));
 			for ( auto const & it : subjets ) {
@@ -388,12 +388,12 @@ DEFINE_NAMED_PTR(subjets);
 class JetProperties : public edm::stream::EDProducer<> {
 public:
 	explicit JetProperties(const edm::ParameterSet&);
-	~JetProperties();
+	~JetProperties() override;
 	
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-	virtual void produce(edm::Event&, const edm::EventSetup&) override;
+	void produce(edm::Event&, const edm::EventSetup&) override;
 	
 	edm::InputTag JetTag_;
 	edm::EDGetTokenT<edm::View<pat::Jet>> JetTok_;
@@ -425,8 +425,8 @@ JetProperties::JetProperties(const edm::ParameterSet& iConfig)
 JetProperties::~JetProperties()
 {
 	//memory management
-	for(unsigned ip = 0; ip < Ptrs_.size(); ++ip){
-		delete (Ptrs_[ip]);
+	for(auto & Ptr : Ptrs_){
+		delete Ptr;
 	}
 	Ptrs_.clear();
 }
@@ -441,16 +441,16 @@ void
 JetProperties::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 	//reset ptrs
-	for(unsigned ip = 0; ip < Ptrs_.size(); ++ip){
-		Ptrs_[ip]->reset();
+	for(auto & Ptr : Ptrs_){
+		Ptr->reset();
 	}
 
 	edm::Handle< edm::View<pat::Jet> > Jets;
 	iEvent.getByToken(JetTok_,Jets);
 	if( Jets.isValid() ) {
 		for(auto Jet = Jets->begin();  Jet != Jets->end(); ++Jet){
-			for(unsigned ip = 0; ip < Ptrs_.size(); ++ip){
-				Ptrs_[ip]->get_property(&(*Jet));
+			for(auto & Ptr : Ptrs_){
+				Ptr->get_property(&(*Jet));
 			}
 			//for debugging: print out available subjet collections & btag discriminators
 			if(debug){
@@ -481,8 +481,8 @@ JetProperties::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	}
 
 	//put products
-	for(unsigned ip = 0; ip < Ptrs_.size(); ++ip){
-		Ptrs_[ip]->put(iEvent);
+	for(auto & Ptr : Ptrs_){
+		Ptr->put(iEvent);
 	}
 
 }

--- a/Utils/src/JetUncertaintyProducer.cc
+++ b/Utils/src/JetUncertaintyProducer.cc
@@ -25,7 +25,7 @@ class JetUncertaintyProducer : public edm::global::EDProducer<> {
 	public:
 		explicit JetUncertaintyProducer(const edm::ParameterSet&);
 	private:
-		virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+		void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 		GreaterByPt<pat::Jet> pTComparator_;
 		edm::InputTag JetTag_;
 		edm::EDGetTokenT<edm::View<pat::Jet>> JetTok_;

--- a/Utils/src/JetsForHadTauProducer.cc
+++ b/Utils/src/JetsForHadTauProducer.cc
@@ -42,12 +42,12 @@
 class JetsForHadTauProducer : public edm::global::EDProducer<> {
 public:
     explicit JetsForHadTauProducer(const edm::ParameterSet&);
-    ~JetsForHadTauProducer();
+    ~JetsForHadTauProducer() override;
     
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     
 private:
-    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
     const reco::GenParticle* TauFound(const reco::GenParticle * particle) const;
     bool matchJetLepton(const pat::Jet* otjet, const edm::Handle<edm::View<reco::GenParticle> >& pruned,
@@ -131,8 +131,8 @@ JetsForHadTauProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
   // finalJets should contain all jets (high-pt duplicates will be discarded after JER smearing)
   // use lepton matching to save space
   if(Jets.isValid()){
-    for(unsigned int ij=0; ij< Jets->size(); ij++){
-      if(!requireLeptonMatch_ || matchJetLepton(&(Jets->at(ij)),pruned,muon,electron)) finalJets->push_back(Jets->at(ij));
+    for(const auto & ij : *Jets){
+      if(!requireLeptonMatch_ || matchJetLepton(&ij,pruned,muon,electron)) finalJets->push_back(ij);
     }
   }
   

--- a/Utils/src/JetsForHadTauProducer.cc
+++ b/Utils/src/JetsForHadTauProducer.cc
@@ -131,8 +131,8 @@ JetsForHadTauProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
   // finalJets should contain all jets (high-pt duplicates will be discarded after JER smearing)
   // use lepton matching to save space
   if(Jets.isValid()){
-    for(const auto & ij : *Jets){
-      if(!requireLeptonMatch_ || matchJetLepton(&ij,pruned,muon,electron)) finalJets->push_back(ij);
+    for(const auto & iJet : *Jets){
+      if(!requireLeptonMatch_ || matchJetLepton(&iJet,pruned,muon,electron)) finalJets->push_back(iJet);
     }
   }
   

--- a/Utils/src/LeptonProducer.cc
+++ b/Utils/src/LeptonProducer.cc
@@ -47,7 +47,7 @@ class LeptonProducer : public edm::global::EDProducer<> {
   enum elecIDLevel {VETO, LOOSE, MEDIUM, TIGHT};
 public:
   explicit LeptonProducer(const edm::ParameterSet&);
-  ~LeptonProducer();
+  ~LeptonProducer() override;
         
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   float MTWCalculator(double metPt,double  metPhi,double  lepPt,double  lepPhi) const;
@@ -56,7 +56,7 @@ public:
   bool ElectronID(const pat::Electron & electron, const reco::Vertex & vtx, const elecIDLevel level, const double rho = 0.0) const;
         
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
         
   // ----------member data ---------------------------
   edm::InputTag MuonTag_, ElecTag_, PrimVtxTag_, metTag_, PFCandTag_, RhoTag_;
@@ -229,9 +229,8 @@ void LeptonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
   iEvent.getByToken(MuonTok_, muonHandle);
   if(muonHandle.isValid())
     {
-      for(unsigned int m=0; m<muonHandle->size(); ++m)
+      for(const auto & aMu : *muonHandle)
         {
-          const pat::Muon& aMu = muonHandle->at(m);
           if(aMu.pt()<minMuPt_ || fabs(aMu.eta())>maxMuEta_) continue;
                         
           if(MuonID(aMu,vtx_h->at(0)))
@@ -263,9 +262,8 @@ void LeptonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
   iEvent.getByToken(ElecTok_, eleHandle);
   if(eleHandle.isValid())
     {
-      for(unsigned int e=0; e<eleHandle->size(); ++e)
+      for(const auto & aEle : *eleHandle)
         {
-          const pat::Electron& aEle = eleHandle->at(e);
           if(fabs(aEle.superCluster()->eta())>maxElecEta_ || aEle.pt()<minElecPt_) continue;
           const reco::Vertex vtx = vtx_h->at(0);
 

--- a/Utils/src/METDouble.cc
+++ b/Utils/src/METDouble.cc
@@ -45,12 +45,12 @@
 class METDouble : public edm::global::EDProducer<> {
 public:
    explicit METDouble(const edm::ParameterSet&);
-   ~METDouble();
+   ~METDouble() override;
    
    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
    
 private:
-   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
    virtual double DeltaT(unsigned int i, edm::Handle< edm::View<pat::Jet> > Jets ) const;
    
    // ----------member data ---------------------------
@@ -142,7 +142,7 @@ METDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSe
    double dpnhat[3];
    unsigned int goodcount=0;
    
-   for(int i=0; i<3; ++i)dpnhat[i]=-999;
+   for(double & i : dpnhat)i=-999;
    reco::MET::LorentzVector metLorentz(0,0,0,0);
    if(MET.isValid() ){
       
@@ -220,8 +220,8 @@ METDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSe
    auto htp5 = std::make_unique<double>(dpnhat[2]);
    iEvent.put(std::move(htp5),"DeltaPhiN3");
    float mindpn=9999;
-   for(int i=0; i<3; ++i){
-      if(mindpn>fabs(dpnhat[i]))mindpn=fabs(dpnhat[i]);
+   for(double i : dpnhat){
+      if(mindpn>fabs(i))mindpn=fabs(i);
    }
    auto htp6 = std::make_unique<double>(mindpn);
    iEvent.put(std::move(htp6),"minDeltaPhiN");

--- a/Utils/src/MhtDouble.cc
+++ b/Utils/src/MhtDouble.cc
@@ -37,12 +37,12 @@
 class MhtDouble : public edm::global::EDProducer<> {
    public:
       explicit MhtDouble(const edm::ParameterSet&);
-      ~MhtDouble();
+      ~MhtDouble() override;
 
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+      void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
       
       // ----------member data ---------------------------
       edm::InputTag JetTag_;

--- a/Utils/src/MinDeltaRDouble.cc
+++ b/Utils/src/MinDeltaRDouble.cc
@@ -15,7 +15,7 @@ class MinDeltaRDouble : public edm::global::EDProducer<> {
 public:
 	explicit MinDeltaRDouble(const edm::ParameterSet&);
 private:
-   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
    edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticlesToken_;
 };
 
@@ -37,9 +37,9 @@ void MinDeltaRDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
       reco::GenParticle * gen;
       // try to get the hard process photon or Z (DY/Zinv/GJets MC)
       bool haveGen = false;
-      for (auto iG = pruned->begin(); iG != pruned->end(); ++iG) {
-         if ((iG->pdgId()==22&&iG->status()==23) || (iG->pdgId()==23&&iG->status()==22)) {
-            gen = iG->clone();
+      for (const auto & iG : *pruned) {
+         if ((iG.pdgId()==22&&iG.status()==23) || (iG.pdgId()==23&&iG.status()==22)) {
+            gen = iG.clone();
             haveGen = true;
             status = gen->status();
             break;
@@ -48,15 +48,15 @@ void MinDeltaRDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
       // try to get the highest pT photon with a parton mother (QCD)
       if (!haveGen) {
          double maxPt = 0.;
-         for (auto iG = pruned->begin(); iG != pruned->end(); ++iG) {
-            if (iG->pdgId()==22) {
-               const int motherID = std::abs(iG->mother()->pdgId());
+         for (const auto & iG : *pruned) {
+            if (iG.pdgId()==22) {
+               const int motherID = std::abs(iG.mother()->pdgId());
                if ((motherID>=1 && motherID<=6) || motherID==21) {
-                  if (iG->pt() > maxPt) {
-                     gen = iG->clone();
+                  if (iG.pt() > maxPt) {
+                     gen = iG.clone();
                      haveGen = true;
                      status = gen->status();
-                     maxPt = iG->pt();
+                     maxPt = iG.pt();
                   }
                }
             }
@@ -65,24 +65,24 @@ void MinDeltaRDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
       // try to get the highest pT photon
       if (!haveGen) {
          double maxPt = 0.;
-         for (auto iG = pruned->begin(); iG != pruned->end(); ++iG) {
-            if (iG->pdgId()==22) {
-               if (iG->pt() > maxPt) {
-                  gen = iG->clone();
+         for (const auto & iG : *pruned) {
+            if (iG.pdgId()==22) {
+               if (iG.pt() > maxPt) {
+                  gen = iG.clone();
                   haveGen = true;
                   status = -gen->status();
-                  maxPt = iG->pt();
+                  maxPt = iG.pt();
                }
             }
          }
       }
       // now calculate deltaR
       if (haveGen) {
-         for (auto iG = pruned->begin(); iG != pruned->end(); ++iG) {
-            if (iG->status()==23) {
-               const int tempID = std::abs(iG->pdgId());
+         for (const auto & iG : *pruned) {
+            if (iG.status()==23) {
+               const int tempID = std::abs(iG.pdgId());
                if ((tempID>=1 && tempID<=6) || tempID==21) {
-                  double tempDR = deltaR(gen->p4(), iG->p4());
+                  double tempDR = deltaR(gen->p4(), iG.p4());
                   if (tempDR < minDR) minDR = tempDR;
                }
             }

--- a/Utils/src/MinDeltaRDouble.cc
+++ b/Utils/src/MinDeltaRDouble.cc
@@ -37,9 +37,9 @@ void MinDeltaRDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
       reco::GenParticle * gen;
       // try to get the hard process photon or Z (DY/Zinv/GJets MC)
       bool haveGen = false;
-      for (const auto & iG : *pruned) {
-         if ((iG.pdgId()==22&&iG.status()==23) || (iG.pdgId()==23&&iG.status()==22)) {
-            gen = iG.clone();
+      for (const auto & iGen : *pruned) {
+         if ((iGen.pdgId()==22&&iGen.status()==23) || (iGen.pdgId()==23&&iGen.status()==22)) {
+            gen = iGen.clone();
             haveGen = true;
             status = gen->status();
             break;
@@ -48,15 +48,15 @@ void MinDeltaRDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
       // try to get the highest pT photon with a parton mother (QCD)
       if (!haveGen) {
          double maxPt = 0.;
-         for (const auto & iG : *pruned) {
-            if (iG.pdgId()==22) {
-               const int motherID = std::abs(iG.mother()->pdgId());
+         for (const auto & iGen : *pruned) {
+            if (iGen.pdgId()==22) {
+               const int motherID = std::abs(iGen.mother()->pdgId());
                if ((motherID>=1 && motherID<=6) || motherID==21) {
-                  if (iG.pt() > maxPt) {
-                     gen = iG.clone();
+                  if (iGen.pt() > maxPt) {
+                     gen = iGen.clone();
                      haveGen = true;
                      status = gen->status();
-                     maxPt = iG.pt();
+                     maxPt = iGen.pt();
                   }
                }
             }
@@ -65,24 +65,24 @@ void MinDeltaRDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::Even
       // try to get the highest pT photon
       if (!haveGen) {
          double maxPt = 0.;
-         for (const auto & iG : *pruned) {
-            if (iG.pdgId()==22) {
-               if (iG.pt() > maxPt) {
-                  gen = iG.clone();
+         for (const auto & iGen : *pruned) {
+            if (iGen.pdgId()==22) {
+               if (iGen.pt() > maxPt) {
+                  gen = iGen.clone();
                   haveGen = true;
                   status = -gen->status();
-                  maxPt = iG.pt();
+                  maxPt = iGen.pt();
                }
             }
          }
       }
       // now calculate deltaR
       if (haveGen) {
-         for (const auto & iG : *pruned) {
-            if (iG.status()==23) {
-               const int tempID = std::abs(iG.pdgId());
+         for (const auto & iGen : *pruned) {
+            if (iGen.status()==23) {
+               const int tempID = std::abs(iGen.pdgId());
                if ((tempID>=1 && tempID<=6) || tempID==21) {
-                  double tempDR = deltaR(gen->p4(), iG.p4());
+                  double tempDR = deltaR(gen->p4(), iGen.p4());
                   if (tempDR < minDR) minDR = tempDR;
                }
             }

--- a/Utils/src/Mt2Producer.cc
+++ b/Utils/src/Mt2Producer.cc
@@ -102,7 +102,7 @@ double Mt2Producer::getMT2Hemi(vector<TLorentzVector> jets, TLorentzVector metVe
   vector<float> Evec;
   vector<int> grouping;
            
-  for (auto & jet : jets)
+  for (const auto & jet : jets)
     {
       pxvec.push_back(jet.Px());
       pyvec.push_back(jet.Py());
@@ -169,10 +169,10 @@ Mt2Producer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& i
 
   std::vector<TLorentzVector > jets; 
   if( Jets.isValid() ) {
-    for(const auto & i : *Jets)
+    for(const auto & iJet : *Jets)
       {
 	TLorentzVector jet;
-	jet.SetPtEtaPhiE(i.p4().Pt(),i.p4().Eta(),i.p4().Phi(),i.p4().E());
+	jet.SetPtEtaPhiE(iJet.p4().Pt(),iJet.p4().Eta(),iJet.p4().Phi(),iJet.p4().E());
 	jets.push_back(jet);
       }
   }

--- a/Utils/src/Mt2Producer.cc
+++ b/Utils/src/Mt2Producer.cc
@@ -38,12 +38,12 @@ using namespace std;
 class Mt2Producer : public edm::global::EDProducer<> {
 public:
   explicit Mt2Producer(const edm::ParameterSet&);
-  ~Mt2Producer();
+  ~Mt2Producer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
       
   edm::InputTag MetTag_, JetTag_;
   edm::EDGetTokenT<reco::CandidateView> JetTok_;
@@ -102,12 +102,12 @@ double Mt2Producer::getMT2Hemi(vector<TLorentzVector> jets, TLorentzVector metVe
   vector<float> Evec;
   vector<int> grouping;
            
-  for (unsigned int j=0; j< jets.size(); j++)
+  for (auto & jet : jets)
     {
-      pxvec.push_back(jets[j].Px());
-      pyvec.push_back(jets[j].Py());
-      pzvec.push_back(jets[j].Pz());
-      Evec.push_back(jets[j].E());
+      pxvec.push_back(jet.Px());
+      pyvec.push_back(jet.Py());
+      pzvec.push_back(jet.Pz());
+      Evec.push_back(jet.E());
     }
   heppy::Hemisphere hemisphere(pxvec, pyvec, pzvec, Evec, 2, 3);
   grouping=hemisphere.getGrouping();
@@ -169,17 +169,17 @@ Mt2Producer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& i
 
   std::vector<TLorentzVector > jets; 
   if( Jets.isValid() ) {
-    for(unsigned int i=0; i<Jets->size();i++)
+    for(const auto & i : *Jets)
       {
 	TLorentzVector jet;
-	jet.SetPtEtaPhiE(Jets->at(i).p4().Pt(),Jets->at(i).p4().Eta(),Jets->at(i).p4().Phi(),Jets->at(i).p4().E());
+	jet.SetPtEtaPhiE(i.p4().Pt(),i.p4().Eta(),i.p4().Phi(),i.p4().E());
 	jets.push_back(jet);
       }
   }
 
   //disable stupid couts from heppy
   streambuf* orig_buf = std::cout.rdbuf();
-  std::cout.rdbuf(NULL);
+  std::cout.rdbuf(nullptr);
   double Mt2 = getMT2Hemi( jets, metvec);
   std::cout.rdbuf(orig_buf);
   

--- a/Utils/src/NJetInt.cc
+++ b/Utils/src/NJetInt.cc
@@ -35,12 +35,12 @@
 class NJetInt : public edm::global::EDProducer<> {
 public:
 	explicit NJetInt(const edm::ParameterSet&);
-	~NJetInt();
+	~NJetInt() override;
 	
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-	virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+	void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
 	// ----------member data ---------------------------
 	edm::InputTag JetTag_;

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -26,12 +26,12 @@
 class PDFWeightProducer : public edm::global::EDProducer<> {
 public:
   explicit PDFWeightProducer(const edm::ParameterSet&);
-  ~PDFWeightProducer();
+  ~PDFWeightProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
   // ----------member data ---------------------------
   edm::GetterOfProducts<LHEEventProduct> getterOfProducts_;

--- a/Utils/src/PackedCandPtrProjector.cc
+++ b/Utils/src/PackedCandPtrProjector.cc
@@ -17,9 +17,9 @@
 class PackedCandPtrProjector : public edm::global::EDProducer<> {
   public:
     explicit PackedCandPtrProjector(const edm::ParameterSet & iConfig);
-    ~PackedCandPtrProjector();
+    ~PackedCandPtrProjector() override;
 
-    virtual void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
+    void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
 
   private:
     edm::EDGetTokenT<edm::View<pat::PackedCandidate> > packedCandSrcToken_;

--- a/Utils/src/PhotonIDisoProducer.cc
+++ b/Utils/src/PhotonIDisoProducer.cc
@@ -387,13 +387,13 @@ bool PhotonIDisoProducer::hasMatchedPromptElectron(const reco::SuperClusterRef &
                                                    float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax) const
 {
   if (sc.isNull()) return false;
-  for (const auto & it : *eleCol) {
+  for (const auto & ele : *eleCol) {
     //match electron to supercluster
-    if (it.superCluster()!=sc) continue;
+    if (ele.superCluster()!=sc) continue;
     //check expected inner hits
-    if (it.gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS) > 0) continue;
+    if (ele.gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS) > 0) continue;
     //check if electron is matching to a conversion
-    if (ConversionTools::hasMatchedConversion(it,convCol,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
+    if (ConversionTools::hasMatchedConversion(ele,convCol,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
     return true;
   }
   return false;

--- a/Utils/src/PhotonIDisoProducer.cc
+++ b/Utils/src/PhotonIDisoProducer.cc
@@ -48,12 +48,12 @@ class PhotonIDisoProducer : public edm::global::EDProducer<> {
 
 public:
   explicit PhotonIDisoProducer(const edm::ParameterSet&);
-  ~PhotonIDisoProducer();
+  ~PhotonIDisoProducer() override;
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
   bool hasMatchedPromptElectron(const reco::SuperClusterRef &sc, const edm::Handle<std::vector<pat::Electron> > &eleCol,
 				const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot,
@@ -296,7 +296,7 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
     if( passAcc && passIDLoose && passIsoLoose && iPhoton->pt() > 100.0){//pure photons
       goodPhotons->push_back( *iPhoton );
       photon_isEB->push_back( iPhoton->isEB() );
-      photon_genMatched->push_back( iPhoton->genPhoton() != NULL );
+      photon_genMatched->push_back( iPhoton->genPhoton() != nullptr );
       photon_hadTowOverEM->push_back( iPhoton->hadTowOverEm() ) ;
       photon_sigmaIetaIeta->push_back( sieie );
       photon_pfChargedIso->push_back(      iPhoton->chargedHadronIso() );
@@ -387,13 +387,13 @@ bool PhotonIDisoProducer::hasMatchedPromptElectron(const reco::SuperClusterRef &
                                                    float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax) const
 {
   if (sc.isNull()) return false;
-  for (std::vector<pat::Electron>::const_iterator it = eleCol->begin(); it!=eleCol->end(); ++it) {
+  for (const auto & it : *eleCol) {
     //match electron to supercluster
-    if (it->superCluster()!=sc) continue;
+    if (it.superCluster()!=sc) continue;
     //check expected inner hits
-    if (it->gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS) > 0) continue;
+    if (it.gsfTrack()->hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS) > 0) continue;
     //check if electron is matching to a conversion
-    if (ConversionTools::hasMatchedConversion(*it,convCol,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
+    if (ConversionTools::hasMatchedConversion(it,convCol,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
     return true;
   }
   return false;

--- a/Utils/src/PhotonIDisoProducer.cc
+++ b/Utils/src/PhotonIDisoProducer.cc
@@ -215,21 +215,21 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
 
   /// setup cluster tools
   noZS::EcalClusterLazyTools clusterTools_(iEvent, iSetup, ecalRecHitsInputTag_EB_Token_, ecalRecHitsInputTag_EE_Token_);
-  for( View< pat::Photon >::const_iterator iPhoton = photonCands->begin(); iPhoton != photonCands->end(); ++iPhoton){
+  for(const auto& iPhoton : *photonCands){
 
     if( debug ) {
       edm::LogInfo("TreeMaker")
-        << "photon pt: " << iPhoton->pt() << "\n"
-        << "photon eta: " << iPhoton->eta() << "\n"
-        << "photon phi: " << iPhoton->phi() << "\n";
+        << "photon pt: " << iPhoton.pt() << "\n"
+        << "photon eta: " << iPhoton.eta() << "\n"
+        << "photon phi: " << iPhoton.phi() << "\n";
     }
 
-    std::vector<float> vCov = clusterTools_.localCovariances( *(iPhoton->superCluster()->seed()) ); 
+    std::vector<float> vCov = clusterTools_.localCovariances( *(iPhoton.superCluster()->seed()) ); 
     const float sieie = (isnan(vCov[0]) ? 0. : sqrt(vCov[0])); 
     
-    double chIso = effAreas.rhoCorrectedIso(  pfCh  , iPhoton->chargedHadronIso() , iPhoton->eta() , rho ); 
-    double nuIso = effAreas.rhoCorrectedIso(  pfNu  , iPhoton->neutralHadronIso() , iPhoton->eta() , rho ); 
-    double gamIso = effAreas.rhoCorrectedIso( pfGam , iPhoton->photonIso()        , iPhoton->eta() , rho ); 
+    double chIso = effAreas.rhoCorrectedIso(  pfCh  , iPhoton.chargedHadronIso() , iPhoton.eta() , rho ); 
+    double nuIso = effAreas.rhoCorrectedIso(  pfNu  , iPhoton.neutralHadronIso() , iPhoton.eta() , rho ); 
+    double gamIso = effAreas.rhoCorrectedIso( pfGam , iPhoton.photonIso()        , iPhoton.eta() , rho ); 
 
     // apply photon selection -- all good photons will be saved
     // use loose selection with no sieie or chiso cuts
@@ -241,7 +241,7 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
     bool passIsoLoose=false;
     bool passAcc=false;
 
-    double PhEta=iPhoton->eta();
+    double PhEta=iPhoton.eta();
 
     if(fabs(PhEta) < 1.4442  ){
       isBarrelPhoton=true;
@@ -261,14 +261,14 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
 
     // apply id cuts using https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedPhotonIdentificationRun2#Working_points_for_92X_and_later
     if (isBarrelPhoton) {
-      if (iPhoton->hadTowOverEm() < hadTowOverEm_EB_cut_ && !hasMatchedPromptElectron(iPhoton->superCluster(), electrons, conversions, beamSpot->position())) {
+      if (iPhoton.hadTowOverEm() < hadTowOverEm_EB_cut_ && !hasMatchedPromptElectron(iPhoton.superCluster(), electrons, conversions, beamSpot->position())) {
 	passIDLoose = true;
 	if (sieie < sieie_EB_cut_) {
 	  passID = true;
 	}
       }
     } else if (isEndcapPhoton) {
-      if (iPhoton->hadTowOverEm() < hadTowOverEm_EE_cut_ && !hasMatchedPromptElectron(iPhoton->superCluster(), electrons, conversions, beamSpot->position())) {
+      if (iPhoton.hadTowOverEm() < hadTowOverEm_EE_cut_ && !hasMatchedPromptElectron(iPhoton.superCluster(), electrons, conversions, beamSpot->position())) {
 	passIDLoose = true;
 	if (sieie < sieie_EE_cut_) {
 	  passID = true;
@@ -278,14 +278,14 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
  
     // apply isolation cuts
     if (isBarrelPhoton) {
-      if (nuIso < (pfNuIsoRhoCorr_EB_cut_[0] + pfNuIsoRhoCorr_EB_cut_[1]*iPhoton->pt() + pfNuIsoRhoCorr_EB_cut_[2]*iPhoton->pt()*iPhoton->pt()) && gamIso < ( pfGmIsoRhoCorr_EB_cut_[0] +  pfGmIsoRhoCorr_EB_cut_[1]*iPhoton->pt())) {
+      if (nuIso < (pfNuIsoRhoCorr_EB_cut_[0] + pfNuIsoRhoCorr_EB_cut_[1]*iPhoton.pt() + pfNuIsoRhoCorr_EB_cut_[2]*iPhoton.pt()*iPhoton.pt()) && gamIso < ( pfGmIsoRhoCorr_EB_cut_[0] +  pfGmIsoRhoCorr_EB_cut_[1]*iPhoton.pt())) {
 	passIsoLoose = true;
 	if (chIso < pfChIsoRhoCorr_EB_cut_) {
 	  passIso = true;
 	}
       }
     } else if (isEndcapPhoton) {
-      if (nuIso < (pfNuIsoRhoCorr_EE_cut_[0] + pfNuIsoRhoCorr_EE_cut_[1]*iPhoton->pt() + pfNuIsoRhoCorr_EE_cut_[2]*iPhoton->pt()*iPhoton->pt())  && gamIso < (pfGmIsoRhoCorr_EE_cut_[0] + pfGmIsoRhoCorr_EE_cut_[1]*iPhoton->pt())) {
+      if (nuIso < (pfNuIsoRhoCorr_EE_cut_[0] + pfNuIsoRhoCorr_EE_cut_[1]*iPhoton.pt() + pfNuIsoRhoCorr_EE_cut_[2]*iPhoton.pt()*iPhoton.pt())  && gamIso < (pfGmIsoRhoCorr_EE_cut_[0] + pfGmIsoRhoCorr_EE_cut_[1]*iPhoton.pt())) {
 	passIsoLoose = true;
 	if (chIso <  pfChIsoRhoCorr_EE_cut_) {
 	  passIso = true;
@@ -293,20 +293,20 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
       }
     }
     // check if photon is a good loose photon
-    if( passAcc && passIDLoose && passIsoLoose && iPhoton->pt() > 100.0){//pure photons
-      goodPhotons->push_back( *iPhoton );
-      photon_isEB->push_back( iPhoton->isEB() );
-      photon_genMatched->push_back( iPhoton->genPhoton() != nullptr );
-      photon_hadTowOverEM->push_back( iPhoton->hadTowOverEm() ) ;
+    if( passAcc && passIDLoose && passIsoLoose && iPhoton.pt() > 100.0){//pure photons
+      goodPhotons->push_back( iPhoton );
+      photon_isEB->push_back( iPhoton.isEB() );
+      photon_genMatched->push_back( iPhoton.genPhoton() != nullptr );
+      photon_hadTowOverEM->push_back( iPhoton.hadTowOverEm() ) ;
       photon_sigmaIetaIeta->push_back( sieie );
-      photon_pfChargedIso->push_back(      iPhoton->chargedHadronIso() );
-      photon_pfGammaIso->push_back(        iPhoton->photonIso() );
-      photon_pfNeutralIso->push_back(      iPhoton->neutralHadronIso() );
+      photon_pfChargedIso->push_back(      iPhoton.chargedHadronIso() );
+      photon_pfGammaIso->push_back(        iPhoton.photonIso() );
+      photon_pfNeutralIso->push_back(      iPhoton.neutralHadronIso() );
       photon_pfChargedIsoRhoCorr->push_back( chIso  );
       photon_pfGammaIsoRhoCorr->push_back(   gamIso  );
       photon_pfNeutralIsoRhoCorr->push_back( nuIso );
-      photon_hasPixelSeed->push_back( iPhoton->hasPixelSeed() );
-      photon_passElectronVeto->push_back( !hasMatchedPromptElectron(iPhoton->superCluster(),electrons, conversions, beamSpot->position()) );
+      photon_hasPixelSeed->push_back( iPhoton.hasPixelSeed() );
+      photon_passElectronVeto->push_back( !hasMatchedPromptElectron(iPhoton.superCluster(),electrons, conversions, beamSpot->position()) );
       photon_fullID->push_back(passID&&passIso);
 
       if (genParticles.isValid()){//genLevel Stuff
@@ -314,20 +314,20 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
         int matchedGenPrompt = 0;
         int matchedGenNonPrompt = 0 ;
         bool photonMatchGenE = false;        
-        for(View<reco::GenParticle>::const_iterator iGen = genParticles->begin(); iGen != genParticles->end(); ++iGen){
+        for(const auto& iGen : *genParticles){
           // check for non-prompt photons ----------------------
-          if( iGen->pdgId() == 22 && ( ( iGen->status() / 10 ) == 2 || iGen->status() == 1 || iGen->status() == 2 ) ){
-            if( deltaR(iGen->p4(),iPhoton->p4()) < 0.2 ){ /// I LEFT OFF HERE!!!!!!
-              if( abs(iGen->mother()->pdgId()) > 100 && abs(iGen->mother()->pdgId()) < 1000000 && abs(iGen->mother()->pdgId()) != 2212 ) matchedGenNonPrompt++ ;
-              if( abs(iGen->mother()->pdgId()) <= 100 || abs(iGen->mother()->pdgId()) == 2212 ){
-                if( iGen->pt()/iPhoton->pt() > 0.5 && iGen->pt()/iPhoton->pt() < 1.5 )
+          if( iGen.pdgId() == 22 && ( ( iGen.status() / 10 ) == 2 || iGen.status() == 1 || iGen.status() == 2 ) ){
+            if( deltaR(iGen.p4(),iPhoton.p4()) < 0.2 ){ /// I LEFT OFF HERE!!!!!!
+              if( abs(iGen.mother()->pdgId()) > 100 && abs(iGen.mother()->pdgId()) < 1000000 && abs(iGen.mother()->pdgId()) != 2212 ) matchedGenNonPrompt++ ;
+              if( abs(iGen.mother()->pdgId()) <= 100 || abs(iGen.mother()->pdgId()) == 2212 ){
+                if( iGen.pt()/iPhoton.pt() > 0.5 && iGen.pt()/iPhoton.pt() < 1.5 )
                   matchedGenPrompt++ ;
               }//for prompt photons
             }//gen matching
           }
           //check whether photon has matched to a gen electron or not
-          if( abs(iGen->pdgId()) == 11 && iGen->status() == 1 && abs(iGen->mother()->pdgId()) <=25 ){
-            if( deltaR(iGen->p4(),iPhoton->p4()) < 0.2 && (iGen->pt()/iPhoton->pt() > 0.9 && iGen->pt()/iPhoton->pt() < 1.1) ){
+          if( abs(iGen.pdgId()) == 11 && iGen.status() == 1 && abs(iGen.mother()->pdgId()) <=25 ){
+            if( deltaR(iGen.p4(),iPhoton.p4()) < 0.2 && (iGen.pt()/iPhoton.pt() > 0.9 && iGen.pt()/iPhoton.pt() < 1.1) ){
               photonMatchGenE = true;
             }
           }
@@ -348,9 +348,9 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
   }// end loop over candidate photons
   bool foundGenPrompt = false;
   if (genParticles.isValid()){
-    for(View<reco::GenParticle>::const_iterator iGen = genParticles->begin(); iGen != genParticles->end(); ++iGen){  
-      if( iGen->pdgId() == 22 && ( ( iGen->status() / 10 ) == 2 || iGen->status() == 1 || iGen->status() == 2 ) ){
-        if( iGen->pt() > 40.0 && (abs(iGen->mother()->pdgId()) <= 100 || abs(iGen->mother()->pdgId()) == 2212 ) ){
+    for(const auto& iGen : *genParticles){
+      if( iGen.pdgId() == 22 && ( ( iGen.status() / 10 ) == 2 || iGen.status() == 1 || iGen.status() == 2 ) ){
+        if( iGen.pt() > 40.0 && (abs(iGen.mother()->pdgId()) <= 100 || abs(iGen.mother()->pdgId()) == 2212 ) ){
           foundGenPrompt = true;
           break;
         }//if there is a photon with pt > 40 and its parent PdgID <=100, then consider the event as having a hard scattered photon.

--- a/Utils/src/PmssmProducer.cc
+++ b/Utils/src/PmssmProducer.cc
@@ -26,11 +26,11 @@
 class PmssmProducer : public edm::global::EDProducer<> {
 public:
   explicit PmssmProducer(const edm::ParameterSet&);
-  ~PmssmProducer();
+  ~PmssmProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
   edm::GetterOfProducts<LHEEventProduct> getterOfProducts_;

--- a/Utils/src/PrescaleWeightProducer.cc
+++ b/Utils/src/PrescaleWeightProducer.cc
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <vector>
 #include <map>
-#include <stdlib.h> 
+#include <cstdlib> 
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -43,11 +43,11 @@ using namespace edm;
 class PrescaleWeightProducer: public edm::global::EDProducer<> {
 public:
   explicit PrescaleWeightProducer(const edm::ParameterSet&);
-  ~PrescaleWeightProducer();
+  ~PrescaleWeightProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   edm::EDGetTokenT<edm::TriggerResults> _triggerBits;
   edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> _triggerObjects;
@@ -90,7 +90,7 @@ void PrescaleWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
   double mht = 0.0;
 
   for (unsigned int i = 0; i < triggerBits->size(); i++) {
-    const string trigName = trigNames.triggerName(i);
+    const string& trigName = trigNames.triggerName(i);
     size_t found;
     found = trigName.find("HLT_PFHT");
     if (found == string::npos)

--- a/Utils/src/PrimaryVerticesInt.cc
+++ b/Utils/src/PrimaryVerticesInt.cc
@@ -38,12 +38,12 @@
 class PrimaryVerticesInt : public edm::global::EDProducer<> {
 public:
 	explicit PrimaryVerticesInt(const edm::ParameterSet&);
-	~PrimaryVerticesInt();
+	~PrimaryVerticesInt() override;
 	
 	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
 private:
-	virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+	void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 	// ----------member data ---------------------------
 	edm::InputTag vertexCollectionTag_;

--- a/Utils/src/SubJetSelection.cc
+++ b/Utils/src/SubJetSelection.cc
@@ -44,12 +44,12 @@ template <class T>
 class SubJetSelectionT : public edm::global::EDProducer<> {
 public:
    explicit SubJetSelectionT(const edm::ParameterSet&);
-   ~SubJetSelectionT();
+   ~SubJetSelectionT() override;
    
    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
    
 private:
-   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
    
    // ----------member data ---------------------------
    edm::InputTag JetTag_;

--- a/Utils/src/SusyScanProducer.cc
+++ b/Utils/src/SusyScanProducer.cc
@@ -26,13 +26,13 @@
 class SusyScanProducer : public edm::stream::EDProducer<> {
 	public:
 		explicit SusyScanProducer(const edm::ParameterSet&);
-		~SusyScanProducer();
+		~SusyScanProducer() override;
 		static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 	private:
-		virtual void produce(edm::Event&, const edm::EventSetup&) override;
+		void produce(edm::Event&, const edm::EventSetup&) override;
 		
-		virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+		void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 		
 		void getModelInfo(std::string comment);
 		

--- a/Utils/src/TrackIsolationFilter.cc
+++ b/Utils/src/TrackIsolationFilter.cc
@@ -64,10 +64,10 @@ using namespace std;
 class TrackIsolationFilter : public edm::global::EDFilter<> {
 public:
      explicit TrackIsolationFilter (const edm::ParameterSet&);
-     ~TrackIsolationFilter();
+     ~TrackIsolationFilter() override;
 
 private:
-  virtual bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
+  bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 
   // ----------member data ---------------------------
   double dR_;
@@ -162,7 +162,7 @@ bool TrackIsolationFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 	edm::Handle<edm::View<reco::Vertex> > vertices;
 	iEvent.getByToken(vertexInputTok_, vertices);
 	bool hasGoodVtx = false;
-	if(vertices->size() > 0) hasGoodVtx = true;
+	if(!vertices->empty()) hasGoodVtx = true;
 	
 	//-------------------------------------------------------------------------------------------------
 	// loop over PFCandidates and calculate the trackIsolation and dz w.r.t. 1st good PV for each one
@@ -254,7 +254,7 @@ bool TrackIsolationFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 		prodminiAOD->push_back( pfCand );
 	}
 
-	bool result = (doTrkIsoVeto_ ? (prodminiAOD->size() == 0) : true);
+	bool result = (doTrkIsoVeto_ ? (prodminiAOD->empty()) : true);
 	
 	int isoTracks=prodminiAOD->size();
 	auto htp = std::make_unique<int>(isoTracks);

--- a/Utils/src/TriggerProducer.cc
+++ b/Utils/src/TriggerProducer.cc
@@ -41,12 +41,12 @@
 class TriggerProducer : public edm::global::EDProducer<> {
 public:
   explicit TriggerProducer(const edm::ParameterSet&);
-  ~TriggerProducer();
+  ~TriggerProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
   void GetInputTag(edm::InputTag& tag, std::string arg1, std::string arg2, std::string arg3, std::string arg1_default);

--- a/Utils/src/ZProducer.cc
+++ b/Utils/src/ZProducer.cc
@@ -15,7 +15,7 @@ class ZProducer : public edm::global::EDProducer<> {
 public:
 	explicit ZProducer(const edm::ParameterSet&);
 private:
-   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
    edm::InputTag ElectronTag_;
    edm::InputTag MuonTag_;
    edm::EDGetTokenT<std::vector<pat::Electron>> ElectronTok_;
@@ -43,12 +43,12 @@ void ZProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup
    const std::vector<pat::Electron> * electrons = electronHandle.product();
    for (std::vector<pat::Electron>::const_iterator iL1 = electrons->begin(); iL1 != electrons->end(); ++iL1) {
       if (iL1->charge() > 0) {
-         for (std::vector<pat::Electron>::const_iterator iL2 = electrons->begin(); iL2 != electrons->end(); ++iL2) {
-            if (iL2->charge() < 0) {
+         for (const auto & electron : *electrons) {
+            if (electron.charge() < 0) {
                pat::CompositeCandidate theZ;
-               theZ.setP4(iL1->p4()+ iL2->p4());
+               theZ.setP4(iL1->p4()+ electron.p4());
                theZ.addDaughter(*iL1, "positive electron daughter");
-               theZ.addDaughter(*iL2, "negative electron daughter");
+               theZ.addDaughter(electron, "negative electron daughter");
                ZCandidates->push_back(theZ);
             }
          }
@@ -61,12 +61,12 @@ void ZProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup
    const std::vector<pat::Muon> * muons = muonHandle.product();
    for (std::vector<pat::Muon>::const_iterator iL1 = muons->begin(); iL1 != muons->end(); ++iL1) {
       if (iL1->charge() > 0) {
-         for (std::vector<pat::Muon>::const_iterator iL2 = muons->begin(); iL2 != muons->end(); ++iL2) {
-            if (iL2->charge() < 0) {
+         for (const auto & muon : *muons) {
+            if (muon.charge() < 0) {
                pat::CompositeCandidate theZ;
-               theZ.setP4(iL1->p4()+iL2->p4());
+               theZ.setP4(iL1->p4()+muon.p4());
                theZ.addDaughter(*iL1, "positive muon daughter");
-               theZ.addDaughter(*iL2, "negative muon daughter");
+               theZ.addDaughter(muon, "negative muon daughter");
                ZCandidates->push_back(theZ);
             }
          }

--- a/WeightProducer/src/NeffFinder.cc
+++ b/WeightProducer/src/NeffFinder.cc
@@ -19,13 +19,13 @@
 class NeffFinder: public edm::one::EDAnalyzer<> {
 	public:
 		explicit NeffFinder(const edm::ParameterSet&);
-		~NeffFinder();
+		~NeffFinder() override;
 		static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 	private:
-		virtual void beginJob();
-		virtual void analyze(const edm::Event&, const edm::EventSetup&);
-		virtual void endJob();
+		void beginJob() override;
+		void analyze(const edm::Event&, const edm::EventSetup&) override;
+		void endJob() override;
 	
 		//member variables
 		std::string name;

--- a/WeightProducer/src/WeightProducer.cc
+++ b/WeightProducer/src/WeightProducer.cc
@@ -51,10 +51,10 @@
 class WeightProducer: public edm::global::EDProducer<> {
 public:
   explicit WeightProducer(const edm::ParameterSet&);
-  ~WeightProducer();
+  ~WeightProducer() override;
   
 private:
-  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
   enum weight_method { StartWeight = 0, FromEvent = 1, Constant = 2, FastSim = 3, other = 4 };
   
@@ -86,7 +86,7 @@ WeightProducer::WeightProducer(const edm::ParameterSet& iConfig) :
    _genEvtTag(edm::InputTag("generator")),
    _puInfoTag(edm::InputTag("slimmedAddPileupInfo")),
    _SusyMotherTag(iConfig.getParameter<edm::InputTag> ("modelIdentifier")),
-   pu_central(0), pu_up(0), pu_down(0), _weightingMethod(other)
+   pu_central(nullptr), pu_up(nullptr), pu_down(nullptr), _weightingMethod(other)
 {
    // Option 1: weight constant, as defined in cfg file
    if (_startWeight >= 0) {
@@ -121,7 +121,7 @@ WeightProducer::WeightProducer(const edm::ParameterSet& iConfig) :
       //setup xsec map
       std::string inputXsecName = iConfig.getParameter<std::string> ("XsecFile");
 	  bool foundXsec = true;
-      if(inputXsecName.size()>0){
+      if(!inputXsecName.empty()){
          edm::FileInPath fileXsec(inputXsecName);
          std::ifstream infile(fileXsec.fullPath().c_str());
          if(infile.is_open()){
@@ -168,11 +168,11 @@ WeightProducer::WeightProducer(const edm::ParameterSet& iConfig) :
         << "  Reading PU scenario from '" << filePUDataDistr.fullPath() << "'";
       TFile* file = TFile::Open(filePUDataDistr.fullPath().c_str(), "READ");
       pu_central = (TH1*)file->Get("pu_weights_central");
-      if(pu_central) pu_central->SetDirectory(0);
+      if(pu_central) pu_central->SetDirectory(nullptr);
       pu_up = (TH1*)file->Get("pu_weights_up");
-      if(pu_up) pu_up->SetDirectory(0);
+      if(pu_up) pu_up->SetDirectory(nullptr);
       pu_down = (TH1*)file->Get("pu_weights_down");
-      if(pu_down) pu_down->SetDirectory(0);
+      if(pu_down) pu_down->SetDirectory(nullptr);
 
       if(!pu_central || !pu_up || !pu_down) {
          edm::LogWarning("TreeMaker") << "ERROR in WeightProducer: Pileup histograms missing from file '" << filePUDataDistr.fullPath();


### PR DESCRIPTION
CMSSW can run code checks via clang-tidy in scram. The default list is here:
https://github.com/cms-sw/cmssw/blob/master/.clang-tidy

I added a few more: `cppcoreguidelines-pro-type-member-init, modernize-loop-convert`

and then ran over TreeMaker source code as follows:
```
touch TreeMakerCode.txt
find TreeMaker/ -name "*.h" >> TreeMakerCode.txt
find TreeMaker/ -name "*.cc" >> TreeMakerCode.txt
env USER_CODE_CHECKS_FILE=TreeMakerCode.txt scram b code-checks
```

The code is automatically updated to conform to the specified code checks.

A few caveats about `modernize-loop-convert`:
* doesn't always use `const` where it could
* sometimes chooses unclear names for loop variables
* doesn't seem to recognize range-based loops for `edm::View` types

I dealt with these few issues by hand.
