### PR TITLE
use deepAK8 v2 by default

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -135,6 +135,7 @@ if [[ "$CMSSWVER" == "CMSSW_10_2_"* ]]; then
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:BoostedDoubleSVTaggerV4-WithWeightFiles-v1_from-CMSSW_10_2_7
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:storeJERFactorIndex10220
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:AddJetAxis1_1027
+	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:DeepAK8v2_10221
 fi
 
 # outside repositories


### PR DESCRIPTION
The DeepAK8 v2 training is selected by patching CMSSW, to ensure it is propagated everywhere.

The contents of the patch are: https://github.com/TreeMaker/cmssw/commit/788635bd903077b62b3899c69639645eddc97a54

based on: https://twiki.cern.ch/twiki/bin/viewauth/CMS/DeepAKXTagging#Additional_instructions_to_run_D