### PR TITLE
[Run2_2017] Add more debug options to aid in synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Brief explanation of the options in [makeTree.py](./TreeMaker/python/makeTree.py
 * `doPDFs`: switch to enable the storage of PDF weights and scale variation weights from LHEEventInfo (default=True)  
   The scale variations stored are: [mur=1, muf=1], [mur=1, muf=2], [mur=1, muf=0.5], [mur=2, muf=1], [mur=2, muf=2], [mur=2, muf=0.5], [mur=0.5, muf=1], [mur=0.5, muf=2], [mur=0.5, muf=0.5]
 * `debugtracks`: store information for all PF candidates in every event (default=False) (use with caution, increases run time and output size by ~10x)
+* `debugtap`: store extra information for the TAP collections (default=False)
 * `debugsubjets`: store some additional information for the AK8 subjets (default=False)
 * `applybaseline`: switch to apply the baseline HT selection (default=False)
 * `saveMinimalGenParticles`: save only the hard scatter gen particles coming from top decays, boson decays, semi-visible jets, or SUSY particles (default=True)

--- a/TreeMaker/python/doLostLeptonBkg.py
+++ b/TreeMaker/python/doLostLeptonBkg.py
@@ -118,6 +118,14 @@ def doLostLeptonBkg(self,process,METTag):
     self.VectorTLorentzVector.extend(['TAPPionTracks:pfcands(TAPPionTracks)'])
     self.VectorDouble.extend(['TAPPionTracks:pfcandstrkiso(TAPPionTracks_trkiso)'])
     self.VectorDouble.extend(['TAPPionTracks:pfcandsmT(TAPPionTracks_mT)'])
+    if self.debugtap:
+        for type in ['Electron','Muon','Pion']:
+            self.VectorDouble.extend(['TAP'+type+'Tracks:pfcandspfreliso03chg(TAP'+type+'Tracks_pfRelIso03chg)'])
+            self.VectorDouble.extend(['TAP'+type+'Tracks:pfcandspfreliso03all(TAP'+type+'Tracks_pfRelIso03all)'])
+            self.VectorDouble.extend(['TAP'+type+'Tracks:pfcandsdzpv(TAP'+type+'Tracks_dzpv)'])
+            self.VectorDouble.extend(['TAP'+type+'Tracks:pfcandsdxypv(TAP'+type+'Tracks_dxypv)'])
+            self.VectorInt.extend(['TAP'+type+'Tracks:pfcandschg(TAP'+type+'Tracks_charge)'])
+            self.VectorInt.extend(['TAP'+type+'Tracks:pfcandsid(TAP'+type+'Tracks_id)'])
     if self.geninfo: # gen information on leptons
         self.VectorRecoCand.extend(['GenLeptons:Muon(GenMuons)','GenLeptons:Electron(GenElectrons)','GenLeptons:Tau(GenTaus)'])
         self.VectorBool.extend(['GenLeptons:TauHadronic(GenTaus_had)'])

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -434,7 +434,7 @@ def makeTreeFromMiniAOD(self,process):
         self.VectorDouble.extend(['IsolatedPionTracksVeto:pfcandspfreliso03chg(PFCands_pfRelIso03chg)'])
         self.VectorDouble.extend(['IsolatedPionTracksVeto:pfcandspfreliso03all(PFCands_pfRelIso03all)'])
         self.VectorDouble.extend(['IsolatedPionTracksVeto:pfcandsdzpv(PFCands_dzpv)'])
-        self.VectorDouble.extend(['IsolatedPionTracksVeto:pfcandsdzpv(PFCands_dxypv)'])
+        self.VectorDouble.extend(['IsolatedPionTracksVeto:pfcandsdxypv(PFCands_dxypv)'])
         self.VectorDouble.extend(['IsolatedPionTracksVeto:pfcandsmT(PFCands_mT)'])
         self.VectorInt.extend(['IsolatedPionTracksVeto:pfcandschg(PFCands_charge)'])
         self.VectorInt.extend(['IsolatedPionTracksVeto:pfcandsid(PFCands_id)'])

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -53,6 +53,7 @@ class maker:
         
         # other options off by default
         self.getParamDefault("debugtracks", False)
+        self.getParamDefault("debugtap", False)
         self.getParamDefault("debugsubjets", False)
         self.getParamDefault("applybaseline", False)
         self.getParamDefault("saveMinimalGenParticles", True)
@@ -143,6 +144,7 @@ class maker:
         print " storing PDF weights: "+str(self.doPDFs)
         print " "
         print " storing track debugging variables: "+str(self.debugtracks)
+        print " storeing TAP collection debugging variables: "+str(self.debugtap)
         print " storing subjet debugging variables: "+str(self.debugsubjets)
         print " Applying baseline selection filter: "+str(self.applybaseline)
         print " Storing a minimal set of GenParticles: "+str(self.saveMinimalGenParticles)

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -144,7 +144,7 @@ class maker:
         print " storing PDF weights: "+str(self.doPDFs)
         print " "
         print " storing track debugging variables: "+str(self.debugtracks)
-        print " storeing TAP collection debugging variables: "+str(self.debugtap)
+        print " storing TAP collection debugging variables: "+str(self.debugtap)
         print " storing subjet debugging variables: "+str(self.debugsubjets)
         print " Applying baseline selection filter: "+str(self.applybaseline)
         print " Storing a minimal set of GenParticles: "+str(self.saveMinimalGenParticles)


### PR DESCRIPTION
Add a new option to save extra information for the TAPElectronTracks, TAPMuonTracks, and TAPPionTracks. Also fix a problem with the dxy collection of the PFCands when using the debugtracks option.