### PR TITLE
[Run2_2017_V17] Save minimal set of gen particles

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Brief explanation of the options in [makeTree.py](./TreeMaker/python/makeTree.py
   The scale variations stored are: [mur=1, muf=1], [mur=1, muf=2], [mur=1, muf=0.5], [mur=2, muf=1], [mur=2, muf=2], [mur=2, muf=0.5], [mur=0.5, muf=1], [mur=0.5, muf=2], [mur=0.5, muf=0.5]
 * `debugtracks`: store information for all PF candidates in every event (default=False) (use with caution, increases run time and output size by ~10x)
 * `applybaseline`: switch to apply the baseline HT selection (default=False)
+* `saveMinimalGenParticles`: save only the hard scatter gen particles coming from top decays, boson decays, semi-visible jets, or SUSY particles (default=True)
 
 The following parameters take their default values from the specified scenario:
 * `globaltag`: global tag for CMSSW database conditions (ref. [FrontierConditions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions))

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -137,23 +137,45 @@ def makeTreeFromMiniAOD(self,process):
     ## GenParticles
     ## ----------------------------------------------------------------------------------------------
     if self.geninfo:
-        process.genParticles = cms.EDProducer("GenParticlesProducer",
-            genCollection = cms.InputTag("prunedGenParticles"),
-            debug = cms.bool(False),
-            childIds = cms.vint32(1,2,3,4,5,11,12,13,14,15,16,22),
-            parentIds = cms.vint32(
-                1,2,6,23,24,25,
-                1000021,1000022,1000023,1000024,1000025,1000035,1000037,1000039,
-                1000001,1000002,1000003,1000004,1000005,1000006,
-                2000001,2000002,2000003,2000004,2000005,2000006,
-                4900021,4900023,4900101,4900102,4900111,4900113,4900211,4900213,51,52,53,
-                5000001,5000002,
-            ),
-            keepIds = cms.vint32(6,23,24,25),
-            keepFirst = cms.bool(True),
-        )
-        # store gluons for signals with Higgs
-        if "T5qqqqZH" in process.source.fileNames[0]: process.genParticles.childIds.append(21)
+        if self.saveMinimalGenParticles:
+            process.genParticles = cms.EDProducer("GenParticlesProducer",
+                genCollection = cms.InputTag("prunedGenParticles"),
+                debug = cms.bool(False),
+                # Particles we want to save from the decay chain of the tops
+                childIds = cms.vint32(1,2,3,4,5,11,12,13,14,15,16,24),
+                # Particles we want to save the last copy from the hard scatter
+                parentIds = cms.vint32(
+                    6,22,23,24,25,
+                    1000021,1000022,1000023,1000024,1000025,1000035,1000037,1000039,
+                    1000001,1000002,1000003,1000004,1000005,1000006,
+                    2000001,2000002,2000003,2000004,2000005,2000006,
+                    4900021,4900023,4900101,4900102,4900111,4900113,4900211,4900213,51,52,53,
+                    5000001,5000002,
+                ),
+                # Other settings
+                keepIds = cms.vint32(),
+                keepFirst = cms.bool(False),
+                keepMinimal = cms.bool(True),
+            )
+        else:
+            process.genParticles = cms.EDProducer("GenParticlesProducer",
+                genCollection = cms.InputTag("prunedGenParticles"),
+                debug = cms.bool(False),
+                childIds = cms.vint32(1,2,3,4,5,11,12,13,14,15,16,22),
+                parentIds = cms.vint32(
+                    1,2,6,23,24,25,
+                    1000021,1000022,1000023,1000024,1000025,1000035,1000037,1000039,
+                    1000001,1000002,1000003,1000004,1000005,1000006,
+                    2000001,2000002,2000003,2000004,2000005,2000006,
+                    4900021,4900023,4900101,4900102,4900111,4900113,4900211,4900213,51,52,53,
+                    5000001,5000002,
+                ),
+                keepIds = cms.vint32(6,23,24,25),
+                keepFirst = cms.bool(True),
+                keepMinimal = cms.bool(False),
+            )
+            # store gluons for signals with Higgs
+            if "T5qqqqZH" in process.source.fileNames[0]: process.genParticles.childIds.append(21)
         self.VectorTLorentzVector.append("genParticles(GenParticles)")
         self.VectorInt.append("genParticles:PdgId(GenParticles_PdgId)")
         self.VectorInt.append("genParticles:Status(GenParticles_Status)")

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -181,7 +181,8 @@ def makeTreeFromMiniAOD(self,process):
         self.VectorInt.append("genParticles:Status(GenParticles_Status)")
         self.VectorInt.append("genParticles:Parent(GenParticles_ParentIdx)")
         self.VectorInt.append("genParticles:ParentId(GenParticles_ParentId)")
-        self.VectorBool.append("genParticles:TTFlag(GenParticles_TTFlag)")
+        if not self.saveMinimalGenParticles:
+            self.VectorBool.append("genParticles:TTFlag(GenParticles_TTFlag)")
         
         # for ttbar pT reweighting
         # params from: https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopPtReweighting#Run_2_strategy

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -53,6 +53,7 @@ class maker:
         # other options off by default
         self.getParamDefault("debugtracks", False)
         self.getParamDefault("applybaseline", False)
+        self.getParamDefault("saveMinimalGenParticles", False)
         
         # take command line input (w/ defaults from scenario if specified)
         self.getParamDefault("globaltag",self.scenario.globaltag)
@@ -128,6 +129,7 @@ class maker:
         print " "
         print " storing track debugging variables: "+str(self.debugtracks)
         print " Applying baseline selection filter: "+str(self.applybaseline)
+        print " Storing a minimal set of GenParticles: "+str(self.saveMinimalGenParticles)
         print " "
         print " scenario: "+self.scenarioName
         print " global tag: "+self.globaltag

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -53,7 +53,7 @@ class maker:
         # other options off by default
         self.getParamDefault("debugtracks", False)
         self.getParamDefault("applybaseline", False)
-        self.getParamDefault("saveMinimalGenParticles", False)
+        self.getParamDefault("saveMinimalGenParticles", True)
         
         # take command line input (w/ defaults from scenario if specified)
         self.getParamDefault("globaltag",self.scenario.globaltag)

--- a/Utils/src/GenParticlesProducer.cc
+++ b/Utils/src/GenParticlesProducer.cc
@@ -88,7 +88,8 @@ debug(iConfig.getParameter<bool>("debug"))
     produces< std::vector< int > >("Status");
     produces< std::vector< int > >("Parent");
     produces< std::vector< int > >("ParentId");
-    produces< std::vector< bool > >("TTFlag");
+    if(!keepMinimal)
+        produces< std::vector< bool > >("TTFlag");
 }
 
 GenParticlesProducer::~GenParticlesProducer() {
@@ -129,7 +130,7 @@ void GenParticlesProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
     iEvent.put(std::move(Status_vec     ), "Status");
     iEvent.put(std::move(ParentId_vec   ), "ParentId");
     iEvent.put(std::move(Parent_vec     ), "Parent");
-    iEvent.put(std::move(TTFlag_vec     ), "TTFlag");
+    if(!keepMinimal) iEvent.put(std::move(TTFlag_vec     ), "TTFlag");
 }
 
 // Based on http://pdg.lbl.gov/2007/reviews/montecarlorpp.pdf

--- a/Utils/src/GenParticlesProducer.cc
+++ b/Utils/src/GenParticlesProducer.cc
@@ -34,11 +34,6 @@ public:
 
 private:
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-    //bool isAncestor(const reco::Candidate* ancestor, const reco::Candidate * particle) const;
-    //void saveChain(int depth, int maxDepth, const reco::GenParticle&, std::unique_ptr<std::vector<TLorentzVector>>&,
-    //               std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<int>>&,
-    //               std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<int>>&,
-    //               std::unordered_set<const reco::Candidate *>&) const;
     const reco::GenParticle* findLast(const reco::GenParticle& particle) const;
     void saveChain(int depth, int parentId, int parent_idx, const reco::GenParticle& particle, std::unique_ptr<std::vector<TLorentzVector>>& genParticle_vec,
                    std::unique_ptr<std::vector<int>>& PdgId_vec, std::unique_ptr<std::vector<int>>& Status_vec,
@@ -337,7 +332,6 @@ void GenParticlesProducer::storeStandard(const edm::Handle< edm::View<reco::GenP
         }
     }
 }
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void GenParticlesProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/Utils/src/GenParticlesProducer.cc
+++ b/Utils/src/GenParticlesProducer.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "TLorentzVector.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
 #include <DataFormats/HepMCCandidate/interface/GenParticle.h>
 #include <DataFormats/PatCandidates/interface/Photon.h>
@@ -33,6 +34,22 @@ public:
 
 private:
     void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+    //bool isAncestor(const reco::Candidate* ancestor, const reco::Candidate * particle) const;
+    //void saveChain(int depth, int maxDepth, const reco::GenParticle&, std::unique_ptr<std::vector<TLorentzVector>>&,
+    //               std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<int>>&,
+    //               std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<int>>&,
+    //               std::unordered_set<const reco::Candidate *>&) const;
+    reco::GenParticle findLast(const reco::GenParticle& particle) const;
+    void saveChain(int depth, int parentId, int parent_idx, const reco::GenParticle& particle, std::unique_ptr<std::vector<TLorentzVector>>& genParticle_vec,
+                   std::unique_ptr<std::vector<int>>& PdgId_vec, std::unique_ptr<std::vector<int>>& Status_vec,
+                   std::unique_ptr<std::vector<int>>& Parent_vec, std::unique_ptr<std::vector<int>>& ParentId_vec,
+                   std::unordered_set<const reco::Candidate *>& stored_particles_ref) const;
+    void storeMinimal(const edm::Handle< edm::View<reco::GenParticle> >&, std::unique_ptr<std::vector<TLorentzVector>>&,
+                      std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<int>>&,
+                      std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<int>>&) const;
+    void storeStandard(const edm::Handle< edm::View<reco::GenParticle> >&, std::unique_ptr<std::vector<TLorentzVector>>&,
+                      std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<int>>&,
+                      std::unique_ptr<std::vector<int>>&, std::unique_ptr<std::vector<bool>>&) const;
 
     // ----------member data ---------------------------
 
@@ -41,6 +58,7 @@ private:
     bool        debug;
     std::unordered_set<int> typicalChildIds, typicalParentIds, keepAllTheseIds;
     bool        keepFirstDecayProducts;
+    bool        keepMinimal;
 
 };
 
@@ -60,6 +78,8 @@ debug(iConfig.getParameter<bool>("debug"))
     keepAllTheseIds.insert(ids.begin(),ids.end());
 
     keepFirstDecayProducts = iConfig.getParameter<bool>("keepFirst");
+
+    keepMinimal = iConfig.getParameter<bool>("keepMinimal");
 
     produces< std::vector< TLorentzVector > >(""); 
     produces< std::vector< int > >("PdgId");
@@ -88,7 +108,6 @@ void GenParticlesProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
     auto Status_vec = std::make_unique<std::vector<int>>();
     auto Parent_vec = std::make_unique<std::vector<int>>();
     auto ParentId_vec = std::make_unique<std::vector<int>>();
-    auto parents = std::make_unique<std::vector<TLorentzVector>>();
     auto TTFlag_vec = std::make_unique<std::vector<bool>>();
 
     edm::Handle< View<reco::GenParticle> > genPartCands;
@@ -99,7 +118,219 @@ void GenParticlesProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
         edm::LogInfo("TreeMaker")<< "======new event============"<<"\n"
         <<"idx\t"<<"pdgId\t"<<"status\t"<<"parId\t"<<"parIdx\t";
     }
+
+    if (keepMinimal) storeMinimal(genPartCands, genParticle_vec,PdgId_vec,Status_vec,Parent_vec,ParentId_vec);
+    else             storeStandard(genPartCands,genParticle_vec,PdgId_vec,Status_vec,Parent_vec,ParentId_vec,TTFlag_vec);
+
+    iEvent.put(std::move(genParticle_vec)); 
+    iEvent.put(std::move(PdgId_vec      ), "PdgId");
+    iEvent.put(std::move(Status_vec     ), "Status");
+    iEvent.put(std::move(ParentId_vec   ), "ParentId");
+    iEvent.put(std::move(Parent_vec     ), "Parent");
+    iEvent.put(std::move(TTFlag_vec     ), "TTFlag");
+}
+
+/*
+bool GenParticlesProducer::isAncestor(const reco::Candidate* ancestor, const reco::Candidate * particle) const {
+    //particle is already the ancestor
+    if(ancestor == particle ) return true;
+
+    //otherwise loop on mothers, if any and return true if the ancestor is found
+    for(size_t i=0; i<particle->numberOfMothers(); i++) {
+        if(isAncestor(ancestor,particle->mother(i))) return true;
+    }
+        
+    //if we did not return yet, then particle and ancestor are not relatives
+    return false;
+}
+
+
+void GenParticlesProducer::saveChain(int depth, int maxDepth, const reco::GenParticle& particle, std::unique_ptr<std::vector<TLorentzVector>>& genParticle_vec,
+                                     std::unique_ptr<std::vector<int>>& PdgId_vec, std::unique_ptr<std::vector<int>>& Status_vec,
+                                     std::unique_ptr<std::vector<int>>& Parent_vec, std::unique_ptr<std::vector<int>>& ParentId_vec,
+                                     std::unordered_set<const reco::Candidate *>& stored_particles_ref) const {
+    if(depth==maxDepth) return;
+    if(depth>0 && typicalChildIds.find(abs(particle.pdgId()))==typicalChildIds.end()) return;
+    if(stored_particles_ref.find(&particle)!=stored_particles_ref.end()) return;
+    if(particle.isLastCopy() && (particle.isHardProcess() || particle.fromHardProcessBeforeFSR())) {
+        TLorentzVector temp;
+        temp.SetPxPyPzE(particle.px(), particle.py(), particle.pz(), particle.energy());
+        genParticle_vec->push_back(temp);
+        PdgId_vec->push_back(particle.pdgId());
+        Status_vec->push_back(abs(particle.status()));
+        stored_particles_ref.insert(&particle);
+        int current_parent_id = PdgId_vec->back();
+        int current_parent_idx = genParticle_vec->size()-1;
+        for(unsigned int iDau=0; iDau<particle.numberOfDaughters(); iDau++) {
+            ParentId_vec->push_back(current_parent_id);
+            Parent_vec->push_back(current_parent_idx);
+            const reco::GenParticle *daughter = static_cast<const reco::GenParticle *>(particle.daughter(iDau));
+            saveChain(depth++, maxDepth, *daughter, genParticle_vec, PdgId_vec, Status_vec, Parent_vec, ParentId_vec, stored_particles_ref);
+        }
+    }
+    else {
+        for(unsigned int iDau=0; iDau<particle.numberOfDaughters(); iDau++) {
+            const reco::GenParticle *daughter = static_cast<const reco::GenParticle *>(particle.daughter(iDau));
+            saveChain(depth, maxDepth, *daughter, genParticle_vec, PdgId_vec, Status_vec, Parent_vec, ParentId_vec, stored_particles_ref);
+        }
+    }
+    return;
+
+}
+
+void GenParticlesProducer::storeMinimal(const edm::Handle< edm::View<reco::GenParticle> >& genPartCands, std::unique_ptr<std::vector<TLorentzVector>>& genParticle_vec, 
+                                        std::unique_ptr<std::vector<int>>& PdgId_vec, std::unique_ptr<std::vector<int>>& Status_vec, std::unique_ptr<std::vector<int>>& Parent_vec,
+                                        std::unique_ptr<std::vector<int>>& ParentId_vec) const {
+    std::unordered_set<const reco::Candidate *> stored_particles_ref;
     for(const auto& iPart : *genPartCands) {
+        // Store the particles contained in the typicalParentIds, being used here to store all particles which should start a chain to be saved
+        if(stored_particles_ref.find(&iPart)!=stored_particles_ref.end()) continue;
+        if(typicalParentIds.find(abs(iPart.pdgId()))!=typicalParentIds.end()) {
+            //if(abs(iPart.pdgId())==6) {
+            //    edm::LogInfo("TreeMaker") << "Found a top(6) isLastCopy(" << iPart.isLastCopy() << ")  isHardProcess(" << iPart.isHardProcess()
+            //                              << ") fromHardProcessFinalState(" << iPart.fromHardProcessFinalState() << ") fromHardProcessDecayed("
+            //                              << iPart.fromHardProcessDecayed() << ") fromHardProcessBeforeFSR(" << iPart.fromHardProcessBeforeFSR() << ")";
+            //}
+
+            if(iPart.isLastCopy() && (iPart.isHardProcess() || iPart.fromHardProcessBeforeFSR())) {
+                //if(abs(iPart.pdgId())==6) {
+                //    edm::LogInfo("TreeMaker") << "A top(6) passed!";
+                //}
+                ParentId_vec->push_back(0);
+                Parent_vec->push_back(-1);
+                saveChain(0,(abs(iPart.pdgId())) ? 2 : 1, iPart, genParticle_vec, PdgId_vec, Status_vec, Parent_vec, ParentId_vec, stored_particles_ref);
+            }
+        }
+    }
+}
+*/
+
+/*
+tops start with status 22 and end with 62
+    any time there is one daughter it is simply radiating. when there are two daughters that should be the final top
+b start with status 23 and end with 71 (ignore any gluon radiation)
+W start with status 22, can immediately decay or go to status 52
+    immediately decays to status 23 which then decay to status 1/2 (leptonic) or 71 (hadronic)
+*/
+
+// Based on http://pdg.lbl.gov/2007/reviews/montecarlorpp.pdf
+enum particle_type
+{
+    down=1,
+    up=2,
+    strange=3,
+    charm=4,
+    bottom=5,
+    top=6,
+    electron=11,
+    electron_neutrino=12,
+    muon=13,
+    muon_neutrino=14,
+    tau=15,
+    tau_neutrino=16,
+    photon=22,
+    Z=23,
+    W=24,
+    Higgs=25
+};
+
+// Referenced:
+//   https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2017
+//   https://github.com/cms-sw/cmssw/blob/master/DataFormats/HepMCCandidate/interface/GenParticle.h
+//   https://github.com/cms-sw/cmssw/blob/master/DataFormats/Candidate/interface/CompositeRefCandidateT.h
+//   https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCandidateModules#ParticleTreeDrawer_Utility
+//   https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePATMCMatchingExercise
+reco::GenParticle GenParticlesProducer::findLast(const reco::GenParticle& particle) const {
+    auto last = particle;
+    bool resetLast = false;
+    const reco::GenParticle *daughter;
+    edm::LogInfo("TreeMaker") << "Found a " << last.pdgId() << " (status=" << last.status() << ", ndaughters=" << last.numberOfDaughters() << "):";
+    while (true) {
+        resetLast=false;
+        for(unsigned int iDau=0; iDau<last.numberOfDaughters(); iDau++) {
+            daughter = static_cast<const reco::GenParticle *>(last.daughter(iDau));
+            if(daughter->pdgId()==last.pdgId()) {
+                last = *daughter;
+                resetLast = true;
+                edm::LogInfo("TreeMaker") << "   reset to " << last.pdgId() << "(status=" << last.status() << ")";
+            }
+        }
+        if(!resetLast) break;
+    }
+    if((last.pdgId() == bottom && last.status()!=71) ||
+       (last.pdgId() == top && last.status()!=62) ||
+       (last.pdgId() == W && (last.status()!=22 && last.status()!=52)) ||
+       ((last.pdgId() >= electron && last.pdgId() <= tau_neutrino) && (last.status() != 1 || last.status() != 2)) ||
+       ((last.pdgId() >= down && last.pdgId() <= charm) && last.status() != 71)) {
+        edm::LogInfo("TreeMaker") << "WARNING The last particle in the chain (" << last.pdgId() << ") does not have a status that corresponds to its type (status=" << last.status() << ")";
+    }
+
+    return last;
+}
+
+void GenParticlesProducer::saveChain(int depth, int parentId, int parent_idx, const reco::GenParticle& particle, std::unique_ptr<std::vector<TLorentzVector>>& genParticle_vec,
+                                     std::unique_ptr<std::vector<int>>& PdgId_vec, std::unique_ptr<std::vector<int>>& Status_vec,
+                                     std::unique_ptr<std::vector<int>>& Parent_vec, std::unique_ptr<std::vector<int>>& ParentId_vec,
+                                     std::unordered_set<const reco::Candidate *>& stored_particles_ref) const {
+    if(debug) edm::LogInfo("TreeMaker") << "Saving chain for a " << particle.pdgId() << "(status=" << particle.status() << ")\n   Current depth is " << depth;
+    if(depth==0) return;
+    auto lastParticle = findLast(particle);
+    TLorentzVector temp;
+    temp.SetPxPyPzE(particle.px(), particle.py(), particle.pz(), particle.energy());
+    genParticle_vec->push_back(temp);
+    PdgId_vec->push_back(particle.pdgId());
+    Status_vec->push_back(abs(particle.status()));
+    stored_particles_ref.insert(&particle);
+    ParentId_vec->push_back(parentId);
+    Parent_vec->push_back(parent_idx);
+    int current_parent_idx = PdgId_vec->size()-1;
+    int current_parent_id = PdgId_vec->back();
+
+    if(particle.numberOfDaughters()==2) {
+        for(unsigned int iDau=0; iDau<particle.numberOfDaughters(); iDau++) {
+            const reco::GenParticle *daughter = static_cast<const reco::GenParticle *>(particle.daughter(iDau));
+            saveChain(--depth, current_parent_id, current_parent_idx, *daughter, genParticle_vec, PdgId_vec, Status_vec, Parent_vec, ParentId_vec, stored_particles_ref);
+        }
+    }
+
+    return;
+}
+
+void GenParticlesProducer::storeMinimal(const edm::Handle< edm::View<reco::GenParticle> >& genPartCands, std::unique_ptr<std::vector<TLorentzVector>>& genParticle_vec, 
+                                        std::unique_ptr<std::vector<int>>& PdgId_vec, std::unique_ptr<std::vector<int>>& Status_vec, std::unique_ptr<std::vector<int>>& Parent_vec,
+                                        std::unique_ptr<std::vector<int>>& ParentId_vec) const {
+    std::unordered_set<const reco::Candidate *> stored_particles_ref;
+    for(const auto& iPart : *genPartCands) {
+        // Skip particles which are already in the list of stored particles
+        if(stored_particles_ref.find(&iPart)!=stored_particles_ref.end()) continue;
+        // Skip starting particles which are not from the hard process
+        if(!iPart.isHardProcess() && !iPart.fromHardProcessBeforeFSR()) continue;
+        // Only store particles in the list of acceptable parent pdgids
+        if(typicalParentIds.find(abs(iPart.pdgId()))!=typicalParentIds.end()) {
+            if (abs(iPart.pdgId())==top) saveChain(3, iPart.mother()->pdgId(), -1, iPart, genParticle_vec, PdgId_vec, Status_vec, Parent_vec, ParentId_vec, stored_particles_ref);
+            else if(abs(iPart.pdgId())>=photon && abs(iPart.pdgId())>=Higgs) saveChain(2, iPart.mother()->pdgId(), -1, iPart, genParticle_vec, PdgId_vec, Status_vec, Parent_vec, ParentId_vec, stored_particles_ref);
+            else {
+                TLorentzVector temp;
+                temp.SetPxPyPzE(iPart.px(), iPart.py(), iPart.pz(), iPart.energy());
+                genParticle_vec->push_back(temp);
+                PdgId_vec->push_back(iPart.pdgId());
+                Status_vec->push_back(abs(iPart.status()));
+                stored_particles_ref.insert(&iPart);
+                ParentId_vec->push_back(iPart.mother()->pdgId());
+                Parent_vec->push_back(-1);
+            }
+        }
+    }
+}
+
+void GenParticlesProducer::storeStandard(const edm::Handle< edm::View<reco::GenParticle> >& genPartCands, std::unique_ptr<std::vector<TLorentzVector>>& genParticle_vec,
+                                         std::unique_ptr<std::vector<int>>& PdgId_vec, std::unique_ptr<std::vector<int>>& Status_vec, std::unique_ptr<std::vector<int>>& Parent_vec,
+                                         std::unique_ptr<std::vector<int>>& ParentId_vec, std::unique_ptr<std::vector<bool>>& TTFlag_vec) const {
+
+    auto parents = std::make_unique<std::vector<TLorentzVector>>();
+
+    for(const auto& iPart : *genPartCands) {
+
         bool keepAllThese = (keepAllTheseIds.find(abs(iPart.pdgId()))!=keepAllTheseIds.end());
         bool firstDecayProducts = false;
         if (keepFirstDecayProducts) firstDecayProducts = (abs(iPart.status())==23);
@@ -160,14 +391,8 @@ void GenParticlesProducer::produce(edm::StreamID, edm::Event& iEvent, const edm:
           << "eta="<< parents->at(g).Eta();
         }
     }
-
-    iEvent.put(std::move(genParticle_vec)); 
-    iEvent.put(std::move(PdgId_vec      ), "PdgId");
-    iEvent.put(std::move(Status_vec     ), "Status");
-    iEvent.put(std::move(ParentId_vec   ), "ParentId");
-    iEvent.put(std::move(Parent_vec     ), "Parent");
-    iEvent.put(std::move(TTFlag_vec     ), "TTFlag");
 }
+
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void GenParticlesProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/Utils/src/GenParticlesProducer.cc
+++ b/Utils/src/GenParticlesProducer.cc
@@ -182,7 +182,7 @@ const reco::GenParticle* GenParticlesProducer::findLast(const reco::GenParticle&
     3. W start with status 22, can immediately decay or go to status 51/52
         immediately decays to status 23 which then decay to status 1/2 (leptonic) or 71 (hadronic)
     */
-    if(((last->pdgId() >= down && last->pdgId() <= bottom) && (last->status()!=51 && last->status()!=52 && last->status()!=71 && last->status()!=72)) ||
+    if(((last->pdgId() >= down && last->pdgId() <= bottom) && (last->status()!=23 && last->status()!=51 && last->status()!=52 && last->status()!=71 && last->status()!=72 && last->status()!=73)) ||
        (last->pdgId() == top && last->status()!=62) ||
        (last->pdgId() == W && (last->status()!=22 && last->status()!=51 && last->status()!=52)) ||
        ((last->pdgId() >= electron && last->pdgId() <= tau_neutrino) && (last->status() != 1 && last->status() != 2))) {


### PR DESCRIPTION
This PR adds a new way to store a collection of gen particles. Previously we were storing a very large set of particles. Now we will only save a small subset of important decays (i.e. tops, W, Z, H, etc.) We will also save SUSY particles and particles important for semi-visible jets. A flag to switch between the two methods has been added to makeTreeFromMiniAOD.

Currently this has been tested using semi-leptonic TTJets decays. The command to do this was:
`cmsRun runMakeTreeFromMiniAOD_cfg.py scenario=Fall17 inputFilesConfig=Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8 nstart=0 nfiles=1 outfile=Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8 numevents=100 saveMinimalGenParticles=True`