### PR TITLE
Fix the tagnames used in the HEMiss studies

### DIFF
--- a/Production/python/scenarios.py
+++ b/Production/python/scenarios.py
@@ -162,7 +162,7 @@ class Scenario:
         elif sname == "RelValCMSSW101X":
             self.set_vars(
                 globaltag="101X_upgrade2018_realistic_v7",
-                tagname="PAT",
+                tagname="RECO",
                 hlttagname="reHLT",
                 geninfo=True,
                 signal=True,
@@ -175,7 +175,7 @@ class Scenario:
         elif sname == "RelValCMSSW101XHEMiss":
             self.set_vars(
                 globaltag="101X_upgrade2018_realistic_HEmiss_v1",
-                tagname="PAT",
+                tagname="RECO",
                 hlttagname="reHLT",
                 geninfo=True,
                 signal=True,


### PR DESCRIPTION
Fix the tagname used for the MC based HEMiss studies. It turned out that the tagnames used in the HEMiss, non-HEMiss, and data relvals were all different. The MC samples failed the first time around when the wrong tagnames were used.