### PR TITLE
Fix for bad jets in 2017 data

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -826,6 +826,8 @@ def makeTreeFromMiniAOD(self,process):
         GenMETTag = cms.InputTag("slimmedMETs","",self.tagname), #original collection used deliberately here
         JetTag = cms.InputTag('HTJets'),
         geninfo = cms.untracked.bool(self.geninfo),
+        InfTagAK4 = cms.InputTag('GoodJets:JetInfCand'),
+        InfTagAK8 = cms.InputTag('GoodJetsAK8:JetInfCand'),
     )
     self.VarsDouble.extend(['MET:Pt(MET)','MET:Phi(METPhi)','MET:CaloPt(CaloMET)','MET:CaloPhi(CaloMETPhi)','MET:PFCaloPtRatio(PFCaloMETRatio)','MET:Significance(METSignificance)'])
     if self.geninfo:

--- a/Utils/python/metdouble_cfi.py
+++ b/Utils/python/metdouble_cfi.py
@@ -4,5 +4,7 @@ metdouble = cms.EDProducer('METDouble',
    METTag  = cms.InputTag("slimmedMETs"),
    GenMETTag  = cms.InputTag("slimmedMETs"),
    JetTag  = cms.InputTag('JetTag'),
+   InfTagAK4 = cms.InputTag(''),
+   InfTagAK8 = cms.InputTag(''),
 )
 


### PR DESCRIPTION
While running 2017 data production, we found ~4 events that have jets with insanely high energy (~90 TeV). We noticed them because they also have a leading constituent with energy = `inf`, and therefore caused fastjet to crash.

This patch removes those jets from the collection, and reuses the `PFCaloMETRatio` branch to denote events where these jets were found. Eventually a more permanent solution will be employed (once these events are submitted to the MET scanners, etc.).

@aperloff 