### PR TITLE
Pdf updates

### DIFF
--- a/Production/test/pdffinder_cfg.py
+++ b/Production/test/pdffinder_cfg.py
@@ -1,0 +1,43 @@
+# Read parameters
+from TreeMaker.Utils.CommandLineParams import CommandLineParams
+parameters = CommandLineParams()
+name = parameters.value("name","")
+redir = parameters.value("redir","root://cmsxrootd.fnal.gov/")
+
+# handle site name usage
+if redir[0]=="T":
+    redir = "root://cmsxrootd.fnal.gov//store/test/xrootd/"+redir
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Demo")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+# only need one event to get run info
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
+
+# this selects the first input file
+readFiles = getattr(__import__("TreeMaker.Production."+name+"_cff",fromlist=["readFiles"]),"readFiles")
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(readFiles[0])
+)
+
+# log output
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.categories.append('TreeMaker')
+process.MessageLogger.cerr.TreeMaker = cms.untracked.PSet(
+    optionalPSet = cms.untracked.bool(True),
+    limit = cms.untracked.int32(10000000),
+)
+
+# temporary redirector fix
+for f,val in enumerate(process.source.fileNames):
+    if process.source.fileNames[f][0:6]=="/store":
+        process.source.fileNames[f] = redir+process.source.fileNames[f]
+
+process.PdfFinder = cms.EDAnalyzer('PdfFinder')
+
+process.p = cms.Path(process.PdfFinder)
+
+process.MessageLogger.cerr.FwkReport.reportEvery = 10000

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -98,7 +98,10 @@ def makeTreeFromMiniAOD(self,process):
     ## ----------------------------------------------------------------------------------------------
     if self.geninfo and self.doPDFs:
         from TreeMaker.Utils.pdfweightproducer_cfi import PDFWeightProducer
-        process.PDFWeights = PDFWeightProducer.clone()
+        process.PDFWeights = PDFWeightProducer.clone(
+            recalculatePDFs = cms.bool(self.signal),
+            pdfSetName = cms.string("NNPDF31_lo_as_0130"),
+        )
         self.VectorDouble.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights','PDFWeights:PSweights'])
 
     ## ----------------------------------------------------------------------------------------------

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -99,7 +99,7 @@ def makeTreeFromMiniAOD(self,process):
     if self.geninfo and self.doPDFs:
         from TreeMaker.Utils.pdfweightproducer_cfi import PDFWeightProducer
         process.PDFWeights = PDFWeightProducer.clone()
-        self.VectorDouble.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights'])
+        self.VectorDouble.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights','PDFWeights:PSweights'])
 
     ## ----------------------------------------------------------------------------------------------
     ## GenHT for stitching together MC samples

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -97,9 +97,9 @@ def makeTreeFromMiniAOD(self,process):
     ## PDF weights for PDF systematics
     ## ----------------------------------------------------------------------------------------------
     if self.geninfo and self.doPDFs:
-        process.PDFWeights = cms.EDProducer('PDFWeightProducer')
+        from TreeMaker.Utils.pdfweightproducer_cfi import PDFWeightProducer
+        process.PDFWeights = PDFWeightProducer.clone()
         self.VectorDouble.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights'])
-        self.VectorInt.extend(['PDFWeights:PDFids'])
 
     ## ----------------------------------------------------------------------------------------------
     ## GenHT for stitching together MC samples

--- a/Utils/python/pdfweightproducer_cfi.py
+++ b/Utils/python/pdfweightproducer_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 PDFWeightProducer = cms.EDProducer("PDFWeightProducer",
     nScales = cms.uint32(9),
     nPDFs = cms.uint32(100),
+    nPSs = cms.uint32(12),
 )
 
 from TreeMaker.TreeMaker.TMEras import TMeras

--- a/Utils/python/pdfweightproducer_cfi.py
+++ b/Utils/python/pdfweightproducer_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+PDFWeightProducer = cms.EDProducer("PDFWeightProducer",
+    nScales = cms.uint32(9),
+    nPDFs = cms.uint32(100),
+)
+
+from TreeMaker.TreeMaker.TMEras import TMeras
+TMeras.TM2017.toModify(PDFWeightProducer,
+    nPDFs = 102,
+)

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -177,12 +177,14 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       unsigned nweights = 1;
       if(LHAPDF::numberPDF(1)>1) nweights += LHAPDF::numberPDF(1);
       pdfweights->reserve(nweights);
-      double norm = 1./(pdf1*pdf2);
+      double norm = 1.;
       for (unsigned int i=0; i<nweights; ++i) {
         LHAPDF::usePDFMember(1,i);
         double newpdf1 = LHAPDF::xfx(1, x1, Q, id1)/x1;
         double newpdf2 = LHAPDF::xfx(1, x2, Q, id2)/x2;
-        pdfweights->push_back(newpdf1*newpdf2*norm);
+        pdfweights->push_back(newpdf1*newpdf2);
+        if(i==0) norm = 1/pdfweights->back();
+        pdfweights->back() *= norm;
       }
       found_pdfs = true;
     }

--- a/WeightProducer/src/PdfFinder.cc
+++ b/WeightProducer/src/PdfFinder.cc
@@ -1,0 +1,72 @@
+// system include files
+#include <string>
+#include <sstream>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
+
+//
+// class declaration
+//
+
+class PdfFinder: public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+	public:
+		explicit PdfFinder(const edm::ParameterSet&);
+		~PdfFinder() override;
+		static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+	private:
+		void beginRun(edm::Run const&, edm::EventSetup const&) override;
+		void analyze(edm::Event const&, edm::EventSetup const&) override {}
+		void endRun(edm::Run const&, edm::EventSetup const&) override {}
+	
+		//member variables
+		edm::InputTag lheRunTag_;
+		edm::EDGetTokenT<LHERunInfoProduct> lheRunTok_;
+};
+
+PdfFinder::PdfFinder(const edm::ParameterSet& iConfig) :
+	lheRunTag_(edm::InputTag("externalLHEProducer")),
+	lheRunTok_(consumes<LHERunInfoProduct,edm::InRun>(lheRunTag_))
+{}
+
+PdfFinder::~PdfFinder() { }
+
+void PdfFinder::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
+	edm::Handle<LHERunInfoProduct> h_lheRun;
+	// getByToken throws since we're not in the endRun (see https://github.com/cms-sw/cmssw/pull/18499)
+	//iRun.getByToken(lheRunTok_, h_lheRun);
+	iRun.getByLabel(lheRunTag_, h_lheRun);
+
+	const auto& lheRun = *(h_lheRun.product());
+	for(auto iter = lheRun.headers_begin(); iter != lheRun.headers_end(); ++iter){
+		std::stringstream ss;
+		ss << iter->tag() << std::endl;
+		for(const auto& line: iter->lines()){
+			ss << line;
+		}
+		edm::LogInfo("TreeMaker") << ss.str();
+	}
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+PdfFinder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(PdfFinder);


### PR DESCRIPTION
* add simple analyzer `PdfFinder` to dump LHE headers
* add parameters for `PDFWeightProducer`
* store PS weights if available
* recalculate PDF weights if not present (currently only for SVJ signal)

Some details may need to change in the future, see: https://hypernews.cern.ch/HyperNews/CMS/get/generators/4156.html