### PR TITLE
add puppi speedup branch to setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,7 @@ git cms-merge-topic -u TreeMaker:MET_942_FixEGdR
 git cms-merge-topic -u TreeMaker:storeJERFactorIndex942
 git cms-merge-topic -u TreeMaker:AddJetAxis1_942
 git cms-merge-topic -u TreeMaker:NjettinessAxis_942
+git cms-merge-topic -u TreeMaker:SpeedupPuppi948
 git clone git@github.com:TreeMaker/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X
 git clone git@github.com:kpedro88/CondorProduction.git Condor/Production  
 git clone git@github.com:${FORK}/TreeMaker.git -b ${BRANCH}


### PR DESCRIPTION
see https://github.com/cms-sw/cmssw/pull/23270 for details

In the future, we should study if reusing the default miniAOD puppi weights is sufficient for the Zinv background estimation in the H(bb)+MET analysis (even though a photon or dilepton is removed from the PF candidate collection).