### PR TITLE
Move to CMSSW_9_4_9, MET fix, DeepAK8 updates, etc.

### DIFF
--- a/Production/test/condorSub/.prodconfig
+++ b/Production/test/condorSub/.prodconfig
@@ -4,5 +4,4 @@ dir = .
 input = 2017B,2017C,2017D,2017E,2017F
 [caches]
 $CMSSW_BASE/src/NNKit/misc = 1
-$CMSSW_BASE/src/NNKit/data = 1
 $CMSSW_BASE/test = 1

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following installation instructions assume the user wants to process 2016 or
 wget https://raw.githubusercontent.com/TreeMaker/TreeMaker/Run2_2017/setup.sh
 chmod +x setup.sh
 ./setup.sh
-cd CMSSW_9_4_8/src/
+cd CMSSW_9_4_9/src/
 cmsenv
 cd TreeMaker/Production/test
 ```

--- a/Reflex/src/classes.h
+++ b/Reflex/src/classes.h
@@ -15,7 +15,6 @@ namespace {
     edm::Wrapper<std::vector<TLorentzVector> > wvlv;
     edm::Wrapper<std::vector<std::vector<TLorentzVector> > > wvvlv;
     edm::Wrapper<std::vector<std::vector<double> > > wvvd;
-    edm::Wrapper<std::vector<std::vector<int> > > wvvi;
     edm::Wrapper<std::vector<std::vector<bool> > > wvvb;
 	edm::Wrapper<edm::PtrVector<pat::PackedCandidate> > wrv2pp;
   };

--- a/Reflex/src/classes_def.xml
+++ b/Reflex/src/classes_def.xml
@@ -7,7 +7,6 @@
   <class name="edm::Wrapper<std::vector<TLorentzVector> >"/>
   <class name="edm::Wrapper<std::vector<std::vector<TLorentzVector> > >"/>
   <class name="edm::Wrapper<std::vector<std::vector<double> > >"/>
-  <class name="edm::Wrapper<std::vector<std::vector<int> > >"/>
   <class name="edm::Wrapper<std::vector<std::vector<bool> > >"/>
   <class name="edm::Wrapper<edm::PtrVector<pat::PackedCandidate> >"/>
 </lcgdict>

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -144,6 +144,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
             reclusterJets=False, # without reclustering
             reapplyJEC=False,
             postfix=postfix+'Orig',
+            computeMETSignificance=False,
         )
         METTagOrig = cms.InputTag('slimmedMETs'+postfix+'Orig')
         MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"jets")

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -146,8 +146,10 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
             postfix=postfix+'Orig',
         )
         METTagOrig = cms.InputTag('slimmedMETs+postfix+'Orig')
+        MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"jets")
     else:
         METTagOrig = None
+        MHTJetTagExt = None
     
     # isolated tracks
     from TreeMaker.Utils.trackIsolationMaker_cfi import trackIsolationFilter
@@ -219,6 +221,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         suff=postfix,
         skipGoodJets=False,
         storeProperties=1,
+        MHTJetTagExt=MHTJetTagExt,
     )
 
     from TreeMaker.Utils.metdouble_cfi import metdouble

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -145,7 +145,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
             reapplyJEC=False,
             postfix=postfix+'Orig',
         )
-        METTagOrig = cms.InputTag('slimmedMETs+postfix+'Orig')
+        METTagOrig = cms.InputTag('slimmedMETs'+postfix+'Orig')
         MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise"+postfix,"jets")
     else:
         METTagOrig = None
@@ -236,6 +236,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         METcleanOrig = METclean.clone(
             METTag = METTagOrig
         )
+        setattr(process,"METclean"+suff+"Orig",METcleanOrig)
         self.VarsDouble.extend(['METclean'+suff+'Orig:Pt(METclean'+suff+'Orig)','METclean'+suff+'Orig:Phi(METPhiclean'+suff+'Orig)'])
 
     return process

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -130,9 +130,24 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         recoMetFromPFCs=True, # to recompute
         reclusterJets=False, # without reclustering
         reapplyJEC=False,
-        postfix=postfix
+        fixEE2017=self.doMETfix,
+        postfix=postfix,
     )
     METTag = cms.InputTag('slimmedMETs'+postfix)
+    if self.doMETfix:
+        runMetCorAndUncFromMiniAOD(
+            process,
+            isData=not self.geninfo, # controls gen met
+            jetCollUnskimmed='patJetsAK4PFCLEAN'+suff,
+            pfCandColl=cleanedCandidates.value(),
+            recoMetFromPFCs=True, # to recompute
+            reclusterJets=False, # without reclustering
+            reapplyJEC=False,
+            postfix=postfix+'Orig',
+        )
+        METTagOrig = cms.InputTag('slimmedMETs+postfix+'Orig')
+    else:
+        METTagOrig = None
     
     # isolated tracks
     from TreeMaker.Utils.trackIsolationMaker_cfi import trackIsolationFilter
@@ -213,6 +228,13 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     )
     setattr(process,"METclean"+suff,METclean)
     self.VarsDouble.extend(['METclean'+suff+':Pt(METclean'+suff+')','METclean'+suff+':Phi(METPhiclean'+suff+')','METclean'+suff+':Significance(METSignificanceclean'+suff+')'])
+
+    if self.doMETfix:
+        METcleanOrig = METclean.clone(
+            METTag = METTagOrig
+        )
+        self.VarsDouble.extend(['METclean'+suff+'Orig:Pt(METclean'+suff+'Orig)','METclean'+suff+'Orig:Phi(METPhiclean'+suff+'Orig)'])
+
     return process
 
 def doZinvBkg(self,process):

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -129,6 +129,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         pfCandColl=cleanedCandidates.value(),
         recoMetFromPFCs=True, # to recompute
         reclusterJets=False, # without reclustering
+        reapplyJEC=False,
         postfix=postfix
     )
     METTag = cms.InputTag('slimmedMETs'+postfix)

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -389,16 +389,28 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
                 "wDiscriminatorDeep",
                 "zDiscriminatorDeep",
                 "hDiscriminatorDeep",
+                "tDiscriminatorDeepDecorrel",
+                "wDiscriminatorDeepDecorrel",
+                "zDiscriminatorDeepDecorrel",
+                "hDiscriminatorDeepDecorrel",
             ])
             JetPropertiesAK8.tDiscriminatorDeep = cms.vstring('deepAK8:tDiscriminatorDeep')
             JetPropertiesAK8.wDiscriminatorDeep = cms.vstring('deepAK8:wDiscriminatorDeep')
             JetPropertiesAK8.zDiscriminatorDeep = cms.vstring('deepAK8:zDiscriminatorDeep')
             JetPropertiesAK8.hDiscriminatorDeep = cms.vstring('deepAK8:hDiscriminatorDeep')
+            JetPropertiesAK8.tDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel:tDiscriminatorDeep')
+            JetPropertiesAK8.wDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel:wDiscriminatorDeep')
+            JetPropertiesAK8.zDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel:zDiscriminatorDeep')
+            JetPropertiesAK8.hDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel:hDiscriminatorDeep')
             self.VectorDouble.extend([
                 'JetProperties'+suff+':tDiscriminatorDeep(Jets'+suff+'_tDiscriminatorDeep)',
                 'JetProperties'+suff+':wDiscriminatorDeep(Jets'+suff+'_wDiscriminatorDeep)',
                 'JetProperties'+suff+':zDiscriminatorDeep(Jets'+suff+'_zDiscriminatorDeep)',
                 'JetProperties'+suff+':hDiscriminatorDeep(Jets'+suff+'_hDiscriminatorDeep)',
+                'JetProperties'+suff+':tDiscriminatorDeepDecorrel(Jets'+suff+'_tDiscriminatorDeepDecorrel)',
+                'JetProperties'+suff+':wDiscriminatorDeepDecorrel(Jets'+suff+'_wDiscriminatorDeepDecorrel)',
+                'JetProperties'+suff+':zDiscriminatorDeepDecorrel(Jets'+suff+'_zDiscriminatorDeepDecorrel)',
+                'JetProperties'+suff+':hDiscriminatorDeepDecorrel(Jets'+suff+'_hDiscriminatorDeepDecorrel)',
             ])
 
         if storeProperties>1:

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -112,7 +112,7 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, Skip
     
     from TreeMaker.Utils.mhtdouble_cfi import mhtdouble
     MHT = mhtdouble.clone(
-        JetTag  = MHTJetTagExt if MHTJetTagExt is not None else MHTJetsTag,
+        JetTag  = MHTJetsTag,
     )
     setattr(process,"MHT"+suff,MHT)
     self.VarsDouble.extend(['MHT'+suff+':Pt(MHT'+suff+')','MHT'+suff+':Phi(MHTPhi'+suff+')'])
@@ -128,10 +128,8 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, Skip
 
     # keep orig MHT, dphi values if ext tag was given
     if MHTJetTagExt is not None:
-        MHTJetsOrig = SubJetSelection.clone(
+        MHTJetsOrig = MHTJets.clone(
             JetTag = JetTag,
-            MinPt  = cms.double(30),
-            MaxEta = cms.double(5.0),
         )
         setattr(process,"MHTJets"+suff+"Orig",MHTJetsOrig)
         if storeProperties>0: self.VectorBool.extend(['MHTJets'+suff+'Orig:SubJetMask(Jets'+suff+'_MHTOrig'+'Mask)'])

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -240,15 +240,9 @@ def makeTreeFromMiniAOD(self,process):
         runMetCorAndUncFromMiniAOD(
             process,
             isData=not self.geninfo, # controls gen met
+            reapplyJEC=False,
         )
         METTag = cms.InputTag('slimmedMETs','',process.name_())
-    else:
-        # pointless run of MET tool because it is barely functional
-        from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
-        runMetCorAndUncFromMiniAOD(
-            process,
-            isData=not self.geninfo, # controls gen met
-        )
 
     # keep jets before any further modifications for hadtau
     JetTagBeforeSmearing = JetTag

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -241,8 +241,21 @@ def makeTreeFromMiniAOD(self,process):
             process,
             isData=not self.geninfo, # controls gen met
             reapplyJEC=False,
+            fixEE2017=self.doMETfix,
         )
         METTag = cms.InputTag('slimmedMETs','',process.name_())
+
+        # additional run to keep orig values
+        if self.doMETfix:
+            runMetCorAndUncFromMiniAOD(
+                process,
+                isData=not self.geninfo, # controls gen met
+                reapplyJEC=False,
+                postfix="Orig"
+            )
+            METTagOrig = cms.InputTag('slimmedMETsOrig')
+        else:
+            METTagOrig = None
 
     # keep jets before any further modifications for hadtau
     JetTagBeforeSmearing = JetTag
@@ -822,6 +835,12 @@ def makeTreeFromMiniAOD(self,process):
     if self.geninfo:
         self.VarsDouble.extend(['MET:GenPt(GenMET)','MET:GenPhi(GenMETPhi)'])
         self.VectorDouble.extend(['MET:PtUp(METUp)', 'MET:PtDown(METDown)', 'MET:PhiUp(METPhiUp)', 'MET:PhiDown(METPhiDown)'])
+
+    if self.doMETfix:
+        process.METOrig = process.MET.clone(
+            METTag = METTagOrig
+        )
+        self.VarsDouble.extend(['METOrig:Pt(METOrig)','METOrig:Phi(METPhiOrig)'])
 
     from TreeMaker.Utils.mt2producer_cfi import mt2Producer
     process.Mt2Producer = mt2Producer.clone(

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -254,8 +254,10 @@ def makeTreeFromMiniAOD(self,process):
                 postfix="Orig"
             )
             METTagOrig = cms.InputTag('slimmedMETsOrig')
+            MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise","jets","process.name_())
         else:
             METTagOrig = None
+            MHTJetTagExt = None
 
     # keep jets before any further modifications for hadtau
     JetTagBeforeSmearing = JetTag
@@ -663,7 +665,8 @@ def makeTreeFromMiniAOD(self,process):
         suff='',
         skipGoodJets=False,
         storeProperties=2,
-        SkipTag=SkipTag
+        SkipTag=SkipTag,
+        MHTJetTagExt = MHTJetTagExt,
     )
     if self.geninfo and self.systematics:
         process.JetProperties.properties.extend(["jerFactorUp","jerFactorDown","jecUnc"])

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -715,11 +715,15 @@ def makeTreeFromMiniAOD(self,process):
 
     _floatsAK8 = []
     if self.deepAK8:
-        from TreeMaker.Utils.deepak8producer_cfi import DeepAK8Producer
+        from TreeMaker.Utils.deepak8producer_cfi import DeepAK8Producer, DeepAK8DecorrelProducer
         process.deepAK8 = DeepAK8Producer.clone(
             JetAK8 = JetAK8Tag
         )
-        _floatsAK8 = ['deepAK8:tDiscriminatorDeep','deepAK8:wDiscriminatorDeep','deepAK8:zDiscriminatorDeep','deepAK8:hDiscriminatorDeep']
+        _floatsAK8.extend(['deepAK8:tDiscriminatorDeep','deepAK8:wDiscriminatorDeep','deepAK8:zDiscriminatorDeep','deepAK8:hDiscriminatorDeep'])
+        process.deepAK8decorrel = DeepAK8DecorrelProducer.clone(
+            JetAK8 = JetAK8Tag
+        )
+        _floatsAK8.extend(['deepAK8decorrel:tDiscriminatorDeep','deepAK8decorrel:wDiscriminatorDeep','deepAK8decorrel:zDiscriminatorDeep','deepAK8decorrel:hDiscriminatorDeep'])
 
     # add discriminator and update tag
     process, JetAK8Tag = addJetInfo(process, JetAK8Tag, _floatsAK8, [], cms.VInputTag(cms.InputTag("pfBoostedDoubleSecondaryVertexAK8BJetTags")))

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -251,7 +251,8 @@ def makeTreeFromMiniAOD(self,process):
                 process,
                 isData=not self.geninfo, # controls gen met
                 reapplyJEC=False,
-                postfix="Orig"
+                postfix="Orig",
+                computeMETSignificance=False,
             )
             METTagOrig = cms.InputTag('slimmedMETsOrig')
             MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise","jets",process.name_())

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -254,7 +254,7 @@ def makeTreeFromMiniAOD(self,process):
                 postfix="Orig"
             )
             METTagOrig = cms.InputTag('slimmedMETsOrig')
-            MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise","jets","process.name_())
+            MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise","jets",process.name_())
         else:
             METTagOrig = None
             MHTJetTagExt = None

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -15,6 +15,9 @@ class maker:
         self.scenarioName=self.parameters.value("scenario","")
         from TreeMaker.Production.scenarios import Scenario
         self.scenario = Scenario(self.scenarioName)
+
+        # to keep track of MET fix, currently applied to all 2017 data and MC
+        self.doMETfix = ("Fall17" in self.scenarioName or "2017" in self.scenarioName)
         
         self.getParamDefault("verbose",True)
         self.getParamDefault("inputFilesConfig","")

--- a/Utils/python/deepak8producer_cfi.py
+++ b/Utils/python/deepak8producer_cfi.py
@@ -1,3 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-DeepAK8Producer = cms.EDProducer('DeepAK8Producer')
+DeepAK8Producer = cms.EDProducer('DeepAK8Producer',
+    JetTag = cms.InputTag("slimmedJetsAK8"),
+    datapath = cms.string("NNKit/data/ak8/full"),
+)
+
+DeepAK8DecorrelProducer = DeepAK8Producer.clone(
+    datapath = cms.string("NNKit/data/ak8/decorrelated"),
+)

--- a/Utils/src/DeepAK8Producer.cc
+++ b/Utils/src/DeepAK8Producer.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
 // new includes
 #include "NNKit/FatJetNN/interface/FatJetNN.h"
 #include "NNKit/FatJetNN/interface/FatJetNNHelper.h"
@@ -34,10 +35,11 @@ DeepAK8Producer::DeepAK8Producer(const edm::ParameterSet& iConfig) :
     // Initialize the FatJetNN class in the constructor
     auto cc = consumesCollector();
     fatjetNN_ = std::make_unique<deepntuples::FatJetNN>(iConfig, cc);
+    const auto& datapath_(iConfig.getParameter<std::string>("datapath"));
     // Load json for input variable transformation
-    fatjetNN_->load_json("data/preprocessing.json"); // use the full path or put the file in the current working directory (i.e., where you run cmsRun)
+    fatjetNN_->load_json(edm::FileInPath(datapath_+"/preprocessing.json").fullPath());
     // Load DNN model and parameter files
-    fatjetNN_->load_model("data/resnet-symbol.json", "data/resnet.params"); // use the full path or put the file in the current working directory (i.e., where you run cmsRun)
+    fatjetNN_->load_model(edm::FileInPath(datapath_+"/resnet-symbol.json").fullPath(), edm::FileInPath(datapath_+"/resnet.params").fullPath());
 
     // Declare what is produced
     produces<edm::ValueMap<float>>("tDiscriminatorDeep");

--- a/Utils/src/GoodJetsProducer.cc
+++ b/Utils/src/GoodJetsProducer.cc
@@ -171,6 +171,7 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
          if (!saveAllPt_ &&
               ( (!invertJetPtFilter_ && iJet.pt() <= jetPtFilter_) ||
                 (invertJetPtFilter_ && iJet.pt() > jetPtFilter_) ) ) continue;
+         if (!iJet.isPFJet()) continue;
          float neufrac=iJet.neutralHadronEnergyFraction();//gives raw energy in the denominator
          float phofrac=iJet.neutralEmEnergyFraction();//gives raw energy in the denominator
          float chgfrac=iJet.chargedHadronEnergyFraction();

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -107,6 +107,10 @@ DEFAULT_NAMED_PTR(D,tDiscriminatorDeep);
 DEFAULT_NAMED_PTR(D,wDiscriminatorDeep);
 DEFAULT_NAMED_PTR(D,zDiscriminatorDeep);
 DEFAULT_NAMED_PTR(D,hDiscriminatorDeep);
+DEFAULT_NAMED_PTR(D,tDiscriminatorDeepDecorrel);
+DEFAULT_NAMED_PTR(D,wDiscriminatorDeepDecorrel);
+DEFAULT_NAMED_PTR(D,zDiscriminatorDeepDecorrel);
+DEFAULT_NAMED_PTR(D,hDiscriminatorDeepDecorrel);
 
 class NamedPtr_I : public NamedPtr<int> {
 	public:

--- a/setup.sh
+++ b/setup.sh
@@ -70,6 +70,7 @@ git cms-merge-topic -u TreeMaker:storeJERFactorIndex942
 git cms-merge-topic -u TreeMaker:AddJetAxis1_942
 git cms-merge-topic -u TreeMaker:NjettinessAxis_948
 git cms-merge-topic -u TreeMaker:METFixEE2017_949
+git cms-merge-topic -u TreeMaker:SpeedupMETSig_949
 
 # outside repositories
 git clone ${ACCESS_GITHUB}TreeMaker/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X

--- a/setup.sh
+++ b/setup.sh
@@ -69,6 +69,7 @@ git cms-merge-topic -u TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from
 git cms-merge-topic -u TreeMaker:storeJERFactorIndex942
 git cms-merge-topic -u TreeMaker:AddJetAxis1_942
 git cms-merge-topic -u TreeMaker:NjettinessAxis_948
+git cms-merge-topic -u TreeMaker:METFixEE2017_949
 
 # outside repositories
 git clone ${ACCESS_GITHUB}TreeMaker/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X

--- a/setup.sh
+++ b/setup.sh
@@ -83,8 +83,3 @@ scram b -j ${CORES}
 # extra setup
 cd TreeMaker/Production/test/condorSub/
 python $CMSSW_BASE/src/Condor/Production/python/linkScripts.py
-DEEPDATA=${CMSSW_BASE}/src/NNKit/data/ak8/full
-TMDATA=${CMSSW_BASE}/src/TreeMaker/Production/test/data
-cp ${DEEPDATA}/preprocessing.json ${TMDATA}/
-cp ${DEEPDATA}/resnet-symbol.json ${TMDATA}/
-cp ${DEEPDATA}/resnet.params ${TMDATA}/

--- a/setup.sh
+++ b/setup.sh
@@ -49,7 +49,7 @@ fi
 # get CMSSW release
 export SCRAM_ARCH=slc6_amd64_gcc630
 # cmsrel
-CMSSWVER=CMSSW_9_4_8
+CMSSWVER=CMSSW_9_4_9
 scram project ${CMSSWVER}
 cd ${CMSSWVER}/src/
 # cmsenv
@@ -64,12 +64,10 @@ cp /cvmfs/cms-lpc.opensciencegrid.org/sl6/opt/mxnet-1.1.0/mxnet_predict.xml $CMS
 scram setup mxnet_predict
 
 # CMSSW patches
-git cms-merge-topic TreeMaker:JERFormula942 # this one has dependencies (will be included in next 94X)
 git cms-merge-topic -u TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_9_4_2
 git cms-merge-topic -u TreeMaker:storeJERFactorIndex942
 git cms-merge-topic -u TreeMaker:AddJetAxis1_942
 git cms-merge-topic -u TreeMaker:NjettinessAxis_948
-git cms-merge-topic -u TreeMaker:SpeedupPuppi948 # will be included in next 94X
 
 # outside repositories
 git clone ${ACCESS_GITHUB}TreeMaker/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_94X

--- a/setup.sh
+++ b/setup.sh
@@ -59,9 +59,10 @@ git config gc.auto 0
 
 # DeepAK8 setup
 if [ "$ACCESS" = "https" ]; then echo "Needs your CERN username and password: NNKit is being cloned from gitlab"; fi
-git clone ${ACCESS_GITLAB}TreeMaker/NNKit.git -b cmssw-improvements
-cp /cvmfs/cms-lpc.opensciencegrid.org/sl6/opt/mxnet-1.1.0/mxnet_predict.xml $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected
-scram setup mxnet_predict
+git clone ${ACCESS_GITLAB}TreeMaker/NNKit.git -b cmssw-improvements-2 --depth 1
+cp NNKit/misc/mxnet-predict.xml $CMSSW_BASE/config/toolbox/$SCRAM_ARCH/tools/selected
+scram setup mxnet-predict
+cp --remove-destination NNKit/misc/lib/libmxnetpredict.so $CMSSW_BASE/external/$SCRAM_ARCH/lib/libmxnetpredict.so
 
 # CMSSW patches
 git cms-merge-topic -u TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_9_4_2


### PR DESCRIPTION
CMSSW_9_4_9:
* JER and puppi speedups now included in base release, removed branches from setup

Bug fixes:
* reject all non-PF jets (in case new JECs move jets w/ pT < 170 above threshold)
* fix duplicated class dictionary for `vector<int>`

MET fix & other improvements:
* 2017F EE PF threshold MET fix implemented as option in MET tool, branch included in setup.sh
* The jet collection produced by the fix (excluding jets w/ pT < 75 GeV, 2.65 < |eta| < 3.139) can also be used to compute MHT
* MET fix applied by default for all 2017 MC and data, "orig" variables for MET, METPhi, MHT, MHTPhi, DeltaPhi1/2/3/4 are stored (and also for the corresponding Zinv clean variables)
* disabled JEC reapplication in the MET tool (we already do it)
* disabled reclustering when recomputing MET from candidates (we already did this previously - it was included in the 8_0_X version of the MET tool, but then lost or reverted in the 9_4_X version. I fixed it.)
* disabled unnecessary MET significance computations (not needed when we rerun the tool to get the "orig" values)
* sped up MET significance computation by ~40%

DeepAK8:
* moved to mxnet 1.2.1.mod1 w/ thread-local engine patch
* disable LPC cvmfs usage (not broadly available on the grid, library out of date)
* add decorrelated version of tagger and associated discriminators

Some notes on DeepAK8 performance:
* newest mxnet version is ~10-15% faster
* When the tagger is disabled, we get ~11 events/sec.
* When the tagger is enabled with the current configuration (run twice, once for full and once for decorrelated), we get ~6 events/sec. In other words, we spend ~40% of our CPU time per event just evaluating DeepAK8.
* According to a [presentation](https://indico.cern.ch/event/746010/contributions/3083337/attachments/1694525/2727184/deepAK8_cmssw_integration_RECOAT_20180727_hqu.pdf) in last week's reco meeting, DeepAK8 is only somewhat slower than DeepDoubleB (which we currently don't include). It's actually faster than DeepFlavour, because there are more AK4 jets than AK8 jets.
* We're currently not running DeepAK8 or DeepFlavour for the Zinv clean jets, so look forward to an even slower TreeMaker once somebody decides they really want to use these variables for an analysis. (Maybe we can run just the decorrelated DeepAK8 for Zinv, since stealth stop doesn't use Zinv variables.)