### PR TITLE
[Run2_2017] Modify the ElectronID code

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -447,8 +447,8 @@ def makeTreeFromMiniAOD(self,process):
     process.LeptonsNew = leptonproducer.clone(
         elecIsoValue       = cms.double(0.1), # only has an effect when used with miniIsolation
         UseMiniIsolation   = cms.bool(True),
-        METTag             = METTag  ,
-        rhoCollection      = cms.InputTag("fixedGridRhoFastjetCentralNeutral")  
+        METTag             = METTag,
+        rhoCollection      = cms.InputTag("fixedGridRhoFastjetAll")
     )
     self.VectorRecoCand.extend(['LeptonsNew:IdMuon(Muons)','LeptonsNew:IdElectron(Electrons)'])
     self.VectorInt.extend(['LeptonsNew:IdMuonCharge(Muons_charge)','LeptonsNew:IdElectronCharge(Electrons_charge)'])

--- a/Utils/python/leptonproducer_cfi.py
+++ b/Utils/python/leptonproducer_cfi.py
@@ -55,5 +55,6 @@ leptonproducer = cms.EDProducer('LeptonProducer',
     tightMuTrackerLayersWithMeasurementMin = cms.int32(5),
     UseMiniIsolation                       = cms.bool(False),
     METTag                                 = cms.InputTag('slimmedMETs'), 
-    rhoCollection                          = cms.InputTag("fixedGridRhoFastjetAll")
+    rhoCollection                          = cms.InputTag("fixedGridRhoFastjetAll"),
+    debug                                  = cms.bool(False),
 )


### PR DESCRIPTION
This PR makes several modifications.

1. Modify the dEta definition used in the electron ID.
2. Switch the energy used in the H over E definition from that of the electron to that of the super cluster.
3. Modify the rho definition used. 
4. Add some debugging information.