### PR TITLE
[Run2_2017] Change the type for the PDF weights branches

### DIFF
--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -37,7 +37,7 @@ using namespace std;
 //enum with known types
 enum TreeTypes { 
 	t_bool=0, t_int=1, t_double=2, t_string=3, t_lorentz=4, t_xyzv=5, t_xyzp=6,
-	t_vbool=100, t_vint=101, t_vdouble=102, t_vstring=103, t_vlorentz=104, t_vxyzv=105, t_vxyzp=106,
+	t_vbool=100, t_vint=101, t_vdouble=102, t_vstring=103, t_vlorentz=104, t_vxyzv=105, t_vxyzp=106, t_vfloat=107,
 	t_vvbool=200, t_vvint=201, t_vvdouble=202, t_vvstring=203, t_vvlorentz=204, t_vvxyzv=205, t_vvxyzp=206,
 	t_recocand=1000
 };
@@ -216,6 +216,8 @@ void TreeObject<vector<bool> >::AddBranch() { if(tree) branch = tree->Branch(nam
 template<>
 void TreeObject<vector<int> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<int>",&value,32000,0); }
 template<>
+void TreeObject<vector<float> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<float>",&value,32000,0); }
+template<>
 void TreeObject<vector<double> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<double>",&value,32000,0); }
 template<>
 void TreeObject<vector<string> >::AddBranch() { if(tree) branch = tree->Branch(nameInTree.c_str(),"vector<string>",&value,32000,0); }
@@ -258,6 +260,8 @@ template<>
 void TreeObject<vector<bool> >::SetDefault() { value.clear(); }
 template<>
 void TreeObject<vector<int> >::SetDefault() { value.clear(); }
+template<>
+void TreeObject<vector<float> >::SetDefault() { value.clear(); }
 template<>
 void TreeObject<vector<double> >::SetDefault() { value.clear(); }
 template<>

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -42,6 +42,7 @@ def makeTreeFromMiniAOD(self,process):
         VectorTLorentzVector       = self.VectorTLorentzVector,
         VectorXYZVector            = self.VectorXYZVector,
         VectorXYZPoint             = self.VectorXYZPoint,
+        VectorFloat                = self.VectorFloat,
         VectorDouble               = self.VectorDouble,
         VectorInt                  = self.VectorInt,
         VectorString               = self.VectorString,
@@ -107,7 +108,7 @@ def makeTreeFromMiniAOD(self,process):
             normalize = (not "SVJ" in self.sample), # skip normalization only for SVJ signals
             pdfSetName = cms.string("NNPDF31_lo_as_0130"),
         )
-        self.VectorDouble.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights','PDFWeights:PSweights'])
+        self.VectorFloat.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights','PDFWeights:PSweights'])
 
     ## ----------------------------------------------------------------------------------------------
     ## GenHT for stitching together MC samples

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -108,6 +108,7 @@ class maker:
         self.VectorTLorentzVector       = cms.vstring()
         self.VectorXYZVector            = cms.vstring()
         self.VectorXYZPoint             = cms.vstring()
+        self.VectorFloat                = cms.vstring()
         self.VectorDouble               = cms.vstring()
         self.VectorString               = cms.vstring()
         self.VectorInt                  = cms.vstring()

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -31,13 +31,13 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 	tree(nullptr),
 	VarTypeNames{
 		"VarsBool","VarsInt","VarsDouble","VarsString","VarsTLorentzVector","VarsXYZVector","VarsXYZPoint",
-		"VectorBool","VectorInt","VectorDouble","VectorString","VectorTLorentzVector","VectorXYZVector","VectorXYZPoint",
+		"VectorBool","VectorInt","VectorDouble","VectorString","VectorTLorentzVector","VectorXYZVector","VectorXYZPoint","VectorFloat",
 		"VectorVectorBool","VectorVectorInt","VectorVectorDouble","VectorVectorString","VectorVectorTLorentzVector","VectorVectorXYZVector","VectorVectorXYZPoint",
 		"VectorRecoCand"
 	},
 	VarTypes{
 		t_bool,t_int,t_double,t_string,t_lorentz,t_xyzv,t_xyzp,
-		t_vbool,t_vint,t_vdouble,t_vstring,t_vlorentz,t_vxyzv,t_vxyzp,
+		t_vbool,t_vint,t_vdouble,t_vstring,t_vlorentz,t_vxyzv,t_vxyzp,t_vfloat,
 		t_vvbool,t_vvint,t_vvdouble,t_vvstring,t_vvlorentz,t_vvxyzv,t_vvxyzp,
 		t_recocand
 	}
@@ -112,6 +112,7 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 				case TreeTypes::t_xyzp     : tmp = new TreeObject<math::XYZPoint>(VarName,VarTitle); break;
 				case TreeTypes::t_vbool    : tmp = new TreeObject<vector<bool>>(VarName,VarTitle); break;
 				case TreeTypes::t_vint     : tmp = new TreeObject<vector<int>>(VarName,VarTitle); break;
+				case TreeTypes::t_vfloat   : tmp = new TreeObject<vector<float>>(VarName,VarTitle); break;
 				case TreeTypes::t_vdouble  : tmp = new TreeObject<vector<double>>(VarName,VarTitle); break;
 				case TreeTypes::t_vstring  : tmp = new TreeObject<vector<string>>(VarName,VarTitle); break;
 				case TreeTypes::t_vlorentz : tmp = new TreeObject<vector<TLorentzVector>>(VarName,VarTitle); break;

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -24,7 +24,7 @@ template <class P>
 class PDFWeightHelper {
   public:
     PDFWeightHelper(const P* prod, bool use_norm) : product_(prod), use_norm_(use_norm) {}
-    bool fillWeights(std::vector<double>* output, unsigned offset, unsigned nWeights, wtype wt) {
+    bool fillWeights(std::vector<float>* output, unsigned offset, unsigned nWeights, wtype wt) {
       unsigned max = this->getMax();
       if(max==0 or offset > max) return false;
       double norm = use_norm_ ? 1./this->getNorm(offset,wt) : 1.;
@@ -107,9 +107,9 @@ PDFWeightProducer::PDFWeightProducer(const edm::ParameterSet& iConfig) :
   }
 
   callWhenNewProductsRegistered(getterOfProducts_);
-  produces<std::vector<double> >("ScaleWeights");
-  produces<std::vector<double> >("PDFweights");
-  produces<std::vector<double> >("PSweights");
+  produces<std::vector<float> >("ScaleWeights");
+  produces<std::vector<float> >("PDFweights");
+  produces<std::vector<float> >("PSweights");
 }
 
 PDFWeightProducer::~PDFWeightProducer()
@@ -128,9 +128,9 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   std::vector<edm::Handle<LHEEventProduct> > handles;
   getterOfProducts_.fillHandles(iEvent, handles);
   
-  auto scaleweights = std::make_unique<std::vector<double>>();
-  auto pdfweights = std::make_unique<std::vector<double>>();
-  auto psweights = std::make_unique<std::vector<double>>();
+  auto scaleweights = std::make_unique<std::vector<float>>();
+  auto pdfweights = std::make_unique<std::vector<float>>();
+  auto psweights = std::make_unique<std::vector<float>>();
   
   bool found_scales = false;
   bool found_pdfs = false;


### PR DESCRIPTION
Change the PDFWeights, PSweights, and ScaleWeights branchest from vector<double> to vector<float>. This reduces the size of the TreeMaker ntuples by about 7.7%. It changes the PDFWeights from being the second largest branch, behind Jets, to the 5th largest branch. This change is something we've said we'd try for a long time. Is this change acceptable from a precision standpoint, ignoring the space saving benefits?