### PR TITLE
[Run2_2017] Update the JECs used by the AK8 subjets and softdrop mass

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Brief explanation of the options in [makeTree.py](./TreeMaker/python/makeTree.py
 * `doPDFs`: switch to enable the storage of PDF weights and scale variation weights from LHEEventInfo (default=True)  
   The scale variations stored are: [mur=1, muf=1], [mur=1, muf=2], [mur=1, muf=0.5], [mur=2, muf=1], [mur=2, muf=2], [mur=2, muf=0.5], [mur=0.5, muf=1], [mur=0.5, muf=2], [mur=0.5, muf=0.5]
 * `debugtracks`: store information for all PF candidates in every event (default=False) (use with caution, increases run time and output size by ~10x)
+* `debugsubjets`: store some additional information for the AK8 subjets (default=False)
 * `applybaseline`: switch to apply the baseline HT selection (default=False)
 * `saveMinimalGenParticles`: save only the hard scatter gen particles coming from top decays, boson decays, semi-visible jets, or SUSY particles (default=True)
 
@@ -239,6 +240,7 @@ The following parameters take their default values from the specified scenario:
 * `geninfo`: switch to enable use of generator information, should only be used for MC
 * `fastsim`: switch to enable special settings for SUSY signal scans produced with FastSim
 * `pmssm`: switch to enable special settings for pMSSM signal scans
+* `scan`: switch to enable special settings for scans produced with FullSim
 * `signal`: switch to enable assessment of signal systematics (currently unused)
 * `jsonfile`: name of JSON file to apply to data
 * `jecfile`: name of a database file from which to get JECs

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -583,6 +583,15 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties, SkipTag=cms.VIn
                 self.VectorVectorTLorentzVector.extend([
                     'JetProperties'+suff+':constituents(Jets'+suff+'_constituents)',
                 ])
+
+        if self.debugsubjets and storeProperties>1:
+            JetPropertiesAK8.GenSubjetTag = cms.InputTag('slimmedGenJetsAK8SoftDropSubJets')
+            JetPropertiesAK8.properties.extend(["SJresponse"])
+            JetPropertiesAK8.SJresponse = cms.vstring('SoftDropPuppiUpdated')
+            self.VectorVectorDouble.extend([
+                'JetProperties'+suff+':SJresponse(Jets'+suff+'_subjets_response)',
+            ])
+
         setattr(process,"JetProperties"+suff,JetPropertiesAK8)
 
     return process        

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -379,13 +379,13 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties, SkipTag=cms.VIn
         )
         # specify userfloats
         JetPropertiesAK8.prunedMass = cms.vstring('ak8PFJetsCHSValueMap:ak8PFJetsCHSPrunedMass')
-        JetPropertiesAK8.softDropMass = cms.vstring('SoftDropPuppi') # computed from subjets
+        JetPropertiesAK8.softDropMass = cms.vstring('SoftDropPuppiUpdated') # computed from subjets
         JetPropertiesAK8.NsubjettinessTau1 = cms.vstring('NjettinessAK8Puppi:tau1')
         JetPropertiesAK8.NsubjettinessTau2 = cms.vstring('NjettinessAK8Puppi:tau2')
         JetPropertiesAK8.NsubjettinessTau3 = cms.vstring('NjettinessAK8Puppi:tau3')
         JetPropertiesAK8.bDiscriminatorCSV = cms.vstring('pfBoostedDoubleSecondaryVertexAK8BJetTags')
-        JetPropertiesAK8.subjets = cms.vstring('SoftDropPuppi')
-        JetPropertiesAK8.SJbDiscriminatorCSV = cms.vstring('SoftDropPuppi','pfCombinedInclusiveSecondaryVertexV2BJetTags')
+        JetPropertiesAK8.subjets = cms.vstring('SoftDropPuppiUpdated')
+        JetPropertiesAK8.SJbDiscriminatorCSV = cms.vstring('SoftDropPuppiUpdated','pfCombinedInclusiveSecondaryVertexV2BJetTags')
         self.VectorDouble.extend([
             'JetProperties'+suff+':prunedMass(Jets'+suff+'_prunedMass)',
             'JetProperties'+suff+':softDropMass(Jets'+suff+'_softDropMass)',

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -525,12 +525,14 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties, SkipTag=cms.VIn
             ])
 
             # extra stuff for subjets
-            JetPropertiesAK8.properties.extend(["SJptD", "SJaxismajor", "SJaxisminor", "SJmultiplicity"])
+            JetPropertiesAK8.properties.extend(["jecFactorSubjets", "SJptD", "SJaxismajor", "SJaxisminor", "SJmultiplicity"])
+            JetPropertiesAK8.jecFactorSubjets = cms.vstring('SoftDropPuppiUpdated')
             JetPropertiesAK8.SJptD = cms.vstring('SoftDropPuppiUpdated','QGTaggerSubjets:ptD')
             JetPropertiesAK8.SJaxismajor = cms.vstring('SoftDropPuppiUpdated','QGTaggerSubjets:axis1')
             JetPropertiesAK8.SJaxisminor = cms.vstring('SoftDropPuppiUpdated','QGTaggerSubjets:axis2')
             JetPropertiesAK8.SJmultiplicity = cms.vstring('SoftDropPuppiUpdated','QGTaggerSubjets:mult')
             self.VectorVectorDouble.extend([
+                'JetProperties'+suff+':jecFactorSubjets(Jets'+suff+'_subjets_jecFactor)',
                 'JetProperties'+suff+':SJptD(Jets'+suff+'_subjets_ptD)',
                 'JetProperties'+suff+':SJaxismajor(Jets'+suff+'_subjets_axismajor)',
                 'JetProperties'+suff+':SJaxisminor(Jets'+suff+'_subjets_axisminor)',

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -335,16 +335,17 @@ def makeTreeFromMiniAOD(self,process):
         updateJetCollection(
             process,
             jetSource = SubjetTag,
-            labelName = 'AK4',
+            labelName = 'slimmedJetsAK8PFPuppiSoftDropPackedSubJets',
             postfix = 'UpdatedJEC',
             jetCorrections = ('AK4PFPuppi', levels, 'None'),
             pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
             svSource = cms.InputTag('slimmedSecondaryVertices'),
             rParam = 0.4,
-            btagDiscriminators = ['None'],
+            btagDiscriminators = ['pfCombinedInclusiveSecondaryVertexV2BJetTags'],
             printWarning = bool(self.verbose),
         )
-        SubjetTag = cms.InputTag(SubjetTag.value()+'UpdatedJEC')
+
+        SubjetTag = cms.InputTag('updatedPatJetsSlimmedJetsAK8PFPuppiSoftDropPackedSubJetsUpdatedJEC')
        
         # update the MET to account for the new JECs
         from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -237,6 +237,11 @@ def makeTreeFromMiniAOD(self,process):
                 ),
                 cms.PSet(
                     record = cms.string("JetCorrectionsRecord"),
+                    tag    = cms.string("JetCorrectorParametersCollection_"+JECera+"_AK4PFPuppi"),
+                    label  = cms.untracked.string("AK4PFPuppi")
+                ),
+                cms.PSet(
+                    record = cms.string("JetCorrectionsRecord"),
                     tag    = cms.string("JetCorrectorParametersCollection_"+JECera+"_AK8PFPuppi"),
                     label  = cms.untracked.string("AK8PFPuppi")
                 ),
@@ -345,7 +350,7 @@ def makeTreeFromMiniAOD(self,process):
             printWarning = bool(self.verbose),
         )
 
-        SubjetTag = cms.InputTag('updatedPatJetsSlimmedJetsAK8PFPuppiSoftDropPackedSubJetsUpdatedJEC')
+        SubjetTag = cms.InputTag('updatedPatJetsTransientCorrectedSlimmedJetsAK8PFPuppiSoftDropPackedSubJetsUpdatedJEC')
        
         # update the MET to account for the new JECs
         from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -329,7 +329,23 @@ def makeTreeFromMiniAOD(self,process):
             process.pfDeepBoostedJetTagInfosAK8UpdatedJEC.min_jet_pt = cms.double(0)
 
         JetAK8Tag = cms.InputTag('updatedPatJetsTransientCorrectedAK8UpdatedJEC')
-        
+ 
+        # update the corrections for the subjets from the AK8 jets
+        # the references from the AK8 jets to the subjects will be fixed later on
+        updateJetCollection(
+            process,
+            jetSource = SubjetTag,
+            labelName = 'AK4',
+            postfix = 'UpdatedJEC',
+            jetCorrections = ('AK4PFPuppi', levels, 'None'),
+            pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+            svSource = cms.InputTag('slimmedSecondaryVertices'),
+            rParam = 0.4,
+            btagDiscriminators = ['None'],
+            printWarning = bool(self.verbose),
+        )
+        SubjetTag = cms.InputTag(SubjetTag.value()+'UpdatedJEC')
+       
         # update the MET to account for the new JECs
         from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
         runMetCorAndUncFromMiniAOD(

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -52,6 +52,7 @@ class maker:
         
         # other options off by default
         self.getParamDefault("debugtracks", False)
+        self.getParamDefault("debugsubjets", False)
         self.getParamDefault("applybaseline", False)
         self.getParamDefault("saveMinimalGenParticles", True)
         
@@ -129,6 +130,7 @@ class maker:
         print " storing PDF weights: "+str(self.doPDFs)
         print " "
         print " storing track debugging variables: "+str(self.debugtracks)
+        print " storing subjet debugging variables: "+str(self.debugsubjets)
         print " Applying baseline selection filter: "+str(self.applybaseline)
         print " Storing a minimal set of GenParticles: "+str(self.saveMinimalGenParticles)
         print " "

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -255,7 +255,7 @@ class NamedPtr_softDropMass : public NamedPtr<double> {
 			LorentzVector fatJet;
 			auto const & subjets = Jet.subjets(extraInfo.at(0));
 			for ( auto const & it : subjets ) {
-				fatJet += it->correctedP4(0);
+				fatJet += it->p4();
 			}
 			push_back(fatJet.M());
 		}

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -387,7 +387,7 @@ class NamedPtr_subjets : public NamedPtr<std::vector<TLorentzVector>> {
 			const auto& subjets = Jet.subjets(extraInfo.at(0));
 			subvecs.reserve(subjets.size());
 			for (const auto& subjet : subjets) {
-				const auto& p4 = subjet->correctedP4(0);
+				const auto& p4 = subjet->p4();
 				subvecs.emplace_back(p4.px(),p4.py(),p4.pz(),p4.energy());
 			}
 			ptr->push_back(subvecs);
@@ -397,6 +397,21 @@ DEFINE_NAMED_PTR(subjets);
 
 //----------------------------------------------------------------------------------------------------------------------------------------
 //subjet floats
+
+class NamedPtr_SJjec : public NamedPtr<std::vector<double>> {
+	public:
+		using NamedPtr<std::vector<double>>::NamedPtr;
+		void get_property(const pat::Jet& Jet) override {
+			std::vector<double> vec;
+			auto const & subjets = Jet.subjets(extraInfo.at(0));
+			vec.reserve(subjets.size());
+			for ( auto const & it : subjets ) {
+				vec.push_back(it->jecFactor(it->availableJECLevels().back())/it->jecFactor("Uncorrected"));
+			}
+			ptr->push_back(vec);
+		}
+};
+DEFAULT_NAMED_PTR(SJjec,jecFactorSubjets);
 
 class NamedPtr_SJD : public NamedPtr<std::vector<double>> {
 	public:

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -25,6 +25,7 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 #include "TreeMaker/Utils/interface/EnergyFractionCalculator.h"
 
@@ -37,7 +38,11 @@ class NamedPtrBase {
 	public:
 		//constructor
 		NamedPtrBase() : name(""), fraction(false) {}
-		NamedPtrBase(std::string name_, edm::stream::EDProducer<>* edprod, const edm::ParameterSet& iConfig) : name(name_), fraction(name.find("Fraction")!=std::string::npos) {
+		NamedPtrBase(std::string name_, edm::stream::EDProducer<>* edprod, const edm::ParameterSet& iConfig) : 
+			name(name_),
+			fraction(name.find("Fraction")!=std::string::npos),
+			response(name.find("response")!=std::string::npos)
+		{
 			if(iConfig.exists(name)) extraInfo = iConfig.getParameter<std::vector<std::string>>(name);
 		}
 		//destructor
@@ -47,10 +52,12 @@ class NamedPtrBase {
 		virtual void reset() { }
 		virtual void get_property(const pat::Jet& Jet) { }
 		virtual void get_property(const EnergyFractionCalculator& Jet) { }
+		virtual void get_property(const pat::Jet& Jet, const edm::View<reco::GenJet>& GenSubjets) { }
 	
 		//member variables
 		std::string name;
 		bool fraction;
+		bool response;
 		std::vector<std::string> extraInfo;		
 };
 
@@ -413,6 +420,32 @@ class NamedPtr_SJjec : public NamedPtr<std::vector<double>> {
 };
 DEFAULT_NAMED_PTR(SJjec,jecFactorSubjets);
 
+class NamedPtr_SJresp : public NamedPtr<std::vector<double>> {
+	public:
+		using NamedPtr<std::vector<double>>::NamedPtr;
+		void get_property(const pat::Jet& Jet, const edm::View<reco::GenJet>& GenSubjets) override {
+			bool matched = false;
+			std::vector<double> vec;
+			auto const & subjets = Jet.subjets(extraInfo.at(0));
+			vec.reserve(subjets.size());
+			for ( auto const & it : subjets ) {
+				matched = false;
+				for ( auto const & gsj : GenSubjets ) {
+					if ( reco::deltaR(*it, gsj) < 0.1 ) {
+						vec.push_back(it->pt()/gsj.pt());
+						matched = true;
+						break;
+					}
+				} // loop through all of the gen subjets
+				if (!matched) {
+					vec.push_back(0);
+				}
+			} // loop through the subjets for a given jet
+			ptr->push_back(vec);
+		}
+};
+DEFAULT_NAMED_PTR(SJresp,SJresponse);
+
 class NamedPtr_SJD : public NamedPtr<std::vector<double>> {
 	public:
 		using NamedPtr<std::vector<double>>::NamedPtr;
@@ -475,8 +508,9 @@ private:
 	void produce(edm::Event&, const edm::EventSetup&) override;
 	std::string debugMessage(const pat::Jet& Jet, const std::string& name, int indent=0);
 	
-	edm::InputTag JetTag_;
+	edm::InputTag JetTag_, GenSubjetTag_;
 	edm::EDGetTokenT<edm::View<pat::Jet>> JetTok_;
+	edm::EDGetTokenT<edm::View<reco::GenJet>> GenSubjetTok_;
 	std::vector<NamedPtrBase*> Ptrs_;
 	bool debug;
 };
@@ -490,9 +524,15 @@ JetProperties::JetProperties(const edm::ParameterSet& iConfig)
 	JetTok_ = consumes<edm::View<pat::Jet>>(JetTag_);
 	debug = iConfig.getParameter<bool>("debug");
 
+	//get gen subjet values only if that collection is necessary
+	if (iConfig.exists("GenSubjetTag")) {
+		GenSubjetTag_ = iConfig.getParameter<edm::InputTag>("GenSubjetTag");
+		GenSubjetTok_ = consumes<edm::View<reco::GenJet>>(GenSubjetTag_);
+	}
+
 	//get lists of desired properties
 	std::vector<std::string> props = iConfig.getParameter<std::vector<std::string>> ("properties");
-	
+
 	auto fac = NamedPtrFactory::get();
 	Ptrs_.reserve(props.size());
 	//register your products
@@ -526,12 +566,15 @@ JetProperties::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	}
 
 	edm::Handle< edm::View<pat::Jet> > Jets;
+	edm::Handle< edm::View<reco::GenJet> > GenSubjets;
 	iEvent.getByToken(JetTok_,Jets);
+	if (!GenSubjetTok_.isUninitialized()) iEvent.getByToken(GenSubjetTok_,GenSubjets);
 	if( Jets.isValid() ) {
 		for(const auto& Jet : *Jets){
 			EnergyFractionCalculator efc(Jet);
 			for(auto & Ptr : Ptrs_){
 				if(Ptr->fraction) Ptr->get_property(efc);
+				else if(GenSubjets.isValid() && Ptr->response) Ptr->get_property(Jet,*GenSubjets);
 				else Ptr->get_property(Jet);
 			}
 			//for debugging: print out available subjet collections, btag discriminators, userfloats/ints


### PR DESCRIPTION
Currently the subjets stored in the ntuples and used for the softdrop mass do not use any JECs. This PR will store the subjets with JECs and will use those to compute the softdrop mass. These same subjets will also be propagated to the other properties which make use of subjets.

Along the way, this PR grew to add the subjet JEC to the tree and to add a debugging option to store the subjet response.

The code has been checked and the JECs are updated when using the new code (if it's commented out the original subjets from the MiniAOD will be used). The attached plot shows what happens to the response with and without the new code.

[SubjetJECUpdate.pdf](https://github.com/TreeMaker/TreeMaker/files/4032913/SubjetJECUpdate.pdf)