### PR TITLE
[Run2_2017] Automatically create Docker images as part of a CI GitHub Action

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ Run2_2017_Docker ]
+    branches: [ Run2_2017 ]
   pull_request:
-    branches: [ Run2_2017_Docker ]
+    branches: [ Run2_2017 ]
 
 env:
   current_branch: $(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')
@@ -21,11 +21,11 @@ jobs:
     - name: Run a CVMFS Docker image and run the setup script
       run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker --entrypoint "/bin/bash" aperloff/cms-cvmfs-docker:light -c "/run.sh -c \"wget https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/setup.sh && chmod +x setup.sh && ./setup.sh -a https -f ${{ github.actor }} -b ${{ env.current_branch }} -B -j 2\" && cvmfs_config wipecache"
     - name: Commit the changes
-      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:latest
+      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-latest
     - name: Log into registry
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
-      run: docker push treemaker/treemaker:latest
+      run: docker push treemaker/treemaker:${{ env.current_branch }}-latest
   integration-test:
     runs-on: ubuntu-latest
     needs: [build]
@@ -39,8 +39,8 @@ jobs:
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
       run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker treemaker/treemaker:latest -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=25 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
     - name: Commit the changes
-      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:cache
+      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
-      run: docker push treemaker/treemaker:cache
+      run: docker push treemaker/treemaker:${{ env.current_branch }}-cache

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -31,13 +31,13 @@ jobs:
     needs: [build]
     if: "!contains(github.event.head_commit.message, '[skip test]')"
     steps:
-    - name: Run the container and perform an intregration test
+    - name: Run the container and perform an integration test
       env:
         download_url: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
         file_name: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
         era: Summer16
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
-      run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker treemaker/treemaker:latest -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=25 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True && pgrep cmsRun | xargs -I {} tail --pid={} -f /dev/null && cat *.log && rm *.root && rm *.log"
+      run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker treemaker/treemaker:latest -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=25 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:cache
     - name: Log into registry

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,27 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ Run2_2017_Docker ]
+  pull_request:
+    branches: [ Run2_2017_Docker ]
+
+env:
+  current_branch: $(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Look at key environment variables
+      run: echo -e "GITHUB_REF=${{ github.ref }}\nGITHUB_ACTOR=${{ github.actor }}\nGITHUB_REPOSITORY=${{ github.repository }}\nGITHUB_SHA=${{ github.sha }}\nBANCH=${{ env.current_branch }}"
+    - name: Take a look around
+      run: pwd && ls -alh
+    - name: Run a CVMFS Docker image and run the setup script
+      run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker --entrypoint "/bin/bash" aperloff/cms-cvmfs-docker:light -c "/run.sh -c \"wget https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/setup.sh && chmod +x setup.sh && ./setup.sh -a https -f ${{ github.actor }} -b ${{ env.current_branch }} -B\" && cvmfs_config wipecache"
+    - name: Commit the changes
+      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:latest
+    - name: Log into registry
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+    - name: Publish the new docker image
+      run: docker push treemaker/treemaker:latest

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -12,25 +12,32 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
     steps:
     - name: Look at key environment variables
       run: echo -e "GITHUB_REF=${{ github.ref }}\nGITHUB_ACTOR=${{ github.actor }}\nGITHUB_REPOSITORY=${{ github.repository }}\nGITHUB_SHA=${{ github.sha }}\nBANCH=${{ env.current_branch }}"
     - name: Take a look around
       run: pwd && ls -alh
     - name: Run a CVMFS Docker image and run the setup script
-      run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker --entrypoint "/bin/bash" aperloff/cms-cvmfs-docker:light -c "/run.sh -c \"wget https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/setup.sh && chmod +x setup.sh && ./setup.sh -a https -f ${{ github.actor }} -b ${{ env.current_branch }} -B\" && cvmfs_config wipecache"
+      run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker --entrypoint "/bin/bash" aperloff/cms-cvmfs-docker:light -c "/run.sh -c \"wget https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/setup.sh && chmod +x setup.sh && ./setup.sh -a https -f ${{ github.actor }} -b ${{ env.current_branch }} -B -j 2\" && cvmfs_config wipecache"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:latest
     - name: Log into registry
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
       run: docker push treemaker/treemaker:latest
-  test:
+  integration-test:
     runs-on: ubuntu-latest
     needs: [build]
+    if: "!contains(github.event.head_commit.message, '[skip test]')"
     steps:
     - name: Run the container and perform an intregration test
-      run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker treemaker/treemaker:latest -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && python unitTest.py test=15 run=True && rm *.root && rm *.log"
+      env:
+        download_url: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
+        file_name: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
+        era: Summer16
+        output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
+      run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker treemaker/treemaker:latest -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=25 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True && pgrep cmsRun | xargs -I {} tail --pid={} -f /dev/null && cat *.log && rm *.root && rm *.log"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:cache
     - name: Log into registry

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -25,3 +25,15 @@ jobs:
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
       run: docker push treemaker/treemaker:latest
+  test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - name: Run the container and perform an intregration test
+      run: docker run -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker treemaker/treemaker:latest -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && python unitTest.py test=15 run=True && rm *.root && rm *.log"
+    - name: Commit the changes
+      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:cache
+    - name: Log into registry
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+    - name: Publish the new docker image
+      run: docker push treemaker/treemaker:cache

--- a/Production/test/unitTest.py
+++ b/Production/test/unitTest.py
@@ -28,65 +28,81 @@ def printTest(mytest, itest):
     logname = mytest[-1]
     tmp = str(itest)+":\n  "+" \\\n  ".join(mytest[0:-1])+" \\\n "+" >& "+logname+" &"
     print tmp
-    
-# Read parameters
-from TreeMaker.Utils.CommandLineParams import CommandLineParams
-parameters = CommandLineParams()
-test=parameters.value("test",-1)
-name=parameters.value("name","")
-run=parameters.value("run",False)
-numevents=parameters.value("numevents",100)
-command=parameters.value("command","")
 
-# only set name for a specific test
-if test==-1: name = ""
+def defineTests(mytests, scenario, name, numevents, command, dataset, inputFilesConfig):
+    # activate these when the requisite MC exists
+    mytests.append(makeTest("Summer16v3","Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Summer16v3","Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Summer16v3sig","Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Summer16v3sigscan","Summer16v3.SMS-T5qqqqZH-mGluino-1000to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T5qqqqZH-mGluino-1000to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Summer16v3Fast","Summer16v3Fast.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3Fast.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Summer16v3Fastsig","Summer16v3Fast.SMS-T1tttt_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3Fast.SMS-T1tttt_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("2016ReReco17Jul",name,numevents,command,inputFilesConfig="Run2016G-17Jul2018-v1.MET",nstart=0,nfiles=10))
+    mytests.append(makeTest("Fall17","Fall17.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Fall17","Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Fall17sig","Fall17.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Fall17Fast","Fall17Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Fall17Fastsig","Fall17Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("2017ReReco31Mar",name,numevents,command,inputFilesConfig="Run2017B-31Mar2018-v1.MET",nstart=0,nfiles=10))
+    mytests.append(makeTest("Summer16","Summer16.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/0010CF3F-1EB7-E611-A46F-00266CFFA678.root"))
+    mytests.append(makeTest("Summer16","Summer16.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0044D655-9DBE-E611-A9D1-008CFA56D764.root"))
+    mytests.append(makeTest("Summer16","Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata",numevents,command,dataset="/eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/0048131D-3CB3-E611-813A-001E67DFFB31.root",redir="root://eospublic.cern.ch/"))
+    mytests.append(makeTest("Summer16sig","SMS-T1tttt_mGluino-1500_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/SMS-T1tttt_mGluino-1500_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0818BABF-64BE-E611-B201-008CFA000280.root"))
+    mytests.append(makeTest("Autumn18","Autumn18.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8_ext1",numevents,command,inputFilesConfig="Autumn18.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8_ext1",nstart=0,nfiles=10))
+    mytests.append(makeTest("Autumn18Fast","Autumn18Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Autumn18Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("Autumn18Fastsig","Autumn18Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Autumn18Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(makeTest("2018B26Sep",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018-v1.JetHT",nstart=0,nfiles=10))
+    mytests.append(makeTest("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEM-v1.JetHT",nstart=0,nfiles=10))
+    mytests.append(makeTest("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEMmitigation-v1.JetHT",nstart=0,nfiles=10))
+    mytests.append(makeTest("2018PromptReco",name,numevents,command,inputFilesConfig="Run2018D-PromptReco-v2.JetHT",nstart=244,nfiles=10))
+    mytests.append(makeTest("2018ReReco17Sep",name,numevents,command,inputFilesConfig="Run2018B-17Sep2018-v1.JetHT",nstart=0,nfiles=10))
 
-# list of tests
-mytests = []
-# activate these when the requisite MC exists
-mytests.append(makeTest("Summer16v3","Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Summer16v3","Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Summer16v3sig","Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Summer16v3sigscan","Summer16v3.SMS-T5qqqqZH-mGluino-1000to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T5qqqqZH-mGluino-1000to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Summer16v3Fast","Summer16v3Fast.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3Fast.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Summer16v3Fastsig","Summer16v3Fast.SMS-T1tttt_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3Fast.SMS-T1tttt_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("2016ReReco17Jul",name,numevents,command,inputFilesConfig="Run2016G-17Jul2018-v1.MET",nstart=0,nfiles=10))
-mytests.append(makeTest("Fall17","Fall17.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Fall17","Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Fall17sig","Fall17.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Fall17Fast","Fall17Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Fall17Fastsig","Fall17Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("2017ReReco31Mar",name,numevents,command,inputFilesConfig="Run2017B-31Mar2018-v1.MET",nstart=0,nfiles=10))
-mytests.append(makeTest("Summer16","Summer16.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/0010CF3F-1EB7-E611-A46F-00266CFFA678.root"))
-mytests.append(makeTest("Summer16","Summer16.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0044D655-9DBE-E611-A9D1-008CFA56D764.root"))
-mytests.append(makeTest("Summer16","Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata",numevents,command,dataset="/eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/0048131D-3CB3-E611-813A-001E67DFFB31.root",redir="root://eospublic.cern.ch/"))
-mytests.append(makeTest("Summer16sig","SMS-T1tttt_mGluino-1500_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/SMS-T1tttt_mGluino-1500_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0818BABF-64BE-E611-B201-008CFA000280.root"))
-mytests.append(makeTest("Autumn18","Autumn18.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8_ext1",numevents,command,inputFilesConfig="Autumn18.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8_ext1",nstart=0,nfiles=10))
-mytests.append(makeTest("Autumn18Fast","Autumn18Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Autumn18Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("Autumn18Fastsig","Autumn18Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Autumn18Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-mytests.append(makeTest("2018B26Sep",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018-v1.JetHT",nstart=0,nfiles=10))
-mytests.append(makeTest("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEM-v1.JetHT",nstart=0,nfiles=10))
-mytests.append(makeTest("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEMmitigation-v1.JetHT",nstart=0,nfiles=10))
-mytests.append(makeTest("2018PromptReco",name,numevents,command,inputFilesConfig="Run2018D-PromptReco-v2.JetHT",nstart=244,nfiles=10))
-mytests.append(makeTest("2018ReReco17Sep",name,numevents,command,inputFilesConfig="Run2018B-17Sep2018-v1.JetHT",nstart=0,nfiles=10))
+    # make sure this is the last test defined
+    mytests.append(makeTest(scenario,name,numevents,command,dataset,inputFilesConfig,nstart=0,nfiles=10,redir=""))
 
+def unitTest():
+    # Read parameters
+    from TreeMaker.Utils.CommandLineParams import CommandLineParams
+    parameters = CommandLineParams()
+    test=parameters.value("test",-1)
+    name=parameters.value("name","")
+    run=parameters.value("run",False)
+    numevents=parameters.value("numevents",100)
+    command=parameters.value("command","")
+    scenario=parameters.value("scenario","")
+    dataset=parameters.value("dataset","")
+    inputFilesConfig=parameters.value("inputFilesConfig","")
 
-if test<0 or test>len(mytests):
-    print "Predefined tests:"
-    for itest, mytest in enumerate(mytests):
-        printTest(mytest,itest)
-else:
-    printTest(mytests[test],test)
-    if run:
-        # fork the cmsRun process and exit
-        fork_pid = os.fork()
-        if fork_pid == 0:
-            with open(mytests[test][-1],'w') as out:
-                p = subprocess.Popen(mytests[test][0:-1], stdin=None, stdout=out, stderr=out, close_fds=True)
-                print "\nRunning test... ["+str(p.pid)+"]"
-                sts = os.waitpid(p.pid, 0)[1]
-                print "\nTest is done! ["+str(p.pid)+"]"
+    # only set name for a specific test
+    if test==-1: name = ""
 
+    # list of tests
+    mytests = []
+    defineTests(mytests,scenario,name,numevents,command,dataset,inputFilesConfig)
+
+    # sanity check for defining an on-the-fly test
+    if test==len(mytests) and dataset=="" and inputFilesConfig=="":
+        print "If defining a unitTest on-the-fly, you must either specity a \'dataset\' or an \'inputFilesConfig\'."
+        return -1
+
+    if test<0 or test>len(mytests):
+        print "Predefined tests:"
+        for itest, mytest in enumerate(mytests):
+            printTest(mytest,itest)
+    else:
+        printTest(mytests[test],test)
+        if run:
+            # fork the cmsRun process and exit
+            fork_pid = os.fork()
+            if fork_pid == 0:
+                with open(mytests[test][-1],'w') as out:
+                    p = subprocess.Popen(mytests[test][0:-1], stdin=None, stdout=out, stderr=out, close_fds=True)
+                    print "\nRunning test... ["+str(p.pid)+"]"
+                    sts = os.waitpid(p.pid, 0)[1]
+                    print "\nTest is done! ["+str(p.pid)+"]"
+
+if __name__ == '__main__':
+    unitTest()
 
 #Example:
 #  python unitTest.py numevents=1000 run=True test=0

--- a/Production/test/unitTest.py
+++ b/Production/test/unitTest.py
@@ -1,69 +1,122 @@
 import os, subprocess
 
-def makeTest(scenario, name, numevents, command, dataset="", inputFilesConfig="", nstart=0, nfiles=0, redir=""):
-    # handle names
-    if len(name)==0 and len(inputFilesConfig)>0: name = inputFilesConfig
+class Test:
+    def __init__(self, scenario, name, numevents, command, dataset="", inputFilesConfig="", nstart=0, nfiles=0, redir=""):
+        self.scenario = scenario
+        self.dataset = dataset
+        self.inputFilesConfig = inputFilesConfig
+        self.nstart = nstart
+        self.nfiles = nfiles
+        self.outfile = name
+        self.numevents = numevents
+        self.command = command
+        self.redir = redir
+        self.cmd = "cmsRun"
+        self.config = "runMakeTreeFromMiniAOD_cfg.py"
+        self.array = self.getArray()
 
-    mytest = []
-    mytest.append("cmsRun")
-    mytest.append("runMakeTreeFromMiniAOD_cfg.py")
-    mytest.append("scenario="+scenario+"")
-    # different methods for input files
-    if len(dataset)>0:
-        mytest.append("dataset="+dataset)
-    else:
-        mytest.append("inputFilesConfig="+inputFilesConfig)
-        mytest.append("nstart="+str(nstart))
-        mytest.append("nfiles="+str(nfiles))
-    # different shell commands
-    mytest.append("outfile="+name)
-    mytest.append("numevents="+str(numevents))
-    if len(command)>0: mytest.append(command)
-    if len(redir)>0: mytest.append("redir="+redir)
-    mytest.append(name+".log")
+    def getArray(self):
+        mytest = []
+        mytest += [self.cmd, self.config, "scenario="+self.scenario]
+        # different methods for input files
+        if len(self.dataset)>0:
+            mytest.append("dataset="+self.dataset)
+        else:
+            mytest.append("inputFilesConfig="+self.inputFilesConfig)
+            mytest.append("nstart="+str(self.nstart))
+            mytest.append("nfiles="+str(self.nfiles))
+        # different shell commands
+        mytest += ["outfile="+self.outfile, "numevents="+str(self.numevents)]
+        if len(self.command)>0: mytest.append(self.command)
+        if len(self.redir)>0: mytest.append("redir="+self.redir)
+        mytest.append(self.getLogName())
+        return mytest
 
-    return mytest
+    def getLogName(self):
+        return self.outfile+".log"
 
-def printTest(mytest, itest):
-    logname = mytest[-1]
-    tmp = str(itest)+":\n  "+" \\\n  ".join(mytest[0:-1])+" \\\n "+" >& "+logname+" &"
-    print tmp
+    def getROOTName(self):
+        return self.outfile+"_RA2AnalysisTree.root"
+
+    def printTest(self, itest, log):
+        logname = self.array[-1]
+        tmp = str(itest)+":\n  "+" \\\n  ".join(self.array[0:-1])
+        if log:
+            tmp +=" \\\n "+" >& "+logname+" &"
+        print tmp
+
+    def forkAndRun(self, clean):
+        # fork the cmsRun process and exit
+        fork_pid = os.fork()
+        if fork_pid == 0:
+            with open(self.getLogName(),'w') as out:
+                p = subprocess.Popen(self.array[0:-1], stdin=None, stdout=out, stderr=out, close_fds=True)
+                print "\nRunning test... ["+str(p.pid)+"]"
+                sts = os.waitpid(p.pid, 0)[1]
+                print "\nTest is done! ["+str(p.pid)+"]"
+                if clean: self.cleanFiles(clean)
+
+    def run(self, log, clean):
+        out = None
+        if log: out = open(self.getLogName(),'w')
+        p = subprocess.Popen(self.array[0:-1], stdin=None, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True, bufsize=1)
+        print "\nRunning test..."
+        with p.stdout:
+            for line in iter(p.stdout.readline, b''):
+                print line,
+                if log: out.write(line)
+        p.wait()
+        if log: out.close()
+        print "\nTest is done!"
+        if clean: self.cleanFiles(clean)
+
+    def cleanFiles(self, clean):
+        print "\nCleaning output files..."
+        files=[self.getROOTName(),self.getLogName()]
+        if clean>0: files=files[0:clean]
+        for file in files:
+            if os.path.exists(file):
+                os.remove(file)
+        print "\nDone cleaning files!"
 
 def defineTests(mytests, scenario, name, numevents, command, dataset, inputFilesConfig):
     # activate these when the requisite MC exists
-    mytests.append(makeTest("Summer16v3","Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Summer16v3","Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Summer16v3sig","Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Summer16v3sigscan","Summer16v3.SMS-T5qqqqZH-mGluino-1000to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T5qqqqZH-mGluino-1000to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Summer16v3Fast","Summer16v3Fast.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3Fast.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Summer16v3Fastsig","Summer16v3Fast.SMS-T1tttt_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3Fast.SMS-T1tttt_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("2016ReReco17Jul",name,numevents,command,inputFilesConfig="Run2016G-17Jul2018-v1.MET",nstart=0,nfiles=10))
-    mytests.append(makeTest("Fall17","Fall17.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Fall17","Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Fall17sig","Fall17.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Fall17Fast","Fall17Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Fall17Fastsig","Fall17Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("2017ReReco31Mar",name,numevents,command,inputFilesConfig="Run2017B-31Mar2018-v1.MET",nstart=0,nfiles=10))
-    mytests.append(makeTest("Summer16","Summer16.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/0010CF3F-1EB7-E611-A46F-00266CFFA678.root"))
-    mytests.append(makeTest("Summer16","Summer16.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0044D655-9DBE-E611-A9D1-008CFA56D764.root"))
-    mytests.append(makeTest("Summer16","Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata",numevents,command,dataset="/eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/0048131D-3CB3-E611-813A-001E67DFFB31.root",redir="root://eospublic.cern.ch/"))
-    mytests.append(makeTest("Summer16sig","SMS-T1tttt_mGluino-1500_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/SMS-T1tttt_mGluino-1500_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0818BABF-64BE-E611-B201-008CFA000280.root"))
-    mytests.append(makeTest("Autumn18","Autumn18.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8_ext1",numevents,command,inputFilesConfig="Autumn18.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8_ext1",nstart=0,nfiles=10))
-    mytests.append(makeTest("Autumn18Fast","Autumn18Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Autumn18Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("Autumn18Fastsig","Autumn18Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Autumn18Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
-    mytests.append(makeTest("2018B26Sep",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018-v1.JetHT",nstart=0,nfiles=10))
-    mytests.append(makeTest("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEM-v1.JetHT",nstart=0,nfiles=10))
-    mytests.append(makeTest("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEMmitigation-v1.JetHT",nstart=0,nfiles=10))
-    mytests.append(makeTest("2018PromptReco",name,numevents,command,inputFilesConfig="Run2018D-PromptReco-v2.JetHT",nstart=244,nfiles=10))
-    mytests.append(makeTest("2018ReReco17Sep",name,numevents,command,inputFilesConfig="Run2018B-17Sep2018-v1.JetHT",nstart=0,nfiles=10))
+    mytests.append(Test("Summer16v3","Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Summer16v3","Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Summer16v3sig","Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Summer16v3sigscan","Summer16v3.SMS-T5qqqqZH-mGluino-1000to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T5qqqqZH-mGluino-1000to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Summer16v3Fast","Summer16v3Fast.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3Fast.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Summer16v3Fastsig","Summer16v3Fast.SMS-T1tttt_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3Fast.SMS-T1tttt_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("2016ReReco17Jul",name,numevents,command,inputFilesConfig="Run2016G-17Jul2018-v1.MET",nstart=0,nfiles=10))
+    mytests.append(Test("Fall17","Fall17.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Fall17","Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Fall17sig","Fall17.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Fall17Fast","Fall17Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Fall17Fastsig","Fall17Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Fall17Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("2017ReReco31Mar",name,numevents,command,inputFilesConfig="Run2017B-31Mar2018-v1.MET",nstart=0,nfiles=10))
+    mytests.append(Test("Summer16","Summer16.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/0010CF3F-1EB7-E611-A46F-00266CFFA678.root"))
+    mytests.append(Test("Summer16","Summer16.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0044D655-9DBE-E611-A9D1-008CFA56D764.root"))
+    mytests.append(Test("Summer16","Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata",numevents,command,dataset="/eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/70000/0048131D-3CB3-E611-813A-001E67DFFB31.root",redir="root://eospublic.cern.ch/"))
+    mytests.append(Test("Summer16sig","SMS-T1tttt_mGluino-1500_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,dataset="/store/mc/RunIISummer16MiniAODv2/SMS-T1tttt_mGluino-1500_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0818BABF-64BE-E611-B201-008CFA000280.root"))
+    mytests.append(Test("Autumn18","Autumn18.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8_ext1",numevents,command,inputFilesConfig="Autumn18.GJets_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8_ext1",nstart=0,nfiles=10))
+    mytests.append(Test("Autumn18Fast","Autumn18Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Autumn18Fast.TTJets_SingleLeptFromT_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("Autumn18Fastsig","Autumn18Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Autumn18Fast.SMS-T1tttt_TuneCP2_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
+    mytests.append(Test("2018B26Sep",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018-v1.JetHT",nstart=0,nfiles=10))
+    mytests.append(Test("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEM-v1.JetHT",nstart=0,nfiles=10))
+    mytests.append(Test("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEMmitigation-v1.JetHT",nstart=0,nfiles=10))
+    mytests.append(Test("2018PromptReco",name,numevents,command,inputFilesConfig="Run2018D-PromptReco-v2.JetHT",nstart=244,nfiles=10))
+    mytests.append(Test("2018ReReco17Sep",name,numevents,command,inputFilesConfig="Run2018B-17Sep2018-v1.JetHT",nstart=0,nfiles=10))
 
     # make sure this is the last test defined
-    mytests.append(makeTest(scenario,name,numevents,command,dataset,inputFilesConfig,nstart=0,nfiles=10,redir=""))
+    mytests.append(Test(scenario,name,numevents,command,dataset,inputFilesConfig,nstart=0,nfiles=10,redir=""))
 
 def unitTest():
     # Read parameters
     from TreeMaker.Utils.CommandLineParams import CommandLineParams
     parameters = CommandLineParams()
+    fork=parameters.value("fork",True)
+    log=parameters.value("log",True)
+    clean=parameters.value("clean",0)
     test=parameters.value("test",-1)
     name=parameters.value("name","")
     run=parameters.value("run",False)
@@ -82,24 +135,20 @@ def unitTest():
 
     # sanity check for defining an on-the-fly test
     if test==len(mytests) and dataset=="" and inputFilesConfig=="":
-        print "If defining a unitTest on-the-fly, you must either specity a \'dataset\' or an \'inputFilesConfig\'."
+        print "If defining a unitTest on-the-fly, you must either specify a \'dataset\' or an \'inputFilesConfig\'."
         return -1
 
     if test<0 or test>len(mytests):
         print "Predefined tests:"
         for itest, mytest in enumerate(mytests):
-            printTest(mytest,itest)
+            mytest.printTest(itest,log)
     else:
-        printTest(mytests[test],test)
+        mytests[test].printTest(test,log)
         if run:
-            # fork the cmsRun process and exit
-            fork_pid = os.fork()
-            if fork_pid == 0:
-                with open(mytests[test][-1],'w') as out:
-                    p = subprocess.Popen(mytests[test][0:-1], stdin=None, stdout=out, stderr=out, close_fds=True)
-                    print "\nRunning test... ["+str(p.pid)+"]"
-                    sts = os.waitpid(p.pid, 0)[1]
-                    print "\nTest is done! ["+str(p.pid)+"]"
+            if fork:
+                mytests[test].forkAndRun(clean)
+            else:
+                mytests[test].run(log,clean)
 
 if __name__ == '__main__':
     unitTest()

--- a/Production/test/unitTest.py
+++ b/Production/test/unitTest.py
@@ -1,4 +1,4 @@
-import os, subprocess
+import os, subprocess, sys
 
 class Test:
     def __init__(self, scenario, name, numevents, command, dataset="", inputFilesConfig="", nstart=0, nfiles=0, redir=""):
@@ -135,7 +135,7 @@ def unitTest():
     # sanity check for defining an on-the-fly test
     if test==len(mytests) and dataset=="" and inputFilesConfig=="":
         print "If defining a unitTest on-the-fly, you must either specify a \'dataset\' or an \'inputFilesConfig\'."
-        exit(-1)
+        sys.exit(-1)
 
     if test<0 or test>len(mytests):
         print "Predefined tests:"

--- a/Production/test/unitTest.py
+++ b/Production/test/unitTest.py
@@ -80,7 +80,6 @@ class Test:
         print "\nDone cleaning files!"
 
 def defineTests(mytests, scenario, name, numevents, command, dataset, inputFilesConfig):
-    # activate these when the requisite MC exists
     mytests.append(Test("Summer16v3","Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
     mytests.append(Test("Summer16v3","Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
     mytests.append(Test("Summer16v3sig","Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
@@ -136,7 +135,7 @@ def unitTest():
     # sanity check for defining an on-the-fly test
     if test==len(mytests) and dataset=="" and inputFilesConfig=="":
         print "If defining a unitTest on-the-fly, you must either specify a \'dataset\' or an \'inputFilesConfig\'."
-        return -1
+        exit(-1)
 
     if test<0 or test>len(mytests):
         print "Predefined tests:"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 - [Info for New Samples](#info-for-new-samples)
     - [Samples with Negative Weight Events](#samples-with-negative-weight-events)
 - [Options](#options)
+- [Notes for Contributors](#notes-for-contributors)
+    - [Docker](#docker)
 
 <!-- /MarkdownTOC -->
 
@@ -30,6 +32,7 @@ The script [setup.sh](./setup.sh) has options to allow installing a different fo
 (though some branches may have different setup scripts, so check carefully which one you download):
 * `-f [fork]`: which fork to download (`git@github.com:fork/TreeMaker.git`, default = TreeMaker)
 * `-b [branch]`: which branch to download (`-b branch`, default = Run2_2017)
+* `-B`: configure some settings for checkout within batch setups
 * `-c [version]`: which CMSSW version to use (default = CMSSW_10_2_21)
 * `-a [protocol]`: which protocol to use for `git clone` (default = ssh, alternative = https)
 * `-j [cores]`: run CMSSW compilation on # cores (default = 8)
@@ -259,3 +262,13 @@ Extra options in [runMakeTreeFromMiniAOD_cfg.py](./Production/test/runMakeTreeFr
 * `tmi`: enable [TimeMemoryInfo](https://github.com/cms-sw/cmssw/blob/master/Validation/Performance/python/TimeMemoryInfo.py) for simple profiling (default=False)
 * `trace`: enable the tracer for debugging (default=False)
 * `debugjets`: print out user floats and discriminators for each jet collection (default=False)
+
+## Notes for Contributors
+
+### Docker
+
+Two Docker images containing the TreeMaker software will be created upon push or pull request to the default TreeMaker branch. For more information about these images see the [TreeMaker wiki](https://github.com/TreeMaker/TreeMaker/wiki/Docker%20Integration%20Test).
+
+In order to cancel or limit these builds one can add the following strings to their commit message:
+* `[skip build]`: neither image will be created
+* `[skip test]`: the no-cache image will be created, but the image containing the CVMFS cache will be skipped

--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@ usage(){
 	echo ""
 	echo "-f [fork]           clone from specified fork (default = ${FORK})"
 	echo "-b [branch]         clone specified branch (default = ${BRANCH})"
-    echo "-B [batch]          configure some settings for checkout within batch setups (default = ${BATCH})"
+	echo "-B                  configure some settings for checkout within batch setups (default = ${BATCH})"
 	echo "-c [version]        use specified CMSSW version (default = ${CMSSWVER})"
 	echo "-a [protocol]       use protocol to clone (default = ${ACCESS}, alternative = https)"
 	echo "-j [cores]          run CMSSW compilation on # cores (default = ${CORES})"
@@ -34,7 +34,7 @@ while getopts "f:b:Ba:j:n:d:c:h" opt; do
 	;;
 	b) BRANCH=$OPTARG
 	;;
-    B) BATCH=--upstream-only
+	B) BATCH=--upstream-only
 	;;
 	c) CMSSWVER=$OPTARG
 	;;
@@ -67,13 +67,13 @@ fi
 # make sure that scram is available
 # examples:
 #   in a non-interactive Docker container this will evaluate to "hB"
-#   in an login session this will evaluate to "himBCHP"
+#   in a login session this will evaluate to "himBCHP"
 if [[ $- != *i* ]]; then
 	echo "WARNING: Non-interactive shell found!"
-    if [[ -f "${HOME}/.bashrc" ]]; then
-        echo "Sourcing the .bashrc file"
-        source ${HOME}/.bashrc
-    fi
+	if [[ -f "${HOME}/.bashrc" ]]; then
+		echo "Sourcing the .bashrc file"
+		source ${HOME}/.bashrc
+	fi
 	if [[ -f "/cvmfs/cms.cern.ch/cmsset_default.sh" ]]; then
 		echo -e "cms.cern.ch is accessible\n\t==> source /cvmfs/cms.cern.ch/cmsset_default.sh\n"
 		source /cvmfs/cms.cern.ch/cmsset_default.sh
@@ -127,7 +127,7 @@ git cms-init $ACCESS_CMSSW $BATCH
 git config gc.auto 0
 
 # batch git config
-if [[ ! -z "$BATCH" ]]; then
+if [[ -n "$BATCH" ]]; then
 	git config --global --add user.name "TreeMaker GitHub"
 	git config --global --add user.email "treemaker@github.com"
 	git config --global --add user.github "TreeMaker"


### PR DESCRIPTION
Setup a system whereby a couple of Docker images are setup using a GitHub Action. Both images will have the TreeMaker software installed. One of them will have the CVMFS cache cleared while the other will not. More information about the images can be found in the [TreeMaker wiki](https://github.com/TreeMaker/TreeMaker/wiki/Docker%20Integration%20Test).