### PR TITLE
Update MET fix

### DIFF
--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -239,6 +239,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     )
     setattr(process,"METclean"+suff,METclean)
     self.VarsDouble.extend(['METclean'+suff+':Pt(METclean'+suff+')','METclean'+suff+':Phi(METPhiclean'+suff+')','METclean'+suff+':Significance(METSignificanceclean'+suff+')'])
+#    self.VarsDouble.extend(['METclean'+suff+':RawPt(RawMETclean'+suff+')','METclean'+suff+':RawPhi(RawMETPhiclean'+suff+')'])
 
     if self.doMETfix:
         METcleanOrig = METclean.clone(
@@ -246,6 +247,7 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         )
         setattr(process,"METclean"+suff+"Orig",METcleanOrig)
         self.VarsDouble.extend(['METclean'+suff+'Orig:Pt(METclean'+suff+'Orig)','METclean'+suff+'Orig:Phi(METPhiclean'+suff+'Orig)'])
+#        self.VarsDouble.extend(['METclean'+suff+'Orig:RawPt(RawMETclean'+suff+'Orig)','METclean'+suff+'Orig:RawPhi(RawMETPhiclean'+suff+'Orig)'])
 
     return process
 

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -283,7 +283,7 @@ def makeTreeFromMiniAOD(self,process):
                 computeMETSignificance=False,
             )
             METTagOrig = cms.InputTag('slimmedMETsOrig')
-            MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise","jets",process.name_())
+            MHTJetTagExt = cms.InputTag("PFCandidateJetsWithEEnoise","good",process.name_())
         else:
             METTagOrig = None
             MHTJetTagExt = None

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -835,6 +835,7 @@ def makeTreeFromMiniAOD(self,process):
         InfTagAK8 = cms.InputTag('GoodJetsAK8:JetInfCand'),
     )
     self.VarsDouble.extend(['MET:Pt(MET)','MET:Phi(METPhi)','MET:CaloPt(CaloMET)','MET:CaloPhi(CaloMETPhi)','MET:PFCaloPtRatio(PFCaloMETRatio)','MET:Significance(METSignificance)'])
+#    self.VarsDouble.extend(['MET:RawPt(RawMET)','MET:RawPhi(RawMETPhi)'])
     if self.geninfo:
         self.VarsDouble.extend(['MET:GenPt(GenMET)','MET:GenPhi(GenMETPhi)'])
         self.VectorDouble.extend(['MET:PtUp(METUp)', 'MET:PtDown(METDown)', 'MET:PhiUp(METPhiUp)', 'MET:PhiDown(METPhiDown)'])
@@ -844,6 +845,7 @@ def makeTreeFromMiniAOD(self,process):
             METTag = METTagOrig
         )
         self.VarsDouble.extend(['METOrig:Pt(METOrig)','METOrig:Phi(METPhiOrig)'])
+#        self.VarsDouble.extend(['METOrig:RawPt(RawMETOrig)','METOrig:RawPhi(RawMETPhiOrig)'])
 
     from TreeMaker.Utils.mt2producer_cfi import mt2Producer
     process.Mt2Producer = mt2Producer.clone(

--- a/Utils/src/METDouble.cc
+++ b/Utils/src/METDouble.cc
@@ -93,6 +93,8 @@ METDouble::METDouble(const edm::ParameterSet& iConfig)
    produces<double>("minDeltaPhiN");
    produces<double>("Pt");
    produces<double>("Phi");
+   produces<double>("RawPt");
+   produces<double>("RawPhi");
    produces<double>("CaloPt");
    produces<double>("CaloPhi");
    produces<double>("GenPt");
@@ -126,6 +128,7 @@ METDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSe
 {
    using namespace edm;
    double metpt_=0, metphi_=0;
+   double rawmetpt_=0, rawmetphi_=0;
    double genmetpt_=0, genmetphi_=0;
    double calometpt_=0, calometphi_=0;
    double metsig_=0;
@@ -162,6 +165,9 @@ METDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSe
         metPhiUp_[u] = MET->at(0).shiftedPhi(uncUpList[u], pat::MET::Type1);
         metPhiDown_[u] = MET->at(0).shiftedPhi(uncDownList[u], pat::MET::Type1);
       }
+
+      rawmetpt_=MET->at(0).uncorPt();
+      rawmetphi_=MET->at(0).uncorPhi();
    }
    else edm::LogWarning("TreeMaker")<<"METDouble::Invalid Tag: "<<metTag_.label();
 
@@ -183,6 +189,11 @@ METDouble::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSe
    iEvent.put(std::move(htp2),"Phi");
    auto htp0 = std::make_unique<double>(metsig_);
    iEvent.put(std::move(htp0),"Significance");
+
+   auto rhtp = std::make_unique<double>(rawmetpt_);
+   iEvent.put(std::move(rhtp),"RawPt");
+   auto rhtp2 = std::make_unique<double>(rawmetphi_);
+   iEvent.put(std::move(rhtp2),"RawPhi");
 
    auto chtp = std::make_unique<double>(calometpt_);
    iEvent.put(std::move(chtp),"CaloPt");

--- a/setup.sh
+++ b/setup.sh
@@ -63,7 +63,7 @@ git cms-merge-topic -u TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from
 git cms-merge-topic -u TreeMaker:storeJERFactorIndex942
 git cms-merge-topic -u TreeMaker:AddJetAxis1_942
 git cms-merge-topic -u TreeMaker:NjettinessAxis_948
-git cms-merge-topic -u TreeMaker:METFixEE2017_949
+git cms-merge-topic -u TreeMaker:METFixEE2017_949_v2
 git cms-merge-topic -u TreeMaker:AddDecorrelDeepTags9411
 
 # outside repositories


### PR DESCRIPTION
* use MET fix V2 (remove candidates, recompute raw MET)
* pT cut for jets considered in MET fix moved to 50 GeV (recommendation)
  * this change propagates to fixed MHT
* add option to store raw MET values (not enabled by default)