### PR TITLE
[Run2_2017] Changes to how the trigger names are stored

### DIFF
--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -18,6 +18,7 @@
 
 //ROOT headers
 #include "TString.h"
+#include "TBranch.h"
 #include "TTree.h"
 #include <TFile.h>
 #include "TLorentzVector.h"
@@ -71,6 +72,7 @@ class TreeMaker : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 		UInt_t lumiBlockNum{};
 		ULong64_t evtNum{};
 		vector<TreeObjectBase*> variables;
+		map<string,string> titleMap;
 };
 
 //base class for tree objects
@@ -78,7 +80,7 @@ class TreeObjectBase {
 	public:
 		//constructor
 		TreeObjectBase() : tempFull(""), branchType("") {}
-		TreeObjectBase(string tempFull_) : tempFull(tempFull_), nameInTree(tempFull_), tagName(tempFull_), tree(nullptr) {}
+		TreeObjectBase(string tempFull_, string title_ = "") : tempFull(tempFull_), nameInTree(tempFull_), tagName(tempFull_), title(title_), tree(nullptr) {}
 		//destructor
 		virtual ~TreeObjectBase() {}
 		//functions
@@ -86,6 +88,7 @@ class TreeObjectBase {
 		virtual void Initialize(map<string,unsigned>& nameCache, edm::ConsumesCollector && iC, stringstream& message) {}
 		virtual void SetTree(TTree* tree_) { tree = tree_; }
 		virtual void AddBranch() {}
+		virtual void AddTitle() { if(branch) branch->SetTitle(title.c_str()); }
 		virtual void SetDefault() {}
 		virtual void FillTree(const edm::Event& iEvent) {}
 		
@@ -108,9 +111,10 @@ class TreeObjectBase {
 		
 	protected:
 		//member variables
-		string tempFull, nameInTree, tagName, branchType;
+		string tempFull, nameInTree, tagName, branchType, title;
 		TTree* tree{};
 		edm::InputTag tag;
+		TBranch* branch{};
 };
 
 //comparator (case-insensitive sort)
@@ -132,7 +136,7 @@ class TreeObject : public TreeObjectBase {
 	public:
 		//constructor
 		TreeObject() : TreeObjectBase() {}
-		TreeObject(string tempFull_) : TreeObjectBase(tempFull_) {}
+		TreeObject(string tempFull_, string title_) : TreeObjectBase(tempFull_,title_) {}
 		//destructor
 		~TreeObject() override {}
 		//functions
@@ -261,7 +265,7 @@ class TreeRecoCand : public TreeObject<vector<TLorentzVector> > {
 	public:
 		//constructor
 		TreeRecoCand() : TreeObject<vector<TLorentzVector> >() {}
-		TreeRecoCand(string tempFull_, bool doLorentz_=true) : TreeObject<vector<TLorentzVector> >(tempFull_), doLorentz(doLorentz_) {}
+		TreeRecoCand(string tempFull_, string title_="", bool doLorentz_=true) : TreeObject<vector<TLorentzVector> >(tempFull_,title_), doLorentz(doLorentz_) {}
 		//destructor
 		~TreeRecoCand() override {}
 		

--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -63,7 +63,7 @@ class TreeMaker : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 		edm::Service<TFileService> fs;
 		string treeName;
 		TTree* tree;	
-		bool doLorentz, sortBranches;
+		bool doLorentz, sortBranches, debugTitles;
 		vector<string> VarTypeNames;
 		vector<TreeTypes> VarTypes;
 		map<string,unsigned> nameCache;
@@ -88,7 +88,7 @@ class TreeObjectBase {
 		virtual void Initialize(map<string,unsigned>& nameCache, edm::ConsumesCollector && iC, stringstream& message) {}
 		virtual void SetTree(TTree* tree_) { tree = tree_; }
 		virtual void AddBranch() {}
-		virtual void AddTitle() { if(branch) branch->SetTitle(title.c_str()); }
+		virtual void AddTitle() { if(branch && !title.empty()) branch->SetTitle(title.c_str()); }
 		virtual void SetDefault() {}
 		virtual void FillTree(const edm::Event& iEvent) {}
 		

--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -194,35 +194,35 @@ class TreeObject : public TreeObjectBase {
 //specialize!
 
 template<>
-void TreeObject<bool>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),&value,(nameInTree+"/O").c_str()); }
+void TreeObject<bool>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),&value,(nameInTree+"/O").c_str()); }
 template<>
-void TreeObject<int>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),&value,(nameInTree+"/I").c_str()); }
+void TreeObject<int>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),&value,(nameInTree+"/I").c_str()); }
 template<>
-void TreeObject<double>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),&value,(nameInTree+"/D").c_str()); }
+void TreeObject<double>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),&value,(nameInTree+"/D").c_str()); }
 template<>
-void TreeObject<string>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),nameInTree.c_str(),&value); }
+void TreeObject<string>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),nameInTree.c_str(),&value); }
 template<>
-void TreeObject<TLorentzVector>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),nameInTree.c_str(),&value); }
+void TreeObject<TLorentzVector>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),nameInTree.c_str(),&value); }
 template<>
-void TreeObject<vector<bool> >::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<bool>",&value,32000,0); }
+void TreeObject<vector<bool> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<bool>",&value,32000,0); }
 template<>
-void TreeObject<vector<int> >::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<int>",&value,32000,0); }
+void TreeObject<vector<int> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<int>",&value,32000,0); }
 template<>
-void TreeObject<vector<double> >::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<double>",&value,32000,0); }
+void TreeObject<vector<double> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<double>",&value,32000,0); }
 template<>
-void TreeObject<vector<string> >::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<string>",&value,32000,0); }
+void TreeObject<vector<string> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<string>",&value,32000,0); }
 template<>
-void TreeObject<vector<TLorentzVector> >::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<TLorentzVector>",&value,32000,0); }
+void TreeObject<vector<TLorentzVector> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<TLorentzVector>",&value,32000,0); }
 template<>
-void TreeObject<vector<vector<bool>>>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<vector<bool>>",&value,32000,0); }
+void TreeObject<vector<vector<bool>>>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<vector<bool>>",&value,32000,0); }
 template<>
-void TreeObject<vector<vector<int>>>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<vector<int>>",&value,32000,0); }
+void TreeObject<vector<vector<int>>>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<vector<int>>",&value,32000,0); }
 template<>
-void TreeObject<vector<vector<double>>>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<vector<double>>",&value,32000,0); }
+void TreeObject<vector<vector<double>>>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<vector<double>>",&value,32000,0); }
 template<>
-void TreeObject<vector<vector<string>>>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<vector<string>>",&value,32000,0); }
+void TreeObject<vector<vector<string>>>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<vector<string>>",&value,32000,0); }
 template<>
-void TreeObject<vector<vector<TLorentzVector>>>::AddBranch() { if(tree) tree->Branch(nameInTree.c_str(),"vector<vector<TLorentzVector>>",&value,32000,0); }
+void TreeObject<vector<vector<TLorentzVector>>>::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<vector<TLorentzVector>>",&value,32000,0); }
 
 template<>
 void TreeObject<bool>::SetDefault() { value = false; }

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -46,6 +46,7 @@ def makeTreeFromMiniAOD(self,process):
         VectorVectorDouble         = self.VectorVectorDouble,
         VectorVectorString         = self.VectorVectorString,
         VectorVectorTLorentzVector = self.VectorVectorTLorentzVector,
+        TitleMap                   = self.TitleMap,
     )
 
     ## ----------------------------------------------------------------------------------------------
@@ -660,7 +661,21 @@ def makeTreeFromMiniAOD(self,process):
         triggerNameList = _triggerNameList
     )
     self.VectorInt.extend(['TriggerProducer:TriggerPass','TriggerProducer:TriggerPrescales','TriggerProducer:TriggerVersion'])
-    self.VectorString.extend(['TriggerProducer:TriggerNames'])
+    #self.VectorString.extend(['TriggerProducer:TriggerNames'])
+
+
+
+
+#################FIX ME
+    _joinedTriggerNameList = ','.join(_triggerNameList)
+    self.TitleMap.extend([
+        'TriggerProducer:TriggerPass',_joinedTriggerNameList,
+        'TriggerProducer:TriggerPrescales',_joinedTriggerNameList,
+        'TriggerProducer:TriggerVersion',_joinedTriggerNameList
+    ])
+
+
+
     if "SingleElectron" in process.source.fileNames[0] or "EGamma" in process.source.fileNames[0]:
         process.TriggerProducer.saveHLTObj = cms.bool(True)
         process.TriggerProducer.saveHLTObjPath = cms.string("HLT_Ele27_WPTight_Gsf_v")

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -3,6 +3,7 @@
 
 import FWCore.ParameterSet.Config as cms
 import sys,os
+from itertools import chain
 def makeTreeFromMiniAOD(self,process):
 
     ## ----------------------------------------------------------------------------------------------
@@ -660,21 +661,10 @@ def makeTreeFromMiniAOD(self,process):
         saveHLTObj = cms.bool(False),
         triggerNameList = _triggerNameList
     )
-    self.VectorInt.extend(['TriggerProducer:TriggerPass','TriggerProducer:TriggerPrescales','TriggerProducer:TriggerVersion'])
-    #self.VectorString.extend(['TriggerProducer:TriggerNames'])
-
-
-
-
-#################FIX ME
     _joinedTriggerNameList = ','.join(_triggerNameList)
-    self.TitleMap.extend([
-        'TriggerProducer:TriggerPass',_joinedTriggerNameList,
-        'TriggerProducer:TriggerPrescales',_joinedTriggerNameList,
-        'TriggerProducer:TriggerVersion',_joinedTriggerNameList
-    ])
-
-
+    _TriggerBranchesList = ['TriggerProducer:TriggerPass','TriggerProducer:TriggerPrescales','TriggerProducer:TriggerVersion']
+    self.VectorInt.extend(_TriggerBranchesList)
+    self.TitleMap.extend(list(chain.from_iterable([[x,_joinedTriggerNameList] for x in _TriggerBranchesList])))
 
     if "SingleElectron" in process.source.fileNames[0] or "EGamma" in process.source.fileNames[0]:
         process.TriggerProducer.saveHLTObj = cms.bool(True)

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -110,6 +110,7 @@ class maker:
         self.VectorVectorDouble         = cms.vstring()
         self.VectorVectorString         = cms.vstring()
         self.VectorVectorTLorentzVector = cms.vstring()
+        self.TitleMap                   = cms.vstring()
 
     def getParamDefault(self,param,default):
         setattr(self,param,self.parameters.value(param,default))

--- a/TreeMaker/python/treeMaker.py
+++ b/TreeMaker/python/treeMaker.py
@@ -9,6 +9,8 @@ TreeName = cms.string('RA2Tree'),
 doLorentz = cms.bool(True),
 #branches are sorted alphabetically by default
 sortBranches = cms.bool(True),
+#debug the InputTag to branch mapping by printing the mapping to the log
+debugTitles = cms.bool(False),
 # list of reco candidate objects: for each reco cand collection, the TLorentzVector will be stored in a vector.
 VarsBool = cms.vstring(),
 VarsInt = cms.vstring(),

--- a/TreeMaker/python/treeMaker.py
+++ b/TreeMaker/python/treeMaker.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 TreeMaker = cms.EDAnalyzer(
 'TreeMaker',
 # Name of the output tree
-TreeName          = cms.string('RA2Tree'),
+TreeName = cms.string('RA2Tree'),
 #default: output RecoCands as vector<TLorentzVector>
 #switches to vector<double> pt, eta, phi, energy if false
 doLorentz = cms.bool(True),
@@ -26,4 +26,5 @@ VectorVectorDouble = cms.vstring(),
 VectorVectorString = cms.vstring(),
 VectorVectorTLorentzVector = cms.vstring(),
 VectorRecoCand = cms.vstring(),
+TitleMap = cms.vstring(),
 )

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -144,6 +144,7 @@ TreeMaker::beginJob()
 	for(auto & variable : variables){
 		variable->SetTree(tree);
 		variable->AddBranch();
+		variable->AddTitle();
 	}
 }
 

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -56,7 +56,7 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 	set<string> titleSet;
 	vector<string> titleVector = iConfig.getParameter< vector<string> >("TitleMap");
 	if(titleVector.size()%2 != 0) {
-		cms::Exception ex("LogicError", "The vector containing the InputTags and titles is odd, indicating that there is not a 1-to-1 pairing");
+		cms::Exception ex("LogicError", "The vector containing the InputTags and titles has an odd number of entries, indicating that there is not a 1-to-1 pairing");
 		ex.addContext("Constructing the TreeMaker class");
 		throw ex;
 	}

--- a/Utils/src/TriggerProducer.cc
+++ b/Utils/src/TriggerProducer.cc
@@ -113,7 +113,6 @@ TriggerProducer::TriggerProducer(const edm::ParameterSet& iConfig)
   edm::InputTag theTrigObjLabel(iConfig.getParameter<edm::InputTag>("trigObj"));
   trigObjCollToken = consumes<pat::TriggerObjectStandAloneCollection>(theTrigObjLabel);
   
-  produces<std::vector<std::string> >("TriggerNames");
   produces<std::vector<int> >("TriggerPass");
   produces<std::vector<int> >("TriggerPrescales");
   produces<std::vector<int> >("TriggerVersion");
@@ -171,7 +170,6 @@ TriggerProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
   auto passTrigVec = std::make_unique<std::vector<int>>(parsedTrigNamesVec.size(),-1);
   auto trigPrescaleVec = std::make_unique<std::vector<int>>(parsedTrigNamesVec.size(),1);
   auto trigVersionVec = std::make_unique<std::vector<int>>(parsedTrigNamesVec.size(),0);
-  auto trigNamesVec = std::make_unique<std::vector<std::string>>(parsedTrigNamesVec);
   auto hltObj = std::make_unique<std::vector<TLorentzVector>>();
 
   //int passesTrigger;
@@ -222,7 +220,6 @@ TriggerProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
   iEvent.put(std::move(passTrigVec),"TriggerPass");
   iEvent.put(std::move(trigPrescaleVec),"TriggerPrescales");
   iEvent.put(std::move(trigVersionVec),"TriggerVersion");
-  iEvent.put(std::move(trigNamesVec),"TriggerNames");
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------


### PR DESCRIPTION
Add the ability to set a docstring/title for each branch. This mapping between InputTags and titles will be used to store the trigger names as a comma separated list in the branch title, rather than a vector of strings for each event. We end up storing the list three times, once per trigger branch, but that is still far less than the once per event we were doing before.

These modifications have been successfully tested using unit test 1 and 100 events. The log file size went from 63K to 75K, which is due to printing the InputTag to title association. This is a big string in the case of the trigger names. The number of branches went from 424 to 423, as expected.

The ROOT file size went from 879K to 754K, but this doesn't tell the entire story as the header size should stay roughly the same, ignoring the title strings, but the per event size will go down significantly. For the original method, the sum of the sizes of the compressed (uncompressed) branches* is 805.34 KB (2067.67 KB). For the new method this goes down to 680.64 KB (1645.88 KB). The average per event size of the tree* goes from 8.05 KB (20.68 KB) to 6.81 KB (16.46 KB), or a ~15.4% reduction in event size.

The TriggerNames branch took 113.46 KB (421.80 KB), or 1.13 KB (4.22 KB) per event. The fact that the compressed values don't make up the difference between the old and new methods can be explained by different compression ratios in the branches and other, more in-depth ROOT optimizations. 

* Data and offsets, not including any key headers.