### PR TITLE
Reorganize AK8, add JEC info for data

### DIFF
--- a/Production/test/condorSub/.prodconfig
+++ b/Production/test/condorSub/.prodconfig
@@ -3,5 +3,5 @@ dir = .
 [submit]
 input = 2017B,2017C,2017D,2017E,2017F
 [caches]
-$CMSSW_BASE/src/NNKit/misc = 1
+$CMSSW_BASE/src/NNKit/misc/lib = 1
 $CMSSW_BASE/test = 1

--- a/TreeMaker/python/JetDepot.py
+++ b/TreeMaker/python/JetDepot.py
@@ -11,14 +11,14 @@ def JetDepot(process, JetTag, jecUncDir=0, storeJec=False, doSmear=True, jerUncD
 
     from TreeMaker.Utils.jetuncertainty_cfi import JetUncertaintyProducer
 
-    if jecUncDir!=0:
+    if jecUncDir!=0 or storeJec:
         #JEC unc up or down
         patJetsJEC = JetUncertaintyProducer.clone(
             JetTag = JetTagOut,
             jecUncDir = cms.int32(jecUncDir),
             storeUnc = cms.bool(storeJec),
         )
-        dir = "up" if jecUncDir>0 else "down"
+        dir = "up" if jecUncDir>0 else "down" if jecUncDir<0 else "unc"
         JetTagOut = cms.InputTag(JetTagOut.value()+"JEC"+dir)
         setattr(process,JetTagOut.value(),patJetsJEC)
 

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -45,6 +45,8 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         JetTag=JetAK8CleanTag,
         suff='AK8Clean',
         storeProperties=1,
+		doDeepAK8=False, # currently disabled
+		doDoubleB=False, # already done above
     )
 
     # update some userfloat names
@@ -59,9 +61,6 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     process.JetPropertiesAK8Clean.ecfN3b1 = cms.vstring('ak8PFJetsPuppiCleanSoftDropValueMap:nb1AK8PuppiCleanSoftDropN3')
     process.JetPropertiesAK8Clean.ecfN2b2 = cms.vstring('ak8PFJetsPuppiCleanSoftDropValueMap:nb2AK8PuppiCleanSoftDropN2')
     process.JetPropertiesAK8Clean.ecfN3b2 = cms.vstring('ak8PFJetsPuppiCleanSoftDropValueMap:nb2AK8PuppiCleanSoftDropN3')
-    # disable deepAK8
-    process.JetPropertiesAK8Clean.properties = cms.vstring([x for x in process.JetPropertiesAK8Clean.properties if "DiscriminatorDeep" not in x])
-    self.VectorDouble.setValue([x for x in self.VectorDouble if not ("JetPropertiesAK8Clean" in x and "DiscriminatorDeep" in x)])
 
     ### end AK8 detour
 

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -231,6 +231,7 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, Skip
             'JetProperties'+suff+':hadronFlavor(Jets'+suff+'_hadronFlavor)',
         ])
         if storeProperties>1:
+            JetProperties.properties.extend(["jecFactor"])
             self.VectorDouble.extend([
                 'JetProperties'+suff+':chargedEmEnergyFraction(Jets'+suff+'_chargedEmEnergyFraction)',
                 'JetProperties'+suff+':neutralEmEnergyFraction(Jets'+suff+'_neutralEmEnergyFraction)',
@@ -243,13 +244,13 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, Skip
                 'JetProperties'+suff+':ptD(Jets'+suff+'_ptD)',
                 'JetProperties'+suff+':axisminor(Jets'+suff+'_axisminor)',
                 'JetProperties'+suff+':axismajor(Jets'+suff+'_axismajor)',
+                'JetProperties'+suff+':jecFactor(Jets'+suff+'_jecFactor)',
             ])
             if self.geninfo:
-                JetProperties.properties.extend(["jerFactor","jecFactor"])
+                JetProperties.properties.extend(["jerFactor"])
                 JetProperties.jerFactor = cms.vstring("jerFactor")
                 self.VectorDouble.extend([
                     'JetProperties'+suff+':jerFactor(Jets'+suff+'_jerFactor)',
-                    'JetProperties'+suff+':jecFactor(Jets'+suff+'_jecFactor)',
                 ])
                 if self.systematics:
                     # account for central JER smearing

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -275,12 +275,74 @@ def makeJetVars(self, process, JetTag, suff, skipGoodJets, storeProperties, Skip
 # 1 = 0 + 4vecs, most properties
 # 2 = 1 + subjet properties + extra substructure
 # 3 = 2 + constituents (large)
-def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
+def makeJetVarsAK8(self, process, JetTag, suff, storeProperties, doDeepAK8=True, doDoubleB=True, CandTag=cms.InputTag("packedPFCandidates")):
+    # select good jets before anything else - eliminates bad AK8 jets (low pT, no constituents stored, etc.)
+    process, GoodJetsTag = self.makeGoodJets(process,JetTag,suff,storeProperties,jetConeSize=0.8)
+
+    # anything to be computed for AK8 jets
+    ak8floats = []
+    ak8ints = []
+    ak8tags = cms.VInputTag()
+
+    if doDoubleB:
+        # get double b-tagger (w/ miniAOD customizations)
+        from RecoBTag.ImpactParameter.pfImpactParameterAK8TagInfos_cfi import pfImpactParameterAK8TagInfos
+        pfImpactParameterAK8TagInfosMod = pfImpactParameterAK8TagInfos.clone(
+            primaryVertex = cms.InputTag("offlineSlimmedPrimaryVertices"),
+            candidates = CandTag,
+            jets = GoodJetsTag,
+        )
+        setattr(process,"pfImpactParameterAK8TagInfos"+suff,pfImpactParameterAK8TagInfosMod)
+        from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderAK8TagInfos_cfi import pfInclusiveSecondaryVertexFinderAK8TagInfos
+        pfInclusiveSecondaryVertexFinderAK8TagInfosMod = pfInclusiveSecondaryVertexFinderAK8TagInfos.clone(
+            extSVCollection = cms.InputTag("slimmedSecondaryVertices"),
+            trackIPTagInfos = cms.InputTag("pfImpactParameterAK8TagInfos"+suff),
+        )
+        setattr(process,"pfInclusiveSecondaryVertexFinderAK8TagInfos"+suff,pfInclusiveSecondaryVertexFinderAK8TagInfosMod)
+        from RecoBTag.SecondaryVertex.pfBoostedDoubleSVAK8TagInfos_cfi import pfBoostedDoubleSVAK8TagInfos
+        pfBoostedDoubleSVAK8TagInfosMod = pfBoostedDoubleSVAK8TagInfos.clone(
+            svTagInfos = cms.InputTag("pfInclusiveSecondaryVertexFinderAK8TagInfos"+suff),
+        )
+        setattr(process,"pfBoostedDoubleSVAK8TagInfos"+suff,pfBoostedDoubleSVAK8TagInfosMod)
+        from RecoBTag.SecondaryVertex.candidateBoostedDoubleSecondaryVertexAK8Computer_cfi import candidateBoostedDoubleSecondaryVertexAK8Computer
+        candidateBoostedDoubleSecondaryVertexAK8ComputerMod = candidateBoostedDoubleSecondaryVertexAK8Computer.clone()
+        setattr(process,"candidateBoostedDoubleSecondaryVertexAK8Computer"+suff,candidateBoostedDoubleSecondaryVertexAK8ComputerMod)
+        from RecoBTag.SecondaryVertex.pfBoostedDoubleSecondaryVertexAK8BJetTags_cfi import pfBoostedDoubleSecondaryVertexAK8BJetTags
+        pfBoostedDoubleSecondaryVertexAK8BJetTagsMod = pfBoostedDoubleSecondaryVertexAK8BJetTags.clone(
+            jetTagComputer = cms.string("candidateBoostedDoubleSecondaryVertexAK8Computer"+suff),
+            tagInfos = cms.VInputTag(cms.InputTag("pfBoostedDoubleSVAK8TagInfos"+suff)),
+        )
+        setattr(process,"pfBoostedDoubleSecondaryVertexAK8BJetTags"+suff,pfBoostedDoubleSecondaryVertexAK8BJetTagsMod)
+        ak8tags.append(cms.InputTag("pfBoostedDoubleSecondaryVertexAK8BJetTags"+suff))
+
+    if self.deepAK8 and doDeepAK8:
+        from TreeMaker.Utils.deepak8producer_cfi import DeepAK8Producer, DeepAK8DecorrelProducer
+        deepAK8 = DeepAK8Producer.clone(
+            JetAK8 = GoodJetsTag
+        )
+        setattr(process,"deepAK8"+suff,deepAK8)
+        ak8floats.extend([
+            'deepAK8'+suff+':tDiscriminatorDeep',
+            'deepAK8'+suff+':wDiscriminatorDeep',
+            'deepAK8'+suff+':zDiscriminatorDeep',
+            'deepAK8'+suff+':hDiscriminatorDeep'
+        ])
+        deepAK8decorrel = DeepAK8DecorrelProducer.clone(
+            JetAK8 = GoodJetsTag
+        )
+        setattr(process,"deepAK8decorrel"+suff,deepAK8decorrel)
+        ak8floats.extend([
+            'deepAK8decorrel'+suff+':tDiscriminatorDeep',
+            'deepAK8decorrel'+suff+':wDiscriminatorDeep',
+            'deepAK8decorrel'+suff+':zDiscriminatorDeep',
+            'deepAK8decorrel'+suff+':hDiscriminatorDeep'
+        ])
+
     # get more substructure
     if self.semivisible and storeProperties>1:
         from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
         NjettinessBeta1 = Njettiness.clone(
-            src = JetTag,
+            src = GoodJetsTag,
             cone = cms.double(0.8),
             storeAxes = cms.bool(True),
             Njets = cms.vuint32(1),
@@ -292,14 +354,14 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
         )
         setattr(process,"NjettinessBeta2"+suff,NjettinessBeta2)
         BasicSubstructure = cms.EDProducer("BasicSubstructureProducer",
-            JetTag = JetTag
+            JetTag = GoodJetsTag
         )
         setattr(process,"BasicSubstructure"+suff,BasicSubstructure)
         QGTagger = process.QGTagger.clone(
-            srcJets = JetTag
+            srcJets = GoodJetsTag
         )
         setattr(process,"QGTagger"+suff,QGTagger)
-        ak8floats = [
+        ak8floats.extend([
             'BasicSubstructure'+suff+':overflow',
             'BasicSubstructure'+suff+':girth',
             'BasicSubstructure'+suff+':momenthalf',
@@ -311,15 +373,14 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
             'QGTagger'+suff+':ptD',
             'QGTagger'+suff+':axis1',
             'QGTagger'+suff+':axis2',
-        ]
-        ak8ints = [
+        ])
+        ak8ints.extend([
             'QGTagger'+suff+':mult',
-        ]
-    
-        # add discriminator and update tag
-        process, JetTag = addJetInfo(process, JetTag, ak8floats, ak8ints)
+        ])
 
-    process, GoodJetsTag = self.makeGoodJets(process,JetTag,suff,storeProperties,jetConeSize=0.8)
+    # add discriminator and update tag
+    if len(ak8floats)>0 or len(ak8ints)>0 or len(ak8tags)>0:
+        process, GoodJetsTag = addJetInfo(process, GoodJetsTag, ak8floats, ak8ints, ak8tags)
 
     if storeProperties>0:
         # AK8 jet variables - separate instance of jet properties producer
@@ -383,7 +444,7 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
             'JetProperties'+suff+':SJbDiscriminatorCSV(Jets'+suff+'_subjets_bDiscriminatorCSV)',
         ])
 
-        if self.deepAK8:
+        if self.deepAK8 and doDeepAK8:
             JetPropertiesAK8.properties.extend([
                 "tDiscriminatorDeep",
                 "wDiscriminatorDeep",
@@ -394,14 +455,14 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties):
                 "zDiscriminatorDeepDecorrel",
                 "hDiscriminatorDeepDecorrel",
             ])
-            JetPropertiesAK8.tDiscriminatorDeep = cms.vstring('deepAK8:tDiscriminatorDeep')
-            JetPropertiesAK8.wDiscriminatorDeep = cms.vstring('deepAK8:wDiscriminatorDeep')
-            JetPropertiesAK8.zDiscriminatorDeep = cms.vstring('deepAK8:zDiscriminatorDeep')
-            JetPropertiesAK8.hDiscriminatorDeep = cms.vstring('deepAK8:hDiscriminatorDeep')
-            JetPropertiesAK8.tDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel:tDiscriminatorDeep')
-            JetPropertiesAK8.wDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel:wDiscriminatorDeep')
-            JetPropertiesAK8.zDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel:zDiscriminatorDeep')
-            JetPropertiesAK8.hDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel:hDiscriminatorDeep')
+            JetPropertiesAK8.tDiscriminatorDeep = cms.vstring('deepAK8'+suff+':tDiscriminatorDeep')
+            JetPropertiesAK8.wDiscriminatorDeep = cms.vstring('deepAK8'+suff+':wDiscriminatorDeep')
+            JetPropertiesAK8.zDiscriminatorDeep = cms.vstring('deepAK8'+suff+':zDiscriminatorDeep')
+            JetPropertiesAK8.hDiscriminatorDeep = cms.vstring('deepAK8'+suff+':hDiscriminatorDeep')
+            JetPropertiesAK8.tDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel'+suff+':tDiscriminatorDeep')
+            JetPropertiesAK8.wDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel'+suff+':wDiscriminatorDeep')
+            JetPropertiesAK8.zDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel'+suff+':zDiscriminatorDeep')
+            JetPropertiesAK8.hDiscriminatorDeepDecorrel = cms.vstring('deepAK8decorrel'+suff+':hDiscriminatorDeep')
             self.VectorDouble.extend([
                 'JetProperties'+suff+':tDiscriminatorDeep(Jets'+suff+'_tDiscriminatorDeep)',
                 'JetProperties'+suff+':wDiscriminatorDeep(Jets'+suff+'_wDiscriminatorDeep)',

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -543,7 +543,7 @@ def makeTreeFromMiniAOD(self,process):
 
     if self.geninfo and self.systematics:
         # JEC unc up
-        process, JetTagJECupTmp, JetTagJECup = JetDepot(process,
+        process, JetTagJECTmp, JetTagJECup = JetDepot(process,
             JetTag=JetTag,
             jecUncDir=1,
             storeJec=True, # get JER unc value (in intermediate tag Tmp)
@@ -612,7 +612,17 @@ def makeTreeFromMiniAOD(self,process):
         )
 
         # append factors to central collection
-        process, JetTag = addJetInfo(process, JetTag, [JetTagJECupTmp.value(),JetTagJERup.value(),JetTagJERdown.value()], [])
+        process, JetTag = addJetInfo(process, JetTag, [JetTagJECTmp.value(),JetTagJERup.value(),JetTagJERdown.value()], [])
+    elif not self.geninfo:
+        # get JEC unc for data
+        process, JetTagJECTmp, _ = JetDepot(process,
+            JetTag=JetTag,
+            jecUncDir=0,
+            storeJec=True, # get JER unc value (in intermediate tag Tmp)
+            doSmear=False,
+        )
+        # append unc to central collection
+        process, JetTag = addJetInfo(process, JetTag, [JetTagJECTmp.value()], [])
 
     if self.geninfo:
         # finally, do central smearing and replace jet tag
@@ -670,13 +680,17 @@ def makeTreeFromMiniAOD(self,process):
         SkipTag=SkipTag,
         MHTJetTagExt = MHTJetTagExt,
     )
-    if self.geninfo and self.systematics:
-        process.JetProperties.properties.extend(["jerFactorUp","jerFactorDown","jecUnc"])
-        process.JetProperties.jerFactorUp = cms.vstring(JetTagJERup.value())
-        process.JetProperties.jerFactorDown = cms.vstring(JetTagJERdown.value())
-        process.JetProperties.jecUnc = cms.vstring(JetTagJECupTmp.value())
+    if self.systematics:
+        process.JetProperties.properties.extend(["jecUnc"])
+        process.JetProperties.jecUnc = cms.vstring(JetTagJECTmp.value())
         self.VectorDouble.extend([
             'JetProperties:jecUnc(Jets_jecUnc)',
+        ])
+    if self.geninfo and self.systematics:
+        process.JetProperties.properties.extend(["jerFactorUp","jerFactorDown"])
+        process.JetProperties.jerFactorUp = cms.vstring(JetTagJERup.value())
+        process.JetProperties.jerFactorDown = cms.vstring(JetTagJERdown.value())
+        self.VectorDouble.extend([
             'JetProperties:jerFactorUp(Jets_jerFactorUp)',
             'JetProperties:jerFactorDown(Jets_jerFactorDown)',
         ])

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -702,33 +702,6 @@ def makeTreeFromMiniAOD(self,process):
     )
     JetAK8Tag = JetAK8TagSJU
     
-    # get double b-tagger (w/ miniAOD customizations)
-    process.load("RecoBTag.ImpactParameter.pfImpactParameterAK8TagInfos_cfi")
-    process.pfImpactParameterAK8TagInfos.primaryVertex = cms.InputTag("offlineSlimmedPrimaryVertices")
-    process.pfImpactParameterAK8TagInfos.candidates = cms.InputTag("packedPFCandidates")
-    process.pfImpactParameterAK8TagInfos.jets = JetAK8Tag
-    process.load("RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderAK8TagInfos_cfi")
-    process.pfInclusiveSecondaryVertexFinderAK8TagInfos.extSVCollection = cms.InputTag("slimmedSecondaryVertices")
-    process.pfInclusiveSecondaryVertexFinderAK8TagInfos.trackIPTagInfos = cms.InputTag("pfImpactParameterAK8TagInfos")
-    process.load("RecoBTag.SecondaryVertex.pfBoostedDoubleSVAK8TagInfos_cfi")
-    process.load("RecoBTag.SecondaryVertex.candidateBoostedDoubleSecondaryVertexAK8Computer_cfi")
-    process.load("RecoBTag.SecondaryVertex.pfBoostedDoubleSecondaryVertexAK8BJetTags_cfi")
-
-    _floatsAK8 = []
-    if self.deepAK8:
-        from TreeMaker.Utils.deepak8producer_cfi import DeepAK8Producer, DeepAK8DecorrelProducer
-        process.deepAK8 = DeepAK8Producer.clone(
-            JetAK8 = JetAK8Tag
-        )
-        _floatsAK8.extend(['deepAK8:tDiscriminatorDeep','deepAK8:wDiscriminatorDeep','deepAK8:zDiscriminatorDeep','deepAK8:hDiscriminatorDeep'])
-        process.deepAK8decorrel = DeepAK8DecorrelProducer.clone(
-            JetAK8 = JetAK8Tag
-        )
-        _floatsAK8.extend(['deepAK8decorrel:tDiscriminatorDeep','deepAK8decorrel:wDiscriminatorDeep','deepAK8decorrel:zDiscriminatorDeep','deepAK8decorrel:hDiscriminatorDeep'])
-
-    # add discriminator and update tag
-    process, JetAK8Tag = addJetInfo(process, JetAK8Tag, _floatsAK8, [], cms.VInputTag(cms.InputTag("pfBoostedDoubleSecondaryVertexAK8BJetTags")))
-
     # apply jet ID and get properties
     process = self.makeJetVarsAK8(process,
         JetTag=JetAK8Tag,

--- a/Utils/src/JetUncertaintyProducer.cc
+++ b/Utils/src/JetUncertaintyProducer.cc
@@ -44,7 +44,9 @@ JetUncertaintyProducer::JetUncertaintyProducer(const edm::ParameterSet& iConfig)
 	if(storeUnc_){
 		produces<edm::ValueMap<float>>("");
 	}
-	produces<std::vector<pat::Jet>>();
+	if(jecUncDir_ != 0){
+		produces<std::vector<pat::Jet>>();
+	}
 }
 
 void JetUncertaintyProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
@@ -60,7 +62,9 @@ void JetUncertaintyProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 	iEvent.getByToken(JetTok_, jets);
 
 	auto newJets  = std::make_unique<std::vector<pat::Jet>>();
-	newJets->reserve(jets->size());
+	if(jecUncDir_ != 0){
+		newJets->reserve(jets->size());
+	}
 	auto jecUncVec  = std::make_unique<std::vector<double>>();
 	if(storeUnc_){
 		jecUncVec->reserve(jets->size());
@@ -94,10 +98,11 @@ void JetUncertaintyProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 		}
 		
 		//apply variation to p4 in jet object
-		ajet.scaleEnergy(jesUncScale);
-		
-		//store varied jet
-		newJets->push_back(ajet);		
+		if(jecUncDir_ != 0){
+			ajet.scaleEnergy(jesUncScale);
+			//store varied jet
+			newJets->push_back(ajet);
+		}
 	}
 
 	if(storeUnc_){
@@ -108,10 +113,11 @@ void JetUncertaintyProducer::produce(edm::StreamID, edm::Event& iEvent, const ed
 		filler.fill();
 		iEvent.put(std::move(out),"");
 	}
-	//sort jets in pt
-	std::sort(newJets->begin(), newJets->end(), pTComparator_);
-	
-	iEvent.put(std::move(newJets));
+	if(jecUncDir_ != 0){
+		//sort jets in pt
+		std::sort(newJets->begin(), newJets->end(), pTComparator_);
+		iEvent.put(std::move(newJets));
+	}
 }
 
 DEFINE_FWK_MODULE(JetUncertaintyProducer);


### PR DESCRIPTION
Following observations from #334, all producers that act on the AK8 jet collection have been moved after `GoodJetsProducer`, which rejects the low-pT, non-`PFJet` jets. (Except for the JEC update, because that can change the pT.) This reduces the CPU usage of `IPProducer` by ~40% (events/sec goes from 9.9 to 10.3).

JEC factor and uncertainty are now stored for data.