### PR TITLE
[Run2_2017] Add a new Docker image for ServiceX

### DIFF
--- a/.github/ServiceX/data/requirements.txt
+++ b/.github/ServiceX/data/requirements.txt
@@ -1,0 +1,17 @@
+servicex-transformer==0.4.4.post1
+requests>=2.22.0
+kafka-python
+confluent_kafka==1.2.0
+pika
+minio
+pytest
+pytest-mock
+flake8==3.5
+coverage==4.5.2
+codecov==2.0.15
+uproot
+awkward>=0.12.0
+xxhash
+lz4
+pyarrow==0.16.0
+numpy==1.16.6

--- a/.github/ServiceX/python/transformer.py
+++ b/.github/ServiceX/python/transformer.py
@@ -64,7 +64,7 @@ def callback(channel, method, properties, body):
 
     servicex.post_status_update(file_id=_file_id,
                                 status_code="start",
-                                info="xAOD Transformer")
+                                info="MiniAOD Transformer")
 
     tick = time.time()
     file_done = False
@@ -73,7 +73,7 @@ def callback(channel, method, properties, body):
         try:
             # Do the transform
             root_file = _file_path.replace('/', ':')
-            output_path = '/home/atlas/' + root_file
+            output_path = '/home/cmsuser/' + root_file
             transform_single_file(_file_path, output_path, servicex)
 
             tock = time.time()
@@ -123,8 +123,6 @@ def callback(channel, method, properties, body):
 
 def transform_single_file(file_path, output_path, servicex=None):
     print("Transforming a single path: " + str(file_path) + " into " + output_path)
-    # os.system("voms-proxy-info --all")
-    #r = os.system('bash /generated/runner.sh -r -d ' + file_path + ' -o ' + output_path +  '| tee log.txt')
     r = os.system('python ' + os.environ['CMSSW_BASE'] + '/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16v3 dataset=file:' + str(file_path) + ' name=' + str(output_path) + ' run=True fork=False log=True')
     reason_bad = None
     if r != 0:
@@ -166,7 +164,7 @@ def compile_code():
 
 
 if __name__ == "__main__":
-    parser = TransformerArgumentParser(description="xAOD CPP Transformer")
+    parser = TransformerArgumentParser(description="MiniAOD CPP Transformer")
     args = parser.parse_args()
 
     kafka_brokers = TransformerArgumentParser.extract_kafka_brokers(args.brokerlist)

--- a/.github/ServiceX/python/transformer.py
+++ b/.github/ServiceX/python/transformer.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import json
+import time
+
+from servicex.transformer.servicex_adapter import ServiceXAdapter
+from servicex.transformer.transformer_argument_parser import TransformerArgumentParser
+from servicex.transformer.kafka_messaging import KafkaMessaging
+from servicex.transformer.object_store_manager import ObjectStoreManager
+from servicex.transformer.rabbit_mq_manager import RabbitMQManager
+from servicex.transformer.uproot_events import UprootEvents
+from servicex.transformer.uproot_transformer import UprootTransformer
+from servicex.transformer.arrow_writer import ArrowWriter
+import uproot
+import os
+import sys
+import traceback
+import pyarrow as pa
+
+
+# How many bytes does an average awkward array cell take up. This is just
+# a rule of thumb to calculate chunksize
+avg_cell_size = 42
+MAX_RETRIES = 3
+
+messaging = None
+object_store = None
+
+
+# noinspection PyUnusedLocal
+def callback(channel, method, properties, body):
+    transform_request = json.loads(body)
+    _request_id = transform_request['request-id']
+    _file_path = transform_request['file-path'].encode('ascii', 'ignore')
+    _file_id = transform_request['file-id']
+    _server_endpoint = transform_request['service-endpoint']
+    # _chunks = transform_request['chunks']
+    servicex = ServiceXAdapter(_server_endpoint)
+
+    servicex.post_status_update(file_id=_file_id,
+                                status_code="start",
+                                info="xAOD Transformer")
+
+    tick = time.time()
+    file_done = False
+    file_retries = 0
+    while not file_done:
+        try:
+            # Do the transform
+            root_file = _file_path.replace('/', ':')
+            output_path = '/home/atlas/' + root_file
+            transform_single_file(_file_path, output_path, servicex)
+
+            tock = time.time()
+
+            if object_store:
+                object_store.upload_file(_request_id, root_file, output_path)
+                os.remove(output_path)
+
+            servicex.post_status_update(file_id=_file_id,
+                                        status_code="complete",
+                                        info="Total time " + str(round(tock - tick, 2)))
+
+            servicex.put_file_complete(_file_path, _file_id, "success",
+                                    num_messages=0,
+                                    total_time=round(tock - tick, 2),
+                                    total_events=0,
+                                    total_bytes=0)
+            file_done = True
+
+        except Exception as error:
+            file_retries += 1
+            if file_retries == MAX_RETRIES:
+                transform_request['error'] = str(error)
+                channel.basic_publish(exchange='transformation_failures',
+                                    routing_key=_request_id + '_errors',
+                                    body=json.dumps(transform_request))
+                servicex.put_file_complete(file_path=_file_path, file_id=_file_id,
+                                        status='failure', num_messages=0, total_time=0,
+                                        total_events=0, total_bytes=0)
+
+                servicex.post_status_update(file_id=_file_id,
+                                            status_code="failure",
+                                            info= " error: " + str(error)[0:1024])
+
+                file_done = True
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                traceback.print_tb(exc_traceback, limit=20, file=sys.stdout)
+                print(exc_value)
+            else:
+                servicex.post_status_update(file_id=_file_id,
+                                            status_code="retry",
+                                            info="Try: " + str(file_retries) +
+                                                 " error: " + str(error)[0:1024])
+
+    channel.basic_ack(delivery_tag=method.delivery_tag)
+
+
+def transform_single_file(file_path, output_path, servicex=None):
+    print("Transforming a single path: " + str(file_path) + " into " + output_path)
+    # os.system("voms-proxy-info --all")
+    #r = os.system('bash /generated/runner.sh -r -d ' + file_path + ' -o ' + output_path +  '| tee log.txt')
+    r = os.system('python ' + os.environ['CMSSW_BASE'] + '/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16v3 dataset=file:' + str(file_path) + ' name=' + str(output_path) + ' run=True fork=False log=True')
+    reason_bad = None
+    if r != 0:
+        reason_bad = "Error return from transformer: " + str(r)
+    if (reason_bad is None) and not os.path.exists(output_path):
+        reason_bad = "Output file " + output_path + " was not found"
+    if reason_bad is not None:
+        with open('log.txt', 'r') as f:
+            errors = f.read()
+            raise RuntimeError("Failed to transform input file " + file_path + ": " + reason_bad + ' -- errors: \n' + errors)
+
+    if not object_store:
+        flat_file = uproot.open(output_path)
+        flat_tree_name = flat_file.keys()[0]
+        attr_name_list = flat_file[flat_tree_name].keys()
+
+        arrow_writer = ArrowWriter(file_format=args.result_format,
+                                   object_store=object_store,
+                                   messaging=messaging)
+        # NB: We're converting the *output* ROOT file to Arrow arrays
+        # TODO: Implement configurable chunk_size
+        event_iterator = UprootEvents(file_path=output_path, tree_name=flat_tree_name,
+                                      attr_name_list=attr_name_list, chunk_size=1000)
+        transformer = UprootTransformer(event_iterator)
+        arrow_writer.write_branches_to_arrow(transformer=transformer, topic_name=args.request_id,
+                                             file_id=None, request_id=args.request_id)
+        print("Kafka Timings: "+str(arrow_writer.messaging_timings))
+
+
+def compile_code():
+    # Have to use bash as the file runner.sh does not execute properly, despite its 'x'
+    # bit set. This seems to be some vagary of a ConfigMap from k8, which is how we usually get
+    # this file.
+    r = os.system('bash /generated/runner.sh -c | tee log.txt')
+    if r != 0:
+        with open('log.txt', 'r') as f:
+            errors = f.read()
+            raise RuntimeError("Unable to compile the code - error return: " + str(r)+ 'errors: \n' + errors)
+
+
+if __name__ == "__main__":
+    parser = TransformerArgumentParser(description="xAOD CPP Transformer")
+    args = parser.parse_args()
+
+    kafka_brokers = TransformerArgumentParser.extract_kafka_brokers(args.brokerlist)
+
+    if args.result_destination == 'kafka':
+        messaging = KafkaMessaging(kafka_brokers, args.max_message_size)
+        object_store = None
+    elif not args.output_dir and args.result_destination == 'object-store':
+        messaging = None
+        object_store = ObjectStoreManager()
+
+    compile_code()
+
+    if args.request_id and not args.path:
+        rabbitmq = RabbitMQManager(args.rabbit_uri, args.request_id, callback)
+
+    if args.path:
+        transform_single_file(args.path, args.output_dir)

--- a/.github/ServiceX/python/validate_requests.py
+++ b/.github/ServiceX/python/validate_requests.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# this code gets requests in state: Created, Validates request on one file
+# if request valid (all branches exist) it sets request state to Defined
+# if not it sets state to Failed, deletes all the paths belonging to that request.
+
+import datetime
+import json
+import os
+import sys
+import time
+
+import requests
+import argparse
+import pika
+
+# What is the largest message we want to send (in megabytes).
+# Note this must be less than the kafka broker setting if we are using kafka
+default_max_message_size = 14.5
+
+parser = argparse.ArgumentParser(
+    description='Validate a request and create kafka topic.')
+
+parser.add_argument('--rabbit-uri', dest="rabbit_uri", action='store',
+                    default='host.docker.internal')
+
+parser.add_argument('--avg-bytes', dest="avg_bytes_per_column", action='store',
+                    help='Average number of bytes per column per event',
+                    default='40')
+
+parser.add_argument("--path", dest='path', action='store',
+                    default=None,
+                    help='Path to single Root file to transform')
+
+parser.add_argument("--tree", dest='tree', action='store',
+                    default="Events",
+                    help='Tree from which columns will be inspected')
+
+
+def validate_request(file_name):
+    print("Validating file: " + file_name)
+
+    try:
+        return(True, {
+            "max-event-size": 0
+        })
+    except Exception as eek:
+        return False, "Could not compile generated code "+str(eek)
+
+
+def post_status_update(endpoint, status_msg):
+    requests.post(endpoint + "/status", data={
+        "timestamp": datetime.datetime.now().isoformat(),
+        "status": status_msg
+    })
+
+
+def post_transform_start(endpoint, info):
+    requests.post(endpoint+"/start", json={
+        "timestamp": datetime.datetime.now().isoformat(),
+        "info": info
+    })
+
+
+def callback(channel, method, properties, body):
+    validation_request = json.loads(body)
+
+    service_endpoint = validation_request[u'service-endpoint']
+    post_status_update(service_endpoint,
+                       "Validation Request received")
+
+    # checks the file
+    (valid, info) = validate_request(validation_request[u'file-path'])
+
+    if valid:
+        post_status_update(service_endpoint,  "Request validated")
+        post_transform_start(service_endpoint, info)
+    else:
+        post_status_update(service_endpoint, "Validation Request failed "+info)
+
+    print(valid, info)
+    channel.basic_ack(delivery_tag=method.delivery_tag)
+
+
+def init_rabbit_mq(rabbitmq_url, retries, retry_interval):
+    rabbitmq = None
+    retry_count = 0
+
+    while not rabbitmq:
+        try:
+            rabbitmq = pika.BlockingConnection(pika.URLParameters(rabbitmq_url))
+            _channel = rabbitmq.channel()
+            _channel.queue_declare(queue='validation_requests')
+
+            print("Connected to RabbitMQ. Ready to start consuming requests")
+
+            _channel.basic_consume(queue='validation_requests',
+                                   auto_ack=False,
+                                   on_message_callback=callback)
+            _channel.start_consuming()
+
+        except pika.exceptions.AMQPConnectionError as eek:
+            rabbitmq = None
+            retry_count += 1
+            if retry_count < retries:
+                print("Failed to connect to RabbitMQ. Waiting before trying again")
+                time.sleep(retry_interval)
+            else:
+                print("Failed to connect to RabbitMQ. Giving Up")
+                raise eek
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    if args.path:
+        # checks the file
+        (valid, info) = validate_request(args.path)
+        print(valid, info)
+        sys.exit(0)
+
+    init_rabbit_mq(args.rabbit_uri, retries=12, retry_interval=10)

--- a/.github/ServiceX/scripts/proxy-exporter.sh
+++ b/.github/ServiceX/scripts/proxy-exporter.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#sudo mkdir -p /etc/grid-security
+#sudo chown cmsuser /etc/grid-security
+
+
+while true; do
+    #sudo cp /etc/grid-security-ro/x509up /etc/grid-security
+    #sudo chown cmsuser /etc/grid-security/x509up
+    #chmod 600 /etc/grid-security/x509up
+
+    # Refresh every hour
+    sleep 3600
+done

--- a/.github/ServiceX/scripts/setup-root.sh
+++ b/.github/ServiceX/scripts/setup-root.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+#
+# Configuration which needs to be done at the 'root' user level
+#
+
+# Setup the folders needed for the grid proxy
+mkdir -p /etc/grid-security/

--- a/.github/ServiceX/scripts/setup.sh
+++ b/.github/ServiceX/scripts/setup.sh
@@ -7,36 +7,36 @@ OPATH="TreeMaker/Production/test/"
 URL=""
 
 usage(){
-        EXIT=$1
+    EXIT=$1
 
-        echo "setup.sh [options]"
-        echo ""
-        echo "-c [version]        use specified CMSSW version (default = ${CMSSWVER})"
-        echo "-d [dir]            project installation area for the CMSSW directory (default = ${DIR})"
-        echo "-f [filename]       the output filename for the downloaded file (default = ${OFILE})"
-        echo "-p [path]           the output path for the downloaded file (default = ${OPATH})"
-        echo "-u [url]            a url to download (default = ${URL})"
-        echo "-h                  display this message and exit"
+    echo "setup.sh [options]"
+    echo ""
+    echo "-c [version]        use specified CMSSW version (default = ${CMSSWVER})"
+    echo "-d [dir]            project installation area for the CMSSW directory (default = ${DIR})"
+    echo "-f [filename]       the output filename for the downloaded file (default = ${OFILE})"
+    echo "-p [path]           the output path for the downloaded file (default = ${OPATH})"
+    echo "-u [url]            a url to download (default = ${URL})"
+    echo "-h                  display this message and exit"
 
-        exit $EXIT
+    exit $EXIT
 }
 
 # process options
 while getopts "c:d:f:p:u:h" opt; do
-        case "$opt" in
-        c) CMSSWVER=$OPTARG
-        ;;
-        d) DIR=$OPTARG
-        ;;
-        f) OFILE=$OPTARG
-		;;
-		p) OPATH=$OPTARG
-		;;
-        u) URL=$OPTARG
-		;;
-        h) usage 0
-        ;;
-        esac
+    case "$opt" in
+    c) CMSSWVER=$OPTARG
+    ;;
+    d) DIR=$OPTARG
+    ;;
+    f) OFILE=$OPTARG
+    ;;
+    p) OPATH=$OPTARG
+    ;;
+    u) URL=$OPTARG
+    ;;
+    h) usage 0
+    ;;
+    esac
 done
 
 # Add these lines to the .bashrc file
@@ -47,16 +47,21 @@ export PYTHONUNBUFFERED=1\n \
 export X509_USER_PROXY=/etc/grid-security/x509up\n" >> ${HOME}/.bashrc
 
 # Initialize the CMSSW environment
+echo -e "Running \'cmsenv\' ... "
 cd ${DIR}/${CMSSWVER}/src
 eval `scramv1 runtime -sh`
 
 # Install missing python packages
-python -m pip install --user --no-cache-dir -r ${CMSSW_BASE}/src/.github/ServiceX/data/requirements.txt
+echo -e "Installing python packages via \'pip\' ... "
+python -m pip install --user --no-cache-dir -r ${CMSSW_BASE}/src/TreeMaker/.github/ServiceX/data/requirements.txt
 
 # Download CMS Open Data test file
 if [[ -n "$URL" ]]; then
-	wget ${URL} -O ${CMSSW_BASE}/src/${OPATH}/${OFILE}
+    DESTINATION="${CMSSW_BASE}/src/${OPATH}/${OFILE}"
+    echo -e "Downloading a file ...\n\tFrom: ${URL}\n\tDestination: ${DESTINATION}"
+    wget ${URL} -O ${DESTINATION}
 fi
 
 # Return to the ${HOME} directory
+echo -e "Returning to ${HOME} ... "
 cd ${HOME}

--- a/.github/ServiceX/scripts/setup.sh
+++ b/.github/ServiceX/scripts/setup.sh
@@ -55,7 +55,7 @@ python -m pip install --user --no-cache-dir -r ${CMSSW_BASE}/src/.github/Service
 
 # Download CMS Open Data test file
 if [[ -n "$URL" ]]; then
-	wget ${URL} -O \ ${CMSSW_BASE}/src/${OPATH}/${OFILE}
+	wget ${URL} -O ${CMSSW_BASE}/src/${OPATH}/${OFILE}
 fi
 
 # Return to the ${HOME} directory

--- a/.github/ServiceX/scripts/setup.sh
+++ b/.github/ServiceX/scripts/setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+
+CMSSWVER=CMSSW_10_2_21
+DIR="${HOME}"
+OFILE="testfile.root"
+OPATH="TreeMaker/Production/test/"
+URL=""
+
+usage(){
+        EXIT=$1
+
+        echo "setup.sh [options]"
+        echo ""
+        echo "-c [version]        use specified CMSSW version (default = ${CMSSWVER})"
+        echo "-d [dir]            project installation area for the CMSSW directory (default = ${DIR})"
+        echo "-f [filename]       the output filename for the downloaded file (default = ${OFILE})"
+        echo "-p [path]           the output path for the downloaded file (default = ${OPATH})"
+        echo "-u [url]            a url to download (default = ${URL})"
+        echo "-h                  display this message and exit"
+
+        exit $EXIT
+}
+
+# process options
+while getopts "c:d:f:p:u:h" opt; do
+        case "$opt" in
+        c) CMSSWVER=$OPTARG
+        ;;
+        d) DIR=$OPTARG
+        ;;
+        f) OFILE=$OPTARG
+		;;
+		p) OPATH=$OPTARG
+		;;
+        u) URL=$OPTARG
+		;;
+        h) usage 0
+        ;;
+        esac
+done
+
+# Turn this on so that stdout isn't buffered - otherwise logs in kubectl don't
+# show up until much later!
+export PYTHONUNBUFFERED=1
+export X509_USER_PROXY=/etc/grid-security/x509up
+
+# Setup the folders needed for the grid proxy
+mkdir -p /etc/grid-security/
+
+# Initialize the CMSSW environment
+cd ${DIR}/${CMSSWVER}/src
+eval `scramv1 runtime -sh`
+
+# Install missing python packages
+python -m pip install --user --no-cache-dir -r ${CMSSW_BASE}/src/.github/ServiceX/data/requirements.txt
+
+# Download CMS Open Data test file
+if [[ -n "$URL" ]]; then
+	wget ${URL} -O \ ${CMSSW_BASE}/src/${OPATH}/${OFILE}
+fi

--- a/.github/ServiceX/scripts/setup.sh
+++ b/.github/ServiceX/scripts/setup.sh
@@ -39,13 +39,12 @@ while getopts "c:d:f:p:u:h" opt; do
         esac
 done
 
-# Turn this on so that stdout isn't buffered - otherwise logs in kubectl don't
-# show up until much later!
-export PYTHONUNBUFFERED=1
-export X509_USER_PROXY=/etc/grid-security/x509up
-
-# Setup the folders needed for the grid proxy
-mkdir -p /etc/grid-security/
+# Add these lines to the .bashrc file
+echo -e "\n \
+# Turn this on so that stdout isn't buffered - otherwise logs in kubectl don't\n \
+#   show up until much later!\n \
+export PYTHONUNBUFFERED=1\n \
+export X509_USER_PROXY=/etc/grid-security/x509up\n" >> ${HOME}/.bashrc
 
 # Initialize the CMSSW environment
 cd ${DIR}/${CMSSWVER}/src
@@ -58,3 +57,6 @@ python -m pip install --user --no-cache-dir -r ${CMSSW_BASE}/src/.github/Service
 if [[ -n "$URL" ]]; then
 	wget ${URL} -O \ ${CMSSW_BASE}/src/${OPATH}/${OFILE}
 fi
+
+# Return to the ${HOME} directory
+cd ${HOME}

--- a/.github/ServiceX/scripts/setup.sh
+++ b/.github/ServiceX/scripts/setup.sh
@@ -47,12 +47,12 @@ export PYTHONUNBUFFERED=1\n \
 export X509_USER_PROXY=/etc/grid-security/x509up\n" >> ${HOME}/.bashrc
 
 # Initialize the CMSSW environment
-echo -e "Running \'cmsenv\' ... "
+echo -e "Running 'cmsenv' ... "
 cd ${DIR}/${CMSSWVER}/src
 eval `scramv1 runtime -sh`
 
 # Install missing python packages
-echo -e "Installing python packages via \'pip\' ... "
+echo -e "Installing python packages via 'pip' ... "
 python -m pip install --user --no-cache-dir -r ${CMSSW_BASE}/src/TreeMaker/.github/ServiceX/data/requirements.txt
 
 # Download CMS Open Data test file

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -96,11 +96,12 @@ jobs:
     steps:
     - name: Build a Service-X compatible Docker image
       env:
+        script_dir: /home/cmsuser/${{ env.CMSSW_VER }}/src/.github/ServiceX/scripts/
         download_url: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
         file_name: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
         base_image: treemaker/treemaker:${{ env.current_branch }}-latest
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker --entrypoint "/bin/bash
-      run: docker run ${{ env.docker_options }} ${{ env.base_image }} -c "./${{ env.CMSSW_VER }}/src/.github/ServiceX/scripts/setup-root.sh && /run.sh -c \"./${{ env.CMSSW_VER }}/src/.github/ServiceX/scripts/setup.sh -c ${{ env.cmssw_ver }} -f ${{ env.file_name }} -u ${{ env.download_url }}\"
+      run: docker run ${{ env.docker_options }} ${{ env.base_image }} -c "${{ env.script_dir }}/setup-root.sh && /run.sh -c \"${{ env.script_dir }}/setup.sh -c ${{ env.cmssw_ver }} -f ${{ env.file_name }} -u ${{ env.download_url }}\""
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-servicex
     - name: Log into registry

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -37,10 +37,10 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-latest
     - name: Log into registry
-      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]') && ${{ env.current_user}} == 'TreeMaker'"
+      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]') && env.current_user == 'TreeMaker'"
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
-      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]') && ${{ env.current_user}} == 'TreeMaker'"
+      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]') && env.current_user == 'TreeMaker'"
       run: docker push treemaker/treemaker:${{ env.current_branch }}-latest
 
     # Run the integration test within the 'build' job only if this is a pull_request initiated build
@@ -66,7 +66,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     needs: [build]
-    if: "!contains(github.event.head_commit.message, '[skip test]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request' && ${{ env.current_user}} == 'TreeMaker'"
+    if: "!contains(github.event.head_commit.message, '[skip test]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request' && env.current_user == 'TreeMaker'"
     steps:
     - name: Run the container and perform an integration test
       env:
@@ -92,7 +92,7 @@ jobs:
   service-x-build:
     runs-on: ubuntu-latest
     needs: [build]
-    if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request' && ${{ env.current_user}} == 'TreeMaker'"
+    if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request' && env.current_user == 'TreeMaker'"
     steps:
     - name: Build a Service-X compatible Docker image
       env:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -76,7 +76,7 @@ jobs:
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
         integration_test_image: treemaker/treemaker:${{ env.current_branch }}-latest
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker
-      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd ${{ env.cmssw_ver }}/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99 && rm ${{ env.file_name }}"
+      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd ${{ env.cmssw_ver }}/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99 && rm ${{ env.file_name }} && cd ${HOME}"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry
@@ -99,8 +99,8 @@ jobs:
         download_url: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
         file_name: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
         base_image: treemaker/treemaker:${{ env.current_branch }}-latest
-        docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker
-      run: docker run ${{ env.docker_options }} ${{ env.base_image }} -- -i -c "./${{ env.CMSSW_VER }}/src/.github/ServiceX/scripts/setup.sh -c ${{ env.cmssw_ver }} -f ${{ env.file_name }} -u ${{ env.download_url }}"
+        docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker --entrypoint "/bin/bash
+      run: docker run ${{ env.docker_options }} ${{ env.base_image }} -c "./${{ env.CMSSW_VER }}/src/.github/ServiceX/scripts/setup-root.sh && /run.sh -c \"./${{ env.CMSSW_VER }}/src/.github/ServiceX/scripts/setup.sh -c ${{ env.cmssw_ver }} -f ${{ env.file_name }} -u ${{ env.download_url }}\"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-servicex
     - name: Log into registry

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -37,10 +37,10 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-latest
     - name: Log into registry
-      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]')"
+      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]') && ${{ env.current_user}} == 'TreeMaker'"
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
-      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]')"
+      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]') && ${{ env.current_user}} == 'TreeMaker'"
       run: docker push treemaker/treemaker:${{ env.current_branch }}-latest
 
     # Run the integration test within the 'build' job only if this is a pull_request initiated build
@@ -66,7 +66,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     needs: [build]
-    if: "!contains(github.event.head_commit.message, '[skip test]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
+    if: "!contains(github.event.head_commit.message, '[skip test]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request' && ${{ env.current_user}} == 'TreeMaker'"
     steps:
     - name: Run the container and perform an integration test
       env:
@@ -92,7 +92,7 @@ jobs:
   service-x-build:
     runs-on: ubuntu-latest
     needs: [build]
-    if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
+    if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request' && ${{ env.current_user}} == 'TreeMaker'"
     steps:
     - name: Build a Service-X compatible Docker image
       env:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,6 +9,7 @@ on:
 env:
   current_branch: $(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')
   current_user: ${{ github.actor }}
+  cmssw_ver: CMSSW_10_2_21
 
 jobs:
 
@@ -54,7 +55,7 @@ jobs:
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
         integration_test_image: treemaker/treemaker:${{ env.current_branch }}-latest
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker-integration
-      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
+      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd ${{ env.cmssw_ver }}/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
 
   # The 'integration-test' job opens the previous 'build' image, pulled from the registry, to:
   #   1. test that the image was successfully uploaded to the registry
@@ -75,10 +76,34 @@ jobs:
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
         integration_test_image: treemaker/treemaker:${{ env.current_branch }}-latest
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker
-      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd CMSSW_10_2_21/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99"
+      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd ${{ env.cmssw_ver }}/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99 && rm ${{ env.file_name }}"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
       run: docker push treemaker/treemaker:${{ env.current_branch }}-cache
+
+  # The 'service-x-build' job opens the previous 'build' image, pulled from the registry, in order to 
+  #   create a slightly modified image which can serve as a Service-X transformer
+  # In the future, we might use the cached version of the image from the 'integration-test' job.
+  # The build needs to run inside a container because it needs access to the CMSSW version of python,
+  #   which is accessed after 'cmsenv', which relies on having access to /cvmfs/cms.cern.ch/.
+  service-x-build:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: "!contains(github.event.head_commit.message, '[skip service-x]') && github.event_name != 'pull_request'"
+    steps:
+    - name: Build a Service-X compatible Docker image
+      env:
+        download_url: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
+        file_name: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
+        base_image: treemaker/treemaker:${{ env.current_branch }}-latest
+        docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker
+      run: docker run ${{ env.docker_options }} ${{ env.base_image }} -- -i -c "./${{ env.CMSSW_VER }}/src/.github/ServiceX/scripts/setup.sh -c ${{ env.cmssw_ver }} -f ${{ env.file_name }} -u ${{ env.download_url }}"
+    - name: Commit the changes
+      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-servicex
+    - name: Log into registry
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+    - name: Publish the new docker image
+      run: docker push treemaker/treemaker:${{ env.current_branch }}-servicex

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ Run2_2017 , Run2_2017_Docker]
+    branches: [ Run2_2017 ]
   pull_request:
     branches: [ Run2_2017 ]
 
@@ -66,7 +66,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     needs: [build]
-    if: "!contains(github.event.head_commit.message, '[skip test]') && github.event_name != 'pull_request'"
+    if: "!contains(github.event.head_commit.message, '[skip test]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
     steps:
     - name: Run the container and perform an integration test
       env:
@@ -80,10 +80,8 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry
-      if: "!contains(github.event.head_commit.message, '[skip publish]')"
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
-      if: "!contains(github.event.head_commit.message, '[skip publish]')"
       run: docker push treemaker/treemaker:${{ env.current_branch }}-cache
 
   # The 'service-x-build' job opens the previous 'build' image, pulled from the registry, in order to 
@@ -94,7 +92,7 @@ jobs:
   service-x-build:
     runs-on: ubuntu-latest
     needs: [build]
-    if: "!contains(github.event.head_commit.message, '[skip service-x]') && github.event_name != 'pull_request'"
+    if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
     steps:
     - name: Build a Service-X compatible Docker image
       env:
@@ -106,8 +104,6 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-servicex
     - name: Log into registry
-      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]')"
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
-      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]')"
       run: docker push treemaker/treemaker:${{ env.current_branch }}-servicex

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ Run2_2017 ]
+    branches: [ Run2_2017 , Run2_2017_Docker]
   pull_request:
     branches: [ Run2_2017 ]
 
@@ -37,10 +37,10 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-latest
     - name: Log into registry
-      if: github.event_name != 'pull_request'
+      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]')"
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
-      if: github.event_name != 'pull_request'
+      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]')"
       run: docker push treemaker/treemaker:${{ env.current_branch }}-latest
 
     # Run the integration test within the 'build' job only if this is a pull_request initiated build
@@ -80,8 +80,10 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry
+      if: "!contains(github.event.head_commit.message, '[skip publish]')"
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
+      if: "!contains(github.event.head_commit.message, '[skip publish]')"
       run: docker push treemaker/treemaker:${{ env.current_branch }}-cache
 
   # The 'service-x-build' job opens the previous 'build' image, pulled from the registry, in order to 
@@ -104,6 +106,8 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-servicex
     - name: Log into registry
+      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]')"
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
+      if: "github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip publish]')"
       run: docker push treemaker/treemaker:${{ env.current_branch }}-servicex

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -66,7 +66,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     needs: [build]
-    if: "!contains(github.event.head_commit.message, '[skip test]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request' && env.current_user == 'TreeMaker'"
+    if: "!contains(github.event.head_commit.message, '[skip test]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
     steps:
     - name: Run the container and perform an integration test
       env:
@@ -80,8 +80,10 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry
+      if: env.current_user == 'TreeMaker'
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
+      if: env.current_user == 'TreeMaker'
       run: docker push treemaker/treemaker:${{ env.current_branch }}-cache
 
   # The 'service-x-build' job opens the previous 'build' image, pulled from the registry, in order to 
@@ -92,7 +94,7 @@ jobs:
   service-x-build:
     runs-on: ubuntu-latest
     needs: [build]
-    if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request' && env.current_user == 'TreeMaker'"
+    if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
     steps:
     - name: Build a Service-X compatible Docker image
       env:
@@ -105,6 +107,8 @@ jobs:
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-servicex
     - name: Log into registry
+      if: env.current_user == 'TreeMaker'
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
+      if: env.current_user == 'TreeMaker'
       run: docker push treemaker/treemaker:${{ env.current_branch }}-servicex


### PR DESCRIPTION
Add the automatic creation of a new Docker image for ServiceX. This creation will take place after the base image for TreeMaker and simultaneous to the integration test. The reason this image is needed is to add some customization to the python packages and environment variables.

In doing this work, several updated were made to the GitHub actions workflow.
1. Publishing is turned off for all users except 'TreeMaker'. While this isn't totally secure, it prevents innocent users from accidentally overwriting the images if they happen to have the DockerHub secrets.
2. The integration-test and service-x workflows won't run if the user isn't 'TreeMaker'. As the image won't be updated unless the user is merging in the Run2_2017 branch after a PR and the users account can't publish the resulting images, it doesn't make sense to go through the effort for them to run a second , but unpublished, integration test.

Because of the changes mentioned above, I was unable to test to ServiceX workflow in it's entirety. I was able to test that if one uses the treemaker/treemaker:Runw_2017-latest image, that the .github/ServiceX/scripts/setup.sh works. The only part that is untested is the .github/ServiceX/scripts/setup-root.sh part.