### PR TITLE
Jet cut updates for MC

### DIFF
--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -14,6 +14,7 @@ def makeGoodJets(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInpu
         SaveAllJetsId             = True,
         # keep lower-pt central jets in case they fluctuate up in systematic collections (only for AK4)
         SaveAllJetsPt             = (jetConeSize==0.4),
+        maxJetEta                 = cms.double(5.0 if jetConeSize==0.8 else -1),
     )
     TMeras.TM2017.toModify(GoodJets,
         maxNeutralFraction        = cms.double(0.90),

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -762,9 +762,6 @@ def makeTreeFromMiniAOD(self,process):
         )
         self.VarsDouble.extend(['GenMHT:Pt(GenMHT)','GenMHT:Phi(GenMHTPhi)'])
     
-        # store all AK8 genjets
-        self.VectorRecoCand.extend ( [ 'slimmedGenJetsAK8(GenJetsAK8)' ] )
-
         # substructure for genjets
         from RecoJets.Configuration.RecoGenJets_cff import ak8GenJetsNoNu
         from RecoJets.JetProducers.SubJetParameters_cfi import SubJetParameters
@@ -795,11 +792,14 @@ def makeTreeFromMiniAOD(self,process):
             PrunedGenJetTag = cms.InputTag("ak8GenJetsPruned"),
             SoftDropGenJetTag = cms.InputTag("ak8GenJetsSoftDrop"),
             distMax = cms.double(0.8),
+            jetPtFilter = cms.double(150),
         )
         self.VectorDouble.extend([
             'ak8GenJetProperties:prunedMass(GenJetsAK8_prunedMass)',
             'ak8GenJetProperties:softDropMass(GenJetsAK8_softDropMass)',
         ])
+        # store AK8 genjets above pt cut
+        self.VectorRecoCand.extend (['ak8GenJetProperties(GenJetsAK8)'])
 
     ## ----------------------------------------------------------------------------------------------
     ## Baseline filters

--- a/Utils/python/genjetproperties_cfi.py
+++ b/Utils/python/genjetproperties_cfi.py
@@ -5,4 +5,5 @@ genjetproperties = cms.EDProducer('GenJetProperties',
     PrunedGenJetTag = cms.InputTag(""),
     SoftDropGenJetTag = cms.InputTag(""),
     distMax = cms.double(0.4),
+    jetPtFilter = cms.double(0.0),
 )

--- a/Utils/src/GoodJetsProducer.cc
+++ b/Utils/src/GoodJetsProducer.cc
@@ -169,7 +169,7 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
       leptonMask->reserve(Jets->size());
       for(const auto & iJet : *Jets)
       {
-         if (std::abs(iJet.eta())>maxEta_) continue;
+         if (maxEta_>0 and std::abs(iJet.eta())>maxEta_) continue;
          if (!saveAllPt_ &&
               ( (!invertJetPtFilter_ && iJet.pt() <= jetPtFilter_) ||
                 (invertJetPtFilter_ && iJet.pt() > jetPtFilter_) ) ) continue;


### PR DESCRIPTION
* keep all AK4 jets regardless of eta: this is needed for the new method of handling jet systematic uncertainties. Some events have jets with eta > 5; excluding these from the output collection means that the `origIndex` branches become unusable.
* only keep AK8 GenJets with pT > 150 GeV: this was the cut in 2016 miniAOD. It was lowered substantially in 2017 miniAOD for SMP studies, but we do not care about this.