### PR TITLE
[Run2_2017] Fix a path to the service-x setup scripts

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -104,7 +104,7 @@ jobs:
       run: echo ::set-env name=current_user::$(echo ${{ github.repository }} | sed -E 's|/.*||')
     - name: Build a Service-X compatible Docker image
       env:
-        script_dir: /home/cmsuser/${{ env.cmssw_ver }}/src/.github/ServiceX/scripts/
+        script_dir: /home/cmsuser/${{ env.cmssw_ver }}/src/TreeMaker/.github/ServiceX/scripts/
         download_url: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
         file_name: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
         base_image: treemaker/treemaker:${{ env.current_branch }}-latest


### PR DESCRIPTION
The path to the setup scripts needed by the service-x workflow was wrong. It missed the TreeMaker folder inside of the $CMSSW_BASE/src folder.