### PR TITLE
Deep ak8 mitigations 2018

### DIFF
--- a/Production/test/condorSub/.prodconfig
+++ b/Production/test/condorSub/.prodconfig
@@ -3,6 +3,6 @@ dir = .
 [submit]
 input = 2018A,2018B
 [caches]
-$CMSSW_BASE/src/NNKit/misc = 1
+$CMSSW_BASE/src/NNKit/misc/lib = 1
 $CMSSW_BASE/src/NNKit/data = 1
 $CMSSW_BASE/test = 1

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -30,13 +30,6 @@ echo "PROCESS:    $PROCESS"
 echo "REDIR:      $REDIR"
 echo ""
 
-ls -l $CMSSW_BASE/external/slc6_amd64_gcc630/lib/
-ls -l /cvmfs/cms-lpc.opensciencegrid.org/sl6/opt/
-LSEXIT=$?
-if [[ $LSEXIT -ne 0 ]]; then
-	exit $LSEXIT
-fi
-
 # link files from CMSSW dir
 ln -s ${CMSSWVER}/src/TreeMaker/Production/test/data
 ln -s ${CMSSWVER}/src/TreeMaker/Production/test/runMakeTreeFromMiniAOD_cfg.py

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -30,6 +30,13 @@ echo "PROCESS:    $PROCESS"
 echo "REDIR:      $REDIR"
 echo ""
 
+ls -l $CMSSW_BASE/external/slc6_amd64_gcc630/lib/
+ls -l /cvmfs/cms-lpc.opensciencegrid.org/sl6/opt/
+LSEXIT=$?
+if [[ $LSEXIT -ne 0 ]]; then
+	exit $LSEXIT
+fi
+
 # link files from CMSSW dir
 ln -s ${CMSSWVER}/src/TreeMaker/Production/test/data
 ln -s ${CMSSWVER}/src/TreeMaker/Production/test/runMakeTreeFromMiniAOD_cfg.py

--- a/Utils/src/DeepAK8Producer.cc
+++ b/Utils/src/DeepAK8Producer.cc
@@ -73,13 +73,22 @@ void DeepAK8Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         // Run the NN predictions
         deepntuples::JetHelper jet_helper(&fatjet);
         const auto& nnpreds = fatjetNN_->predict(jet_helper);
-        deepntuples::FatJetNNHelper nn(nnpreds);
+        if(nnpreds.size()>0){
+            deepntuples::FatJetNNHelper nn(nnpreds);
         
-        // Get the scores
-        tDiscriminatorDeep.push_back(nn.get_binarized_score_top());
-        wDiscriminatorDeep.push_back(nn.get_binarized_score_w());
-        zDiscriminatorDeep.push_back(nn.get_binarized_score_z());
-        hDiscriminatorDeep.push_back(nn.get_binarized_score_hbb());
+            // Get the scores
+            tDiscriminatorDeep.push_back(nn.get_binarized_score_top());
+            wDiscriminatorDeep.push_back(nn.get_binarized_score_w());
+            zDiscriminatorDeep.push_back(nn.get_binarized_score_z());
+            hDiscriminatorDeep.push_back(nn.get_binarized_score_hbb());
+        }
+        else {
+            // dummy scores
+            tDiscriminatorDeep.push_back(-1);
+            wDiscriminatorDeep.push_back(-1);
+            zDiscriminatorDeep.push_back(-1);
+            hDiscriminatorDeep.push_back(-1);
+        }
     }
 
     // Make userfloat maps

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,7 @@ usage(){
 	echo "-b [branch]         clone specified branch (default = Run2_2018_prompt)"
 	echo "-a [protocol]       use protocol to clone (default = ssh, alternative = https)"
 	echo "-j [cores]          run CMSSW compilation on # cores (default = 8)"
+	echo "-l                  link to mxnet library from cvmfs (default = use local version)"
 	echo "-h                  display this message and exit"
 
 	exit $EXIT
@@ -18,9 +19,10 @@ FORK=TreeMaker
 BRANCH=Run2_2018_prompt
 ACCESS=ssh
 CORES=8
+LINKMXNET=""
 
 # process options
-while getopts "f:b:a:j:h" opt; do
+while getopts "f:b:a:j:lh" opt; do
 	case "$opt" in
 	f) FORK=$OPTARG
 	;;
@@ -29,6 +31,8 @@ while getopts "f:b:a:j:h" opt; do
 	a) ACCESS=$OPTARG
 	;;
 	j) CORES=$OPTARG
+	;;
+	l) LINKMXNET=true
 	;;
 	h) usage 0
 	;;
@@ -60,8 +64,14 @@ git config gc.auto 0
 # DeepAK8 setup
 if [ "$ACCESS" = "https" ]; then echo "Needs your CERN username and password: NNKit is being cloned from gitlab"; fi
 git clone ${ACCESS_GITLAB}TreeMaker/NNKit.git -b avoid_exceptions
-cp /cvmfs/cms-lpc.opensciencegrid.org/sl6/opt/mxnet-1.1.0/mxnet_predict.xml $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected
-scram setup mxnet_predict
+if [ -n "$LINKMXNET" ]; then
+	cp /cvmfs/cms-lpc.opensciencegrid.org/sl6/opt/mxnet-1.1.0/mxnet_predict.xml $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected
+	scram setup mxnet_predict
+else
+	cp NNKit/misc/mxnet_predict.xml $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected
+	scram setup mxnet_predict
+	cp --remove-destination NNKit/misc/lib/libmxnet_predict.so $CMSSW_BASE/external/$SCRAM_ARCH/lib/libmxnet_predict.so
+fi
 
 # CMSSW patches
 git cms-merge-topic TreeMaker:JERFormula1017 # this one has dependencies (will be included in next 94X)

--- a/setup.sh
+++ b/setup.sh
@@ -59,7 +59,7 @@ git config gc.auto 0
 
 # DeepAK8 setup
 if [ "$ACCESS" = "https" ]; then echo "Needs your CERN username and password: NNKit is being cloned from gitlab"; fi
-git clone ${ACCESS_GITLAB}TreeMaker/NNKit.git -b cmssw-improvements
+git clone ${ACCESS_GITLAB}TreeMaker/NNKit.git -b avoid_exceptions
 cp /cvmfs/cms-lpc.opensciencegrid.org/sl6/opt/mxnet-1.1.0/mxnet_predict.xml $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected
 scram setup mxnet_predict
 


### PR DESCRIPTION
A few issues have been encountered with DeepAK8 while running central production for 2018 prompt data:
1. Many sites do not have `autofs` running or configured correctly, so they can't mount the LPC cvmfs area. The empirically identified list of sites is:
```
T1_FR_CCIN2P3,T1_ES_PIC,T1_IT_CNAF,T1_RU_JINR,T2_BE_IIHE,T2_BR_SPRACE,T2_CH_CSCS,T2_CH_CSCS_HPC,T2_DE_RWTH,T2_FR_IPHC,T2_IN_TIFR,T2_IT_Legnaro,T2_IT_Rome,T2_EE_Estonia,T2_PL_Warsaw,T2_PT_NCG_Lisbon,T2_RU_JINR,T2_TW_NCHC,T2_UA_KIPT,T2_US_Florida,T2_US_MIT,T2_US_Vanderbilt,T3_CH_CERN_HelixNebula,T3_US_Colorado
```
Excluding all of these reduces the pool of available CPUs quite substantially. To that end, the local library installation will be used as default from now on (with cvmfs available as an alternative).
2. A number of files had exceptions "Error running forward!". These have been replaced with a LogError message and dummy output values. This may actually be a thread safety issue, because I couldn't reproduce it for a failing event when running in single-threaded mode. Needs further investigation.

At least some of these changes should be backported to Run2_2017 before starting that central production.