### PR TITLE
generate rootmap for reflex dictionaries

### DIFF
--- a/Reflex/BuildFile.xml
+++ b/Reflex/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags rootmap="yes"/>
 <use name="root"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>


### PR DESCRIPTION
The resulting rootmap can then be used with hadd or ROOT macros to ensure correct streamer info for our tree branches.

NB, the rootmap is generated with the name `TreeMakerReflex_xr.rootmap`, but ROOT may expect the name `TreeMakerReflex.rootmap` instead (to match the shared library). This can be fixed by hand.