### PR TITLE
[Run2_2017] Add gfal-copy functionality to the step2 scripts

### DIFF
--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -57,20 +57,18 @@ if [[ $CMSEXIT -ne 0 ]]; then
 fi
 
 # copy output to eos
-CMDSTR="xrdcp"
+export CMDSTR="xrdcp"
+export GFLAG=""
 if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
-	CMDSTR="gfal-copy"
+	export CMDSTR="gfal-copy"
+	export GFLAG="-g"
     export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
 	export OUTDIR=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do
 	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE}"
-	if [[ $CMDSTR == "gfal-copy" ]]; then
-		stageOut -g -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
-    else
-		stageOut -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
-	fi
+	stageOut ${GFLAG} -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
 	XRDEXIT=$?
 	if [[ $XRDEXIT -ne 0 ]]; then
 		rm *.root

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -57,21 +57,24 @@ if [[ $CMSEXIT -ne 0 ]]; then
 fi
 
 # copy output to eos
-echo "xrdcp/gfal-copy output for condor"
+CMDSTR="xrdcp"
+if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
+	CMDSTR="gfal-copy"
+    export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
+	export OUTDIR=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
+fi
+echo "$CMDSTR output for condor"
 for FILE in *.root; do
-	if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
-        export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
-		export OUTDIR_GFAL=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
-		echo "gfal-copy -f ${FILE} ${OUTDIR_GFAL}/${FILE}"
-		stageOut -g -x "-f" -i ${FILE} -o ${OUTDIR_GFAL}/${FILE}
+	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE}"
+	if [[ $CMDSTR == "gfal-copy" ]]; then
+		stageOut -g -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
     else
-		echo "xrdcp -f ${FILE} ${OUTDIR}/${FILE}"
 		stageOut -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
 	fi
 	XRDEXIT=$?
 	if [[ $XRDEXIT -ne 0 ]]; then
 		rm *.root
-		echo "exit code $XRDEXIT, failure in xrdcp/gfal-copy"
+		echo "exit code $XRDEXIT, failure in $CMDSTR"
 		exit $XRDEXIT
 	fi
 	rm ${FILE}

--- a/Production/test/condorSub/step2Neff.sh
+++ b/Production/test/condorSub/step2Neff.sh
@@ -52,20 +52,18 @@ if [[ $CMSEXIT -ne 0 ]]; then
 fi
 
 # copy output to eos
-CMDSTR="xrdcp"
+export CMDSTR="xrdcp"
+export GFLAG=""
 if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
-    CMDSTR="gfal-copy"
+    export CMDSTR="gfal-copy"
+	export GFLAG="-g"
     export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
     export OUTDIR=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do
 	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE}"
-	if [[ $CMDSTR == "gfal-copy" ]]; then
-		stageOut -g -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
-	else
-		stageOut -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
-	fi
+	stageOut ${GFLAG} -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
 	XRDEXIT=$?
 	if [[ $XRDEXIT -ne 0 ]]; then
 		rm *.root

--- a/Production/test/condorSub/step2Neff.sh
+++ b/Production/test/condorSub/step2Neff.sh
@@ -52,14 +52,21 @@ if [[ $CMSEXIT -ne 0 ]]; then
 fi
 
 # copy output to eos
-echo "xrdcp output for condor"
+echo "xrdcp/gfal-copy output for condor"
 for FILE in *.root; do
-	echo "xrdcp -f ${FILE} ${OUTDIR}/${FILE}"
-	stageOut -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
+	if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
+		export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
+		export OUTDIR_GFAL=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
+		echo "gfal-copy -f ${FILE} ${OUTDIR_GFAL}/${FILE}"
+		stageOut -g -x "-f" -i ${FILE} -o ${OUTDIR_GFAL}/${FILE}
+	else
+		echo "xrdcp -f ${FILE} ${OUTDIR}/${FILE}"
+		stageOut -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
+	fi
 	XRDEXIT=$?
 	if [[ $XRDEXIT -ne 0 ]]; then
 		rm *.root
-		echo "exit code $XRDEXIT, failure in xrdcp"
+		echo "exit code $XRDEXIT, failure in xrdcp/gfal-copy"
 		exit $XRDEXIT
 	fi
 	rm ${FILE}


### PR DESCRIPTION
Add gfal-copy functionality to the step2 scripts in the case where the job is running on T1_US_FNAL, the user is cmsgli (global pool pilot), and the output directory is on FNAL EOS. This PR relies on kpedro88/CondorProduction#4 being merged first.