### PR TITLE
[Run2_2017] Add option for a new output folder structure

### DIFF
--- a/Production/test/condorSub/jobSubmitterTM.py
+++ b/Production/test/condorSub/jobSubmitterTM.py
@@ -15,6 +15,7 @@ class jobSubmitterTM(jobSubmitter):
         parser.add_option("-A", "--args", dest="args", default="", help="additional common args to use for all jobs (default = %default)")
         parser.add_option("-v", "--verbose", dest="verbose", default=False, action="store_true", help="enable verbose output (default = %default)")
         parser.add_option("-x", "--redir", dest="redir", default="", help="input file redirector (default = %default)")
+        parser.add_option("-f", "--use-folders", dest="useFolders", default=False, action="store_true", help="store the output in folders based on era and dataset (default = %default)")
         
     def checkExtraOptions(self,options,parser):
         super(jobSubmitterTM,self).checkExtraOptions(options,parser)
@@ -30,7 +31,7 @@ class jobSubmitterTM(jobSubmitter):
         job.patterns.update([
             ("JOBNAME",job.name+"_$(Process)_$(Cluster)"),
             ("EXTRAINPUTS","input/args_"+job.name+"_$(Process).txt"),
-            ("EXTRAARGS","-j "+job.name+" -p $(Process) -o "+self.output+(" -x "+self.redir if len(self.redir)>0 else "")),
+            ("EXTRAARGS","-j "+job.name+" -p $(Process) -o "+self.output+(" -x "+self.redir if len(self.redir)>0 else "")+(" -f " if self.useFolders else "")),
         ])
         if "cmslpc" in os.uname()[1]:
             job.appends.append(

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -5,10 +5,13 @@ export PROCESS=""
 export OUTDIR=""
 export REDIR=""
 export OPTIND=1
+export USE_FOLDERS="false"
 while [[ $OPTIND -lt $# ]]; do
 	# getopts in silent mode, don't exit on errors
-	getopts ":j:p:o:x:" opt || status=$?
+	getopts ":fj:p:o:x:" opt || status=$?
 	case "$opt" in
+		f) export USE_FOLDERS="true"
+		;;
 		j) export JOBNAME=$OPTARG
 		;;
 		p) export PROCESS=$OPTARG
@@ -67,6 +70,9 @@ if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"ro
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do
+	if [[ "${USE_FOLDERS}" == "true" ]]; then
+		FILE=`structuredOutput ${FILE}`
+	fi
 	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE}"
 	stageOut ${GFLAG} -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
 	XRDEXIT=$?

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -65,12 +65,13 @@ export GFLAG=""
 if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
 	export CMDSTR="gfal-copy"
 	export GFLAG="-g"
-    export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
+	export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
 	export OUTDIR=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do
 	if [[ "${USE_FOLDERS}" == "true" ]]; then
+		echo "Changing to folder structure consisting of <era>/<sample>/<filename>.root"
 		FILE=`structuredOutput ${FILE}`
 	fi
 	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE}"

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -6,7 +6,7 @@ export OUTDIR=""
 export REDIR=""
 export OPTIND=1
 export USE_FOLDERS="false"
-while [[ $OPTIND -lt $# ]]; do
+while [[ $OPTIND -le $# ]]; do
 	# getopts in silent mode, don't exit on errors
 	getopts ":fj:p:o:x:" opt || status=$?
 	case "$opt" in
@@ -27,10 +27,11 @@ while [[ $OPTIND -lt $# ]]; do
 done
 
 echo "parameter set:"
-echo "OUTDIR:     $OUTDIR"
-echo "JOBNAME:    $JOBNAME"
-echo "PROCESS:    $PROCESS"
-echo "REDIR:      $REDIR"
+echo "OUTDIR:      $OUTDIR"
+echo "JOBNAME:     $JOBNAME"
+echo "PROCESS:     $PROCESS"
+echo "REDIR:       $REDIR"
+echo "USE_FOLDERS: $USE_FOLDERS"
 echo ""
 
 # link files from CMSSW dir

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+# helper function to structure the ouput into folders
+structuredOutput() {
+	RES=""
+	TMP=${1/.//}
+	IFS='_' read -r -a array <<< "$TMP"
+	cut=$(expr ${#array[@]} - 2)
+	for index in "${!array[@]}"; do
+		if [[ $index -lt $cut ]]; then
+			if [[ $index -eq 0 ]]; then
+				RES=${RES}${array[index]}
+			else
+				RES=${RES}"_"${array[index]}
+			fi
+		elif [[ $index -eq $cut ]]; then
+			RES=${RES}"/"${array[index]}
+		else
+			RES=${RES}"_"${array[index]}
+		fi
+	done
+	echo ${RES}
+}
+
 export JOBNAME=""
 export PROCESS=""
 export OUTDIR=""

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -71,12 +71,15 @@ if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"ro
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do
+	FILE_DST=${FILE}
 	if [[ "${USE_FOLDERS}" == "true" ]]; then
 		echo "Changing to folder structure consisting of <era>/<sample>/<filename>.root"
-		FILE=`structuredOutput ${FILE}`
+		echo -e "\tPrior to change: ${FILE_DST}"
+		FILE_DST=`structuredOutput ${FILE_DST}`
+		echo -e "\t   After change: ${FILE_DST}"
 	fi
-	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE}"
-	stageOut ${GFLAG} -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE}
+	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE_DST}"
+	stageOut ${GFLAG} -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE_DST}
 	XRDEXIT=$?
 	if [[ $XRDEXIT -ne 0 ]]; then
 		rm *.root

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Python:
 * `-A, --args [list]`: additional common args to use for all jobs (passed to [runMakeTreeFromMiniAOD_cfg.py](./Production/test/runMakeTreeFromMiniAOD_cfg.py))
 * `-v, --verbose`: enable verbose output (default = False)
 * `-x, --redir`: input file redirector
+* `-f, --use-folders`: store the output in folders based on era and dataset (default = False)
 
 Shell (in [step2.sh](./Production/test/condorSub/step2.sh)):
 * `-o [dir]`: output directory


### PR DESCRIPTION
This PR adds the option to store the output in a folder structure using the pattern \<output_dir>/\<era>/\<dataset>/\<filename>.root, rather than storing all of the files in the single <output_dir> directory. This change had been tested. This PR depends on https://github.com/kpedro88/CondorProduction/pull/7.