### PR TITLE
[Run2_2017] Fix some issues with the workflow, setup, and unit tests

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   current_branch: $(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')
+  current_user: ${{ github.actor }}
 
 jobs:
 
@@ -17,18 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip build]')"
     steps:
+    - name: Reset User on Push
+      if: github.event_name == 'push'
+      run: echo ::set-env name=current_user::$(echo ${{ github.repository }} | sed -E 's|/.*||')
     - name: Reset Branch on Pull Request
       if: github.event_name == 'pull_request'
       run: echo ::set-env name=current_branch::${{ github.head_ref }}
     - name: Look at key environment variables
-      run: echo -e "GITHUB_REF=${{ github.ref }}\nGITHUB_HEAD_REF=${{ github.head_ref }}\nGITHUB_BASE_REF=${{ github.base_ref }}\nGITHUB_ACTOR=${{ github.actor }}\nGITHUB_REPOSITORY=${{ github.repository }}\nGITHUB_SHA=${{ github.sha }}\nBANCH=${{ env.current_branch }}"
+      run: echo -e "GITHUB_REF=${{ github.ref }}\nGITHUB_HEAD_REF=${{ github.head_ref }}\nGITHUB_BASE_REF=${{ github.base_ref }}\nGITHUB_ACTOR=${{ github.actor }}\nGITHUB_REPOSITORY=${{ github.repository }}\nGITHUB_SHA=${{ github.sha }}\nUSER=${{ env.current_user }}\nBANCH=${{ env.current_branch }}"
     - name: Take a look around
       run: pwd && ls -alh
     - name: Run a CVMFS Docker image and run the setup script
       env:
         build_image: aperloff/cms-cvmfs-docker:light
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker --entrypoint "/bin/bash"
-      run: docker run ${{ env.docker_options }} ${{ env.build_image }} -c "/run.sh -c \"wget https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/setup.sh && chmod +x setup.sh && ./setup.sh -a https -f ${{ github.actor }} -b ${{ env.current_branch }} -B -j 2\" && cvmfs_config wipecache"
+      run: docker run ${{ env.docker_options }} ${{ env.build_image }} -c "/run.sh -c \"wget https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/setup.sh && chmod +x setup.sh && ./setup.sh -a https -f ${{ env.current_user }} -b ${{ env.current_branch }} -B -j 2\" && cvmfs_config wipecache"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-latest
     - name: Log into registry
@@ -50,7 +54,7 @@ jobs:
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
         integration_test_image: treemaker/treemaker:${{ env.current_branch }}-latest
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker-integration
-      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=25 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
+      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
 
   # The 'integration-test' job opens the previous 'build' image, pulled from the registry, to:
   #   1. test that the image was successfully uploaded to the registry
@@ -71,7 +75,7 @@ jobs:
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
         integration_test_image: treemaker/treemaker:${{ env.current_branch }}-latest
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker
-      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=25 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
+      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry

--- a/Production/test/unitTest.py
+++ b/Production/test/unitTest.py
@@ -80,6 +80,11 @@ class Test:
         print "\nDone cleaning files!"
 
 def defineTests(mytests, scenario, name, numevents, command, dataset, inputFilesConfig):
+    # User defined test
+    # make sure this is the first test defined
+    mytests.append(Test(scenario,name,numevents,command,dataset,inputFilesConfig,nstart=0,nfiles=10,redir=""))
+
+    # pre-defined tests
     mytests.append(Test("Summer16v3","Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.GJets_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
     mytests.append(Test("Summer16v3","Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.TTJets_SingleLeptFromT_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
     mytests.append(Test("Summer16v3sig","Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",numevents,command,inputFilesConfig="Summer16v3.SMS-T1tttt_mGluino-2000_mLSP-100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8",nstart=0,nfiles=1))
@@ -106,9 +111,6 @@ def defineTests(mytests, scenario, name, numevents, command, dataset, inputFiles
     mytests.append(Test("2018PromptReco",name,numevents,command,inputFilesConfig="Run2018D-PromptReco-v2.JetHT",nstart=244,nfiles=10))
     mytests.append(Test("2018ReReco17Sep",name,numevents,command,inputFilesConfig="Run2018B-17Sep2018-v1.JetHT",nstart=0,nfiles=10))
 
-    # make sure this is the last test defined
-    mytests.append(Test(scenario,name,numevents,command,dataset,inputFilesConfig,nstart=0,nfiles=10,redir=""))
-
 def unitTest():
     # Read parameters
     from TreeMaker.Utils.CommandLineParams import CommandLineParams
@@ -133,11 +135,11 @@ def unitTest():
     defineTests(mytests,scenario,name,numevents,command,dataset,inputFilesConfig)
 
     # sanity check for defining an on-the-fly test
-    if test==len(mytests) and dataset=="" and inputFilesConfig=="":
+    if test==0 and dataset=="" and inputFilesConfig=="":
         print "If defining a unitTest on-the-fly, you must either specify a \'dataset\' or an \'inputFilesConfig\'."
         sys.exit(-1)
 
-    if test<0 or test>len(mytests):
+    if test<0 or test>=len(mytests):
         print "Predefined tests:"
         for itest, mytest in enumerate(mytests):
             mytest.printTest(itest,log)

--- a/setup.sh
+++ b/setup.sh
@@ -64,11 +64,8 @@ else
 	usage 1
 fi
 
-# make sure that scram is available
-# examples:
-#   in a non-interactive Docker container this will evaluate to "hB"
-#   in a login session this will evaluate to "himBCHP"
-if [[ $- != *i* ]]; then
+# make sure that scram is available in a batch situation when an interactive terminal might not be available
+if [[ -n "$BATCH" ]]; then
 	echo "WARNING: Non-interactive shell found!"
 	if [[ -f "${HOME}/.bashrc" ]]; then
 		echo "Sourcing the .bashrc file"


### PR DESCRIPTION
This PR fixes the following issues:
1. The setup.sh script sources a .bashrc file every time the shell is not-interactive, which is always when the script is executed. Instead, only source the login file when in batch mode.
2. Fix an off-by-one error in the unitTest.py file. Also rearrange the unit tests themselves.
3. Fix some issues with the github user referenced in the workflows.