### PR TITLE
[Run2_2017] Transform nested vector branches to flattend+offset vector branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Brief explanation of the options in [makeTree.py](./TreeMaker/python/makeTree.py
 * `saveMinimalGenParticles`: save only the hard scatter gen particles coming from top decays, boson decays, semi-visible jets, or SUSY particles (default=True)
 * `saveGenTops`: save the 4-vectors of the generated tops and the TTbar reweighting scale factor (default=False)
 * `doMT2`: switch to enable the storage of the MT2 variable (default=False)
+* `nestedVectors`: switch to change from saving vector<\vector<T>> to saving vector<T> values and vector<\int> offsets (default=True)
 
 The following parameters take their default values from the specified scenario:
 * `globaltag`: global tag for CMSSW database conditions (ref. [FrontierConditions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions))

--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -433,7 +433,7 @@ class TreeNestedVector : public TreeObject<Top> {
 	protected:
 		//member variables
 		edm::EDGetTokenT<Top> tok;
-		string type{};
+		string type;
 		bool nestedVectors{};
 		vector<typename Sub::value_type> values;
 		vector<int> offsets;

--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -31,6 +31,8 @@
 #include <map>
 #include <sstream>
 #include <algorithm>
+#include <utility>
+#include <iterator>
 
 using namespace std;
 
@@ -63,7 +65,7 @@ class TreeMaker : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 		edm::Service<TFileService> fs;
 		string treeName;
 		TTree* tree;	
-		bool doLorentz, sortBranches, debugTitles;
+		bool doLorentz, sortBranches, debugTitles, nestedVectors;
 		vector<string> VarTypeNames;
 		vector<TreeTypes> VarTypes;
 		map<string,unsigned> nameCache;
@@ -355,4 +357,84 @@ class TreeRecoCand : public TreeObject<vector<TLorentzVector> > {
 		edm::EDGetTokenT<edm::View<reco::Candidate>> candTok;
 		bool doLorentz{};
 		vector<double> pt, eta, phi, energy;
+};
+
+//derived version of vector<vector<T>>
+//with switch for vector<T> values and vector<int> offsets instead
+template <template<typename...> class R=std::vector, typename Top = R<R<double>>, typename Sub = typename Top::value_type>
+class TreeNestedVector : public TreeObject<Top> {
+	public:
+		//constructor
+		TreeNestedVector() : TreeObject<Top>() {}
+		TreeNestedVector(string type_, string tempFull_, string title_="", bool nestedVectors_=true) : TreeObject<Top>(tempFull_,title_), type(type_), nestedVectors(nestedVectors_) {}
+		//destructor
+		~TreeNestedVector() override {}
+		
+		//functions
+		//From: https://stackoverflow.com/questions/17294629/merging-flattening-sub-vectors-into-a-single-vector-c-converting-2d-to-1d
+		void flatten(Top const& all, R<typename Sub::value_type> &accum, R<int> &offsets) {
+			// Don't store any offsets if there are no sub-vectors
+			if (all.size() > 0)	offsets.insert(std::end(offsets),0);
+			else 				return;
+			for(auto& sub : all) {
+				accum.insert(std::end(accum), std::begin(sub), std::end(sub));
+				offsets.insert(std::end(offsets), accum.size());
+			}
+			// This protects against the case where there were >=1 empty sub-vectors, and only empty vectors
+			// Thus, nothing will be in the output (accum) vector, but the offsets would be all '0'
+			if (accum.size() == 0) offsets.clear();
+		}
+		void SetConsumes(edm::ConsumesCollector && iC) override{
+			tok = iC.consumes<Top>(this->tag);
+		}
+		void FillTree(const edm::Event& iEvent) override{
+			SetDefault();
+			edm::Handle<Top> var;
+			iEvent.getByToken(tok,var);
+			if( var.isValid() ) {
+				if(nestedVectors){
+					this->value = *var;
+				}
+				else{
+					size_t totalLength = 0;
+					for(auto iOuter = var->begin(); iOuter != var->end(); ++iOuter) {
+						totalLength += iOuter->size();
+					}
+					values.reserve(totalLength);
+					offsets.reserve(var->size());
+					flatten(*var,values,offsets);
+				}
+			}
+			else {
+				edm::LogWarning("TreeMaker") << "WARNING ... " << this->tagName << " is NOT valid?!";
+			}
+		}
+		void AddBranch() override {
+			if(this->tree){
+				if(nestedVectors){
+					this->tree->Branch(this->nameInTree.c_str(),("vector<vector<"+type+">>").c_str(),&this->value,32000,0);
+				}
+				else {
+					this->tree->Branch((this->nameInTree).c_str(),("vector<"+type+">").c_str(),&values,32000,0);
+					this->tree->Branch((this->nameInTree+"Offsets").c_str(),"vector<int>",&offsets,32000,0);
+				}
+			}
+		}
+		void SetDefault() override {
+			if(nestedVectors){
+				this->value.clear();
+			}
+			else{
+				values.clear();
+				offsets.clear();
+			}
+		}
+
+	protected:
+		//member variables
+		edm::EDGetTokenT<Top> tok;
+		string type{};
+		bool nestedVectors{};
+		vector<typename Sub::value_type> values;
+		vector<int> offsets;
 };

--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -360,9 +360,13 @@ class TreeRecoCand : public TreeObject<vector<TLorentzVector> > {
 };
 
 // Derived version of vector<vector<T>> with switch for vector<T> values and vector<int> offsets instead
-template <typename Base = double, typename Sub = std::vector<Base>, typename Top = std::vector<Sub>> 
-class TreeNestedVector : public TreeObject<Top> {
+template <typename Base = double> 
+class TreeNestedVector : public TreeObject<std::vector<std::vector<Base>>> {
 	public:
+		// Typedefs
+		typedef std::vector<Base> Sub;
+		typedef std::vector<Sub> Top;
+
 		// Constructor
 		TreeNestedVector() : TreeObject<Top>() {}
 		TreeNestedVector(string tempFull_, string title_="", bool nestedVectors_=true) : TreeObject<Top>(tempFull_,title_), nestedVectors(nestedVectors_) {}

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -54,6 +54,7 @@ def makeTreeFromMiniAOD(self,process):
         VectorVectorXYZVector      = self.VectorVectorXYZVector,
         VectorVectorXYZPoint       = self.VectorVectorXYZVector,
         TitleMap                   = self.TitleMap,
+        nestedVectors              = self.nestedVectors,
     )
 
     ## ----------------------------------------------------------------------------------------------

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -147,7 +147,8 @@ class maker:
         print " Storing a minimal set of GenParticles: "+str(self.saveMinimalGenParticles)
         print " Storing the GenTops: "+str(self.saveGenTops)
         print " Saving the MT2 variable: "+str(self.doMT2)
-        print " Saving nested vectors as vector<vector<T>>: "+str(self.nestedVectors)
+        if self.nestedVectors: print " Saving nested vectors as vector<vector<T>>"
+        else: print " Saving nested vectors as vector<T> + vector<int>"
         print " "
         print " scenario: "+self.scenarioName
         print " global tag: "+self.globaltag

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -58,6 +58,7 @@ class maker:
         self.getParamDefault("saveMinimalGenParticles", True)
         self.getParamDefault("saveGenTops", False)
         self.getParamDefault("doMT2",False)
+        self.getParamDefault("nestedVectors", True)
         
         # take command line input (w/ defaults from scenario if specified)
         self.getParamDefault("globaltag",self.scenario.globaltag)
@@ -146,6 +147,7 @@ class maker:
         print " Storing a minimal set of GenParticles: "+str(self.saveMinimalGenParticles)
         print " Storing the GenTops: "+str(self.saveGenTops)
         print " Saving the MT2 variable: "+str(self.doMT2)
+        print " Saving nested vectors as vector<vector<T>>: "+str(self.nestedVectors)
         print " "
         print " scenario: "+self.scenarioName
         print " global tag: "+self.globaltag

--- a/TreeMaker/python/treeMaker.py
+++ b/TreeMaker/python/treeMaker.py
@@ -11,6 +11,9 @@ doLorentz = cms.bool(True),
 sortBranches = cms.bool(True),
 #debug the InputTag to branch mapping by printing the mapping to the log
 debugTitles = cms.bool(False),
+#default: output vector<vector<T>>
+#switches to vector<T> values, vector<int> skips
+nestedVectors = cms.bool(True),
 # list of reco candidate objects: for each reco cand collection, the TLorentzVector will be stored in a vector.
 VarsBool = cms.vstring(),
 VarsInt = cms.vstring(),

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -118,13 +118,13 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 				case TreeTypes::t_vlorentz : tmp = new TreeObject<vector<TLorentzVector>>(VarName,VarTitle); break;
 				case TreeTypes::t_vxyzv    : tmp = new TreeObject<vector<math::XYZVector>>(VarName,VarTitle); break;
 				case TreeTypes::t_vxyzp    : tmp = new TreeObject<vector<math::XYZPoint>>(VarName,VarTitle); break;
-				case TreeTypes::t_vvbool   : tmp = new TreeNestedVector<vector, vector<vector<bool>>>("bool",VarName,VarTitle,nestedVectors); break;
-				case TreeTypes::t_vvint    : tmp = new TreeNestedVector<vector, vector<vector<int>>>("int",VarName,VarTitle,nestedVectors); break;
-				case TreeTypes::t_vvdouble : tmp = new TreeNestedVector<vector, vector<vector<double>>>("double",VarName,VarTitle,nestedVectors); break;
-				case TreeTypes::t_vvstring : tmp = new TreeNestedVector<vector, vector<vector<string>>>("string",VarName,VarTitle,nestedVectors); break;
-				case TreeTypes::t_vvlorentz: tmp = new TreeNestedVector<vector, vector<vector<TLorentzVector>>>("TLorentzVector",VarName,VarTitle,nestedVectors); break;
-				case TreeTypes::t_vvxyzv   : tmp = new TreeNestedVector<vector, vector<vector<math::XYZVector>>>("math::XYZVector",VarName,VarTitle,nestedVectors); break;
-				case TreeTypes::t_vvxyzp   : tmp = new TreeNestedVector<vector, vector<vector<math::XYZPoint>>>("math::XYZPoint",VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvbool   : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvint    : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvdouble : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvstring : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvlorentz: tmp = new TreeNestedVector<TLorentzVector>(VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvxyzv   : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvxyzp   : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors); break;
 				case TreeTypes::t_recocand : tmp = new TreeRecoCand(VarName,VarTitle,doLorentz); break;
 			}
 			//if a known type was found, initialize and store the object

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -49,6 +49,7 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 	doLorentz = iConfig.getParameter<bool>("doLorentz");
 	sortBranches = iConfig.getParameter<bool>("sortBranches");
 	debugTitles = iConfig.getParameter<bool>("debugTitles");
+	nestedVectors = iConfig.getParameter<bool>("nestedVectors");
 
 	// parse the TitleMap
 	stringstream skipMessage;
@@ -117,13 +118,13 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 				case TreeTypes::t_vlorentz : tmp = new TreeObject<vector<TLorentzVector>>(VarName,VarTitle); break;
 				case TreeTypes::t_vxyzv    : tmp = new TreeObject<vector<math::XYZVector>>(VarName,VarTitle); break;
 				case TreeTypes::t_vxyzp    : tmp = new TreeObject<vector<math::XYZPoint>>(VarName,VarTitle); break;
-				case TreeTypes::t_vvbool   : tmp = new TreeObject<vector<vector<bool>>>(VarName,VarTitle); break;
-				case TreeTypes::t_vvint    : tmp = new TreeObject<vector<vector<int>>>(VarName,VarTitle); break;
-				case TreeTypes::t_vvdouble : tmp = new TreeObject<vector<vector<double>>>(VarName,VarTitle); break;
-				case TreeTypes::t_vvstring : tmp = new TreeObject<vector<vector<string>>>(VarName,VarTitle); break;
-				case TreeTypes::t_vvlorentz: tmp = new TreeObject<vector<vector<TLorentzVector>>>(VarName,VarTitle); break;
-				case TreeTypes::t_vvxyzv   : tmp = new TreeObject<vector<vector<math::XYZVector>>>(VarName,VarTitle); break;
-				case TreeTypes::t_vvxyzp   : tmp = new TreeObject<vector<vector<math::XYZPoint>>>(VarName,VarTitle); break;
+				case TreeTypes::t_vvbool   : tmp = new TreeNestedVector<vector, vector<vector<bool>>>("bool",VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvint    : tmp = new TreeNestedVector<vector, vector<vector<int>>>("int",VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvdouble : tmp = new TreeNestedVector<vector, vector<vector<double>>>("double",VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvstring : tmp = new TreeNestedVector<vector, vector<vector<string>>>("string",VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvlorentz: tmp = new TreeNestedVector<vector, vector<vector<TLorentzVector>>>("TLorentzVector",VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvxyzv   : tmp = new TreeNestedVector<vector, vector<vector<math::XYZVector>>>("math::XYZVector",VarName,VarTitle,nestedVectors); break;
+				case TreeTypes::t_vvxyzp   : tmp = new TreeNestedVector<vector, vector<vector<math::XYZPoint>>>("math::XYZPoint",VarName,VarTitle,nestedVectors); break;
 				case TreeTypes::t_recocand : tmp = new TreeRecoCand(VarName,VarTitle,doLorentz); break;
 			}
 			//if a known type was found, initialize and store the object


### PR DESCRIPTION
Allow the transformation of vector<vector<T>> branches to be saved as flattened vector<T> branches with an associated vector<int> branch of offsets.

Two unit tests were performed, one keeping the nested vector format and the other flattening the vectors. Flattening the vectors has the effect of decreasing the ntuple size by a little under 1% (0.88% in our 100 event test).

I have not tested the speed change.