### PR TITLE
New approach for storing jet systematic information

### DIFF
--- a/TreeMaker/python/doHadTauBkg.py
+++ b/TreeMaker/python/doHadTauBkg.py
@@ -4,7 +4,7 @@ def makeJetVarsHadTau(self,process,JetTag,suff,storeProperties=0):
     # clone GoodJetsProducer
     GoodJetsForHadTau = process.GoodJets.clone(
         JetTag = JetTag,
-        jetPtFilter = cms.double(30),
+        jetPtFilter = cms.double(10),
         invertJetPtFilter = cms.bool(True),
         SaveAllJetsId = cms.bool(True),
         SaveAllJetsPt = cms.bool(False), # save only jets *below* pt cut

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -192,7 +192,6 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         suff=postfix,
         skipGoodJets=False,
         storeProperties=1,
-        systematic=True,
     )
 
     from TreeMaker.Utils.metdouble_cfi import metdouble

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -192,6 +192,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         suff=postfix,
         skipGoodJets=False,
         storeProperties=1,
+        systematic=True,
     )
 
     from TreeMaker.Utils.metdouble_cfi import metdouble

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -7,13 +7,13 @@ def makeGoodJets(self, process, JetTag, suff, storeProperties, systematic=False,
     GoodJets = GoodJetsProducer.clone(
         TagMode                   = cms.bool(True),
         JetTag                    = JetTag,
-        # keep lower-pt central jets in case they fluctuate up in systematic collections
-        jetPtFilter               = cms.double(170 if jetConeSize==0.8 else 30 if systematic else 0),
+        jetPtFilter               = cms.double(170 if jetConeSize==0.8 else 30),
         ExcludeLepIsoTrackPhotons = cms.bool(True),
         JetConeSize               = cms.double(jetConeSize),
         SkipTag                   = SkipTag,
         SaveAllJetsId             = True,
-        SaveAllJetsPt             = False, # exclude low pt jets from good collection
+        # keep lower-pt central jets in case they fluctuate up in systematic collections (only for AK4)
+        SaveAllJetsPt             = (jetConeSize==0.4),
     )
     TMeras.TM2017.toModify(GoodJets,
         maxNeutralFraction        = cms.double(0.90),
@@ -27,8 +27,8 @@ def makeGoodJets(self, process, JetTag, suff, storeProperties, systematic=False,
     setattr(process,"GoodJets"+suff,GoodJets)
     GoodJetsTag = cms.InputTag("GoodJets"+suff)
     self.VarsBool.extend(['GoodJets'+suff+':JetID(JetID'+suff+')'])
-    self.VectorRecoCand.extend(['GoodJets'+suff+'(Jets'+suff+')'])
     if storeProperties>0:
+        self.VectorRecoCand.extend(['GoodJets'+suff+'(Jets'+suff+')'])
         self.VectorBool.extend(['GoodJets'+suff+':JetIDMask(Jets'+suff+'_ID)'])
         if len(SkipTag)>0: self.VectorBool.extend(['GoodJets'+suff+':JetLeptonMask(Jets'+suff+'_LeptonMask)'])
     return (process,GoodJetsTag)

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from TreeMaker.TreeMaker.addJetInfo import addJetInfo
 
-def makeGoodJets(self, process, JetTag, suff, storeProperties, systematic=False, SkipTag=cms.VInputTag(), jetConeSize=0.4):
+def makeGoodJets(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInputTag(), jetConeSize=0.4):
     from TreeMaker.TreeMaker.TMEras import TMeras
     from TreeMaker.Utils.goodjetsproducer_cfi import GoodJetsProducer
     GoodJets = GoodJetsProducer.clone(
@@ -37,14 +37,14 @@ def makeGoodJets(self, process, JetTag, suff, storeProperties, systematic=False,
 # 0 = goodJets and scalars (+ origIndex for syst)
 # 1 = 0 + masks, minimal set of properties
 # 2 = all properties
-def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, systematic=False, SkipTag=cms.VInputTag(), onlyGoodJets=False):
+def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, SkipTag=cms.VInputTag(), onlyGoodJets=False):
     ## ----------------------------------------------------------------------------------------------
     ## GoodJets
     ## ----------------------------------------------------------------------------------------------
     if skipGoodJets:
         GoodJetsTag = JetTag
     else:
-        process, GoodJetsTag = self.makeGoodJets(process,JetTag,suff,storeProperties,systematic,SkipTag,0.4)
+        process, GoodJetsTag = self.makeGoodJets(process,JetTag,suff,storeProperties,SkipTag,0.4)
         if onlyGoodJets:
             return process
     
@@ -153,7 +153,8 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, syst
     ## ----------------------------------------------------------------------------------------------
     ## Jet properties
     ## ----------------------------------------------------------------------------------------------
-    if storeProperties==0 and systematic:
+    if storeProperties==0:
+        # for systematics
         JetProperties = cms.EDProducer("JetProperties",
             JetTag = GoodJetsTag,
             debug = cms.bool(False),

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -585,7 +585,6 @@ def makeTreeFromMiniAOD(self,process):
                               suff='JECup',
                               skipGoodJets=False,
                               storeProperties=0,
-                              systematic=True,
                               SkipTag=SkipTag
         )
         
@@ -601,7 +600,6 @@ def makeTreeFromMiniAOD(self,process):
                               suff='JECdown',
                               skipGoodJets=False,
                               storeProperties=0,
-                              systematic=True,
                               SkipTag=SkipTag
         )
 
@@ -617,7 +615,6 @@ def makeTreeFromMiniAOD(self,process):
                               suff='JERup',
                               skipGoodJets=False,
                               storeProperties=0,
-                              systematic=True,
                               SkipTag=SkipTag
         )
         
@@ -633,7 +630,6 @@ def makeTreeFromMiniAOD(self,process):
                               suff='JERdown',
                               skipGoodJets=False,
                               storeProperties=0,
-                              systematic=True,
                               SkipTag=SkipTag
         )
 

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -584,7 +584,8 @@ def makeTreeFromMiniAOD(self,process):
                               JetTag=JetTagJECup,
                               suff='JECup',
                               skipGoodJets=False,
-                              storeProperties=1,
+                              storeProperties=0,
+                              systematic=True,
                               SkipTag=SkipTag
         )
         
@@ -599,7 +600,8 @@ def makeTreeFromMiniAOD(self,process):
                               JetTag=JetTagJECdown,
                               suff='JECdown',
                               skipGoodJets=False,
-                              storeProperties=1,
+                              storeProperties=0,
+                              systematic=True,
                               SkipTag=SkipTag
         )
 
@@ -614,7 +616,8 @@ def makeTreeFromMiniAOD(self,process):
                               JetTag=JetTagJERup,
                               suff='JERup',
                               skipGoodJets=False,
-                              storeProperties=1,
+                              storeProperties=0,
+                              systematic=True,
                               SkipTag=SkipTag
         )
         
@@ -629,7 +632,8 @@ def makeTreeFromMiniAOD(self,process):
                               JetTag=JetTagJERdown,
                               suff='JERdown',
                               skipGoodJets=False,
-                              storeProperties=1,
+                              storeProperties=0,
+                              systematic=True,
                               SkipTag=SkipTag
         )
 

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -111,6 +111,7 @@ class NamedPtr_I : public NamedPtr<int> {
 		void get_property(const pat::Jet* Jet) override { push_back(Jet->userInt(extraInfo.at(0))); }
 };
 DEFAULT_NAMED_PTR(I,multiplicity);
+DEFAULT_NAMED_PTR(I,origIndex);
 
 // specialized helper classes (for non-userfloats)
 

--- a/Utils/src/JetUncertaintyProducer.cc
+++ b/Utils/src/JetUncertaintyProducer.cc
@@ -64,18 +64,16 @@ void JetUncertaintyProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 	auto jecUncVec  = std::make_unique<std::vector<double>>();
 	jecUncVec->reserve(jets->size());
 
-	for (edm::View<pat::Jet>::const_iterator itJet = jets->begin(); itJet != jets->end(); itJet++) {
+	for (unsigned idx = 0; idx < jets->size(); ++idx) {
 		// construct the Jet from the ref -> save ref to original object
-		unsigned int idx = std::distance(jets->begin(),itJet);
-		edm::RefToBase<pat::Jet> jetRef = jets->refAt(idx);
 		edm::Ptr<pat::Jet> jetPtr = jets->ptrAt(idx);
 		pat::Jet ajet(jetPtr);
 		math::XYZTLorentzVector vjet = ajet.p4();
 		ajet.addUserInt("origIndex",idx);
 
 		//get JEC unc for this jet, using corrected pT
-		jecUnc->setJetEta(itJet->eta());
-		jecUnc->setJetPt(itJet->pt());
+		jecUnc->setJetEta(jets->at(idx).eta());
+		jecUnc->setJetPt(jets->at(idx).pt());
 		double uncertainty = jecUnc->getUncertainty(true);
 		//safety check if uncertainty is not available for a jet
 		if(uncertainty==-999.) uncertainty = 0;

--- a/Utils/src/JetUncertaintyProducer.cc
+++ b/Utils/src/JetUncertaintyProducer.cc
@@ -71,7 +71,8 @@ void JetUncertaintyProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 		edm::Ptr<pat::Jet> jetPtr = jets->ptrAt(idx);
 		pat::Jet ajet(jetPtr);
 		math::XYZTLorentzVector vjet = ajet.p4();
-		
+		ajet.addUserInt("origIndex",idx);
+
 		//get JEC unc for this jet, using corrected pT
 		jecUnc->setJetEta(itJet->eta());
 		jecUnc->setJetPt(itJet->pt());

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ eval `scramv1 runtime -sh`
 git cms-init
 git cms-merge-topic -u TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_9_4_2
 git cms-merge-topic -u TreeMaker:MET_942_FixEGdR
-git cms-merge-topic -u TreeMaker:storeJERFactor942
+git cms-merge-topic -u TreeMaker:storeJERFactorIndex942
 git cms-merge-topic -u TreeMaker:AddJetAxis1_942
 git cms-merge-topic -u TreeMaker:NjettinessAxis_942
 git clone git@github.com:TreeMaker/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X


### PR DESCRIPTION
Brief ntuple size (kB/event) history:

| Type | V12 | V14 | V15a | V15b |
|--------|------:|-----:|-----:|-----:|
| MC (ttbar) | 6.3 | 5.5 | 9.0 | 5.5 |
| Data (MET) | 1.6 | 1.0 | ? | ? |

From V12 to V14, we stopped storing the soft jets (pT < 30 GeV).

For the upcoming V15, keeping 5 copies of all of the AK4 jet properties (vector branches) ends up taking a significant amount of space (see V15a). (Previously, we only kept a few property branches, but now more are needed e.g. for top tagging or b-tagging studies.)

Instead, we can store the list of original indices for the systematically varied jet collections (which get resorted by pT), which removes the need to duplicate the property branches. For a further optimization, we don't even need to store the 4-vectors for the systematic collections (saving 0.5 kB/evt), because we already store the JEC and JER uncertainty factors (which can easily be used to rescale the central 4-vectors). This way, the most novel operation (sorting the jet collection) doesn't have to be repeated, but no information is duplicated. (We still keep the scalar computed quantities, like NJets etc., which also involve some potentially nontrivial computations.)

However, to make this work, we once again need to store all the jets down to the miniAOD cut of pT > 10 GeV. This causes the size of the central jets collection to increase substantially, but there's still an overall saving by eliminating the systematic collections (see V15b). It also enables studies with lower-pT jets, which may be desired by some analyses. (I tried just going down to pT > 20 GeV, but there are still some jets below 20 GeV that can fluctuate up above 30 GeV with the systematics.)

Another consideration is data vs MC. In V12 we have approximately 2x as many data events compared to MC. We don't store systematic variations for data, so including the soft jets down to 10 GeV will just increase the size. But even if we assume the data event size goes back to 1.6 kB, the MC size decreases enough that we save space overall. It is probably worthwhile to have consistent pT cuts in data and MC to avoid confusion. We should double-check this once we have 94X miniAODv2 data files available.