### PR TITLE
[Run2_2017] Save information for primary vertices

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1122,7 +1122,22 @@ def makeTreeFromMiniAOD(self,process):
     ## Emerging jets
     ## ----------------------------------------------------------------------------------------------
     if self.emerging:
-        self.VarsInt.extend(['primaryVertices:_______(Vertices_)'])
+        self.VectorXYZPoint.extend(['primaryVertices:vtxposition(PrimaryVertices_position)'])
+        self.VectorDouble.extend([
+            'primaryVertices:vtxtime(PrimaryVertices_time)',
+            'primaryVertices:vtxndof(PrimaryVertices_ndof)',
+            'primaryVertices:vtxchi2(PrimaryVertices_chi2)',
+            'primaryVertices:vtxxError(PrimaryVertices_xError)',
+            'primaryVertices:vtxyError(PrimaryVertices_yError)',
+            'primaryVertices:vtxzError(PrimaryVertices_zError)',
+            'primaryVertices:vtxtError(PrimaryVertices_tError)',
+        ])
+        self.VectorBool.extend([
+            'primaryVertices:vtxisValid(PrimaryVertices_isValid)',
+            'primaryVertices:vtxisFake(PrimaryVertices_isFake)',
+            'primaryVertices:vtxisGood(PrimaryVertices_isGood)',
+        ])        
+        self.VectorInt.extend(['primaryVertices:vtxntracks(PrimaryVertices_nTracks)'])
 
         process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
         from TreeMaker.Utils.candidateTrackMaker_cfi import candidateTrackFilter

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -126,15 +126,12 @@ def makeTreeFromMiniAOD(self,process):
         filter = cms.bool(False)
     )
     from TreeMaker.Utils.primaryvertices_cfi import primaryvertices
-    process.NVtx = primaryvertices.clone(
-        VertexCollection  = cms.InputTag('goodVertices'),
+    process.primaryVertices = primaryvertices.clone(
+        VertexCollection     = cms.InputTag('offlineSlimmedPrimaryVertices'),
+        GoodVertexCollection = cms.InputTag('goodVertices'),
+        saveVertices         = cms.bool(True if self.emerging else False),
     )
-    self.VarsInt.extend(['NVtx'])
-    # also store total number of vertices without quality checks
-    process.nAllVertices = primaryvertices.clone(
-        VertexCollection  = cms.InputTag('offlineSlimmedPrimaryVertices'),
-    )
-    self.VarsInt.extend(['nAllVertices'])
+    self.VarsInt.extend(['primaryVertices:NVtx(NVtx)','primaryVertices:nAllVertices(nAllVertices)'])
     # also store rho for PU comparisons
     self.VarsDouble.extend(['fixedGridRhoFastjetAll'])
 
@@ -1125,8 +1122,9 @@ def makeTreeFromMiniAOD(self,process):
     ## Emerging jets
     ## ----------------------------------------------------------------------------------------------
     if self.emerging:
-        process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
+        self.VarsInt.extend(['primaryVertices:_______(Vertices_)'])
 
+        process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
         from TreeMaker.Utils.candidateTrackMaker_cfi import candidateTrackFilter
         process.trackFilter = candidateTrackFilter.clone(
                 vertexInputTag    = cms.InputTag("goodVertices"),

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -129,7 +129,7 @@ def makeTreeFromMiniAOD(self,process):
     process.primaryVertices = primaryvertices.clone(
         VertexCollection     = cms.InputTag('offlineSlimmedPrimaryVertices'),
         GoodVertexCollection = cms.InputTag('goodVertices'),
-        saveVertices         = cms.bool(True if self.emerging else False),
+        saveVertices         = cms.bool(self.emerging),
     )
     self.VarsInt.extend(['primaryVertices:NVtx(NVtx)','primaryVertices:nAllVertices(nAllVertices)'])
     # also store rho for PU comparisons

--- a/Utils/python/primaryvertices_cfi.py
+++ b/Utils/python/primaryvertices_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-primaryvertices = cms.EDProducer('PrimaryVerticesInt',
-VertexCollection  = cms.InputTag('offlineSlimmedPrimaryVertices'),
+primaryvertices = cms.EDProducer('PrimaryVerticesProducer',
+    VertexCollection     = cms.InputTag('offlineSlimmedPrimaryVertices'),
+    GoodVertexCollection = cms.InputTag('goodVertices'),
+    saveVertices         = cms.bool(False),
 )

--- a/Utils/src/PrimaryVerticesProducer.cc
+++ b/Utils/src/PrimaryVerticesProducer.cc
@@ -10,10 +10,65 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/Math/interface/Point3D.h"
 
 //
 // class declaration
 //
+class VertexInfos {
+public:
+	VertexInfos() {
+		vtx_position = std::make_unique<std::vector<math::XYZPoint>>();
+		vtx_time     = std::make_unique<std::vector<double>>();
+		vtx_isValid  = std::make_unique<std::vector<bool>>();
+		vtx_isFake   = std::make_unique<std::vector<bool>>();
+		vtx_isGood   = std::make_unique<std::vector<bool>>();
+		vtx_ndof     = std::make_unique<std::vector<double>>();
+		vtx_chi2     = std::make_unique<std::vector<double>>();
+		vtx_xError   = std::make_unique<std::vector<double>>();
+		vtx_yError   = std::make_unique<std::vector<double>>();
+		vtx_zError   = std::make_unique<std::vector<double>>();
+		vtx_tError   = std::make_unique<std::vector<double>>();
+		vtx_ntracks  = std::make_unique<std::vector<int>>();
+	}
+
+	void fill(const reco::Vertex & vertex, bool good) {
+		vtx_position->push_back(vertex.position());
+		vtx_time->push_back(vertex.t());
+		vtx_isValid->push_back(vertex.isValid());
+		vtx_isFake->push_back(vertex.isFake());
+		vtx_isGood->push_back(good);
+		vtx_ndof->push_back(vertex.ndof());
+		vtx_chi2->push_back(vertex.chi2());
+		vtx_xError->push_back(vertex.xError());
+		vtx_yError->push_back(vertex.yError());
+		vtx_zError->push_back(vertex.zError());
+		vtx_tError->push_back(vertex.tError());
+		vtx_ntracks->push_back(vertex.nTracks());
+
+	}
+
+	void put(edm::Event & iEvent) {
+		iEvent.put(std::move(vtx_position), "vtxposition");
+		iEvent.put(std::move(vtx_time),     "vtxtime");
+		iEvent.put(std::move(vtx_isValid),  "vtxisValid");
+		iEvent.put(std::move(vtx_isFake),   "vtxisFake");
+		iEvent.put(std::move(vtx_isGood),   "vtxisGood");
+		iEvent.put(std::move(vtx_ndof),     "vtxndof");
+		iEvent.put(std::move(vtx_chi2),     "vtxchi2");
+		iEvent.put(std::move(vtx_xError),   "vtxxError");
+		iEvent.put(std::move(vtx_yError),   "vtxyError");
+		iEvent.put(std::move(vtx_zError),   "vtxzError");
+		iEvent.put(std::move(vtx_tError),   "vtxtError");
+		iEvent.put(std::move(vtx_ntracks),  "vtxntracks");
+	}
+
+// ----------member data ---------------------------
+	std::unique_ptr<std::vector<math::XYZPoint>> vtx_position;
+	std::unique_ptr<std::vector<bool>> vtx_isValid, vtx_isFake, vtx_isGood;
+	std::unique_ptr<std::vector<double>> vtx_time, vtx_ndof, vtx_chi2, vtx_xError, vtx_yError, vtx_zError, vtx_tError;
+	std::unique_ptr<std::vector<int>> vtx_ntracks;
+};
 
 class PrimaryVerticesProducer : public edm::global::EDProducer<> {
 public:
@@ -28,6 +83,7 @@ private:
 	// ----------member data ---------------------------
 	edm::InputTag vertexCollectionTag_, goodVertexCollectionTag_;
 	edm::EDGetTokenT<reco::VertexCollection> vertexCollectionTok_, goodVertexCollectionTok_;
+	bool saveVertices_;
 };
 
 //
@@ -37,10 +93,25 @@ PrimaryVerticesProducer::PrimaryVerticesProducer(const edm::ParameterSet& iConfi
 vertexCollectionTag_(iConfig.getParameter<edm::InputTag>("VertexCollection")),
 goodVertexCollectionTag_(iConfig.getParameter<edm::InputTag>("GoodVertexCollection")),
 vertexCollectionTok_(consumes<reco::VertexCollection>(vertexCollectionTag_)),
-goodVertexCollectionTok_(consumes<reco::VertexCollection>(goodVertexCollectionTag_))
+goodVertexCollectionTok_(consumes<reco::VertexCollection>(goodVertexCollectionTag_)),
+saveVertices_(iConfig.getParameter<bool>("saveVertices"))
 {	
 	produces<int>("NVtx");
 	produces<int>("nAllVertices");
+	if (saveVertices_) {
+		produces<std::vector<math::XYZPoint> > ("vtxposition");
+		produces<std::vector<double> >         ("vtxtime");
+		produces<std::vector<bool> >           ("vtxisValid");
+		produces<std::vector<bool> >           ("vtxisFake");
+		produces<std::vector<bool> >           ("vtxisGood");
+		produces<std::vector<double> >         ("vtxndof");
+		produces<std::vector<double> >         ("vtxchi2");
+		produces<std::vector<double> >         ("vtxxError");
+		produces<std::vector<double> >         ("vtxyError");
+		produces<std::vector<double> >         ("vtxzError");
+		produces<std::vector<double> >         ("vtxtError");
+		produces<std::vector<int> >            ("vtxntracks");
+	}
 }
 
 
@@ -61,7 +132,7 @@ PrimaryVerticesProducer::~PrimaryVerticesProducer()
 void
 PrimaryVerticesProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
-	edm::Handle<reco::VertexCollection> vertices;
+	edm::Handle<reco::VertexCollection> vertices, goodVertices;
 	int nVertices=0, nGoodVertices=0;
 
 	iEvent.getByToken(vertexCollectionTok_,vertices);
@@ -69,18 +140,32 @@ PrimaryVerticesProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 		nVertices = vertices->size();
 	}
 	else edm::LogWarning("TreeMaker")<<"Warning VertexCollection Tag not valid: "<<vertexCollectionTag_;
+	auto nVerticesPtr     = std::make_unique<int>(nVertices);
 
-	iEvent.getByToken(goodVertexCollectionTok_,vertices);
-	if( vertices.isValid() ) {
-		nGoodVertices = vertices->size();
+	iEvent.getByToken(goodVertexCollectionTok_,goodVertices);
+	if( goodVertices.isValid() ) {
+		nGoodVertices = goodVertices->size();
 	}
 	else edm::LogWarning("TreeMaker")<<"Warning VertexCollection Tag not valid: "<<goodVertexCollectionTag_;
-
-	auto nVerticesPtr     = std::make_unique<int>(nVertices);
 	auto nGoodVerticesPtr = std::make_unique<int>(nGoodVertices);
+
+	VertexInfos infos;
+	if (saveVertices_){
+		for (size_t i=0; i<vertices->size();i++) {
+			const reco::Vertex vertex = (*vertices)[i];
+
+			reco::VertexCollection::const_iterator it;
+			it = std::find_if(goodVertices->begin(), goodVertices->end(), [&vertex](reco::Vertex const& obj){
+					return obj.position() == vertex.position();
+				} );
+
+			infos.fill(vertex,it!=goodVertices->end());
+		}
+		infos.put(iEvent);
+	}
+
 	iEvent.put(std::move(nVerticesPtr    ), "nAllVertices");
 	iEvent.put(std::move(nGoodVerticesPtr), "NVtx");
-	
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------


### PR DESCRIPTION
Changes the PrimaryVerticesInt producer to save the good vertex and all primary vertices ints at the same time. Also allows use to save the primary vertex information for all vertices, marking off if it was included in the collection of good vertices. Without saving any emerging jets information, the per event size is 6.81 KiB. After saving just the track information this goes to 24.02 KiB. After the addition of the vertices, the size again grows to 30.42 KiB.