### PR TITLE
AK8 jet fractions and multiplicities

### DIFF
--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -468,6 +468,46 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties, SkipTag=cms.VIn
                     JetPropertiesAK8.properties.extend(["origIndex"])
                     JetPropertiesAK8.origIndex = cms.vstring("jerOrigIndex")
                     self.VectorInt.extend(['JetProperties'+suff+':origIndex(Jets'+suff+'_origIndex)'])
+            # fractions and multiplicities
+            JetPropertiesAK8.properties.extend([
+                'chargedHadronMultiplicity',
+                'neutralHadronMultiplicity',
+                'electronMultiplicity',
+                'photonMultiplicity',
+                'muonMultiplicity',
+                'chargedMultiplicity',
+                'neutralMultiplicity',
+                'chargedHadronEnergyFraction',
+                'neutralHadronEnergyFraction',
+                'chargedEmEnergyFraction',
+                'neutralEmEnergyFraction',
+                'electronEnergyFraction',
+                'photonEnergyFraction',
+                'muonEnergyFraction',
+                'hfEMEnergyFraction',
+                'hfHadronEnergyFraction',
+            ])
+            self.VectorDouble.extend([
+                'JetProperties'+suff+':muonEnergyFraction(Jets'+suff+'_muonEnergyFraction)',
+                'JetProperties'+suff+':chargedHadronEnergyFraction(Jets'+suff+'_chargedHadronEnergyFraction)',
+                'JetProperties'+suff+':chargedEmEnergyFraction(Jets'+suff+'_chargedEmEnergyFraction)',
+                'JetProperties'+suff+':neutralEmEnergyFraction(Jets'+suff+'_neutralEmEnergyFraction)',
+                'JetProperties'+suff+':neutralHadronEnergyFraction(Jets'+suff+'_neutralHadronEnergyFraction)',
+                'JetProperties'+suff+':photonEnergyFraction(Jets'+suff+'_photonEnergyFraction)',
+                'JetProperties'+suff+':electronEnergyFraction(Jets'+suff+'_electronEnergyFraction)',
+                'JetProperties'+suff+':hfEMEnergyFraction(Jets'+suff+'_hfEMEnergyFraction)',
+                'JetProperties'+suff+':hfHadronEnergyFraction(Jets'+suff+'_hfHadronEnergyFraction)',
+            ])
+            self.VectorInt.extend([
+                'JetProperties'+suff+':chargedHadronMultiplicity(Jets'+suff+'_chargedHadronMultiplicity)',
+                'JetProperties'+suff+':electronMultiplicity(Jets'+suff+'_electronMultiplicity)',
+                'JetProperties'+suff+':muonMultiplicity(Jets'+suff+'_muonMultiplicity)',
+                'JetProperties'+suff+':neutralHadronMultiplicity(Jets'+suff+'_neutralHadronMultiplicity)',
+                'JetProperties'+suff+':photonMultiplicity(Jets'+suff+'_photonMultiplicity)',
+                'JetProperties'+suff+':chargedMultiplicity(Jets'+suff+'_chargedMultiplicity)',
+                'JetProperties'+suff+':neutralMultiplicity(Jets'+suff+'_neutralMultiplicity)',
+            ])
+
             # extra stuff for subjets
             JetPropertiesAK8.properties.extend(["SJptD", "SJaxismajor", "SJaxisminor", "SJmultiplicity"])
             JetPropertiesAK8.SJptD = cms.vstring('SoftDropPuppiUpdated','QGTaggerSubjets:ptD')

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -29,7 +29,7 @@ class maker:
         self.getParamDefault("outfile","test_run")
         # get base sample name, assuming format is name or name_#
         outfilesplit = self.outfile.split('_')
-        if outfilesplit[-1].isdigit(): outfilesplit = outfilesplit[:-1]
+        if outfilesplit[-1][-1].isdigit(): outfilesplit = outfilesplit[:-1]
         self.sample = '_'.join(outfilesplit)
         outfilesuff=self.parameters.value("outfilesuff","_RA2AnalysisTree")
         self.outfile += outfilesuff


### PR DESCRIPTION
To allow tightening/modifying jet ID, etc. Event size does not increase much because most events have only a few high-pT AK8 jets.

Also a very small bug fix in the wrong PU handling to be more flexible when detecting sample names from output file names.