### PR TITLE
[Run2_2017] Add a new workflow for ServiceX

### DIFF
--- a/.github/ServiceX/Dockerfile
+++ b/.github/ServiceX/Dockerfile
@@ -1,0 +1,39 @@
+# Make the base image configurable:
+ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-07-fc019a29
+
+# Set up the CMSSW base:
+FROM ${BASEIMAGE}
+
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VCS_URL
+ARG VERSION
+LABEL   org.label-schema.build-date=$BUILD_DATE \
+        org.label-schema.name="TreeMaker Docker image for ServiceX" \
+        org.label-schema.description="Provide completely offline-runnable CMSSW images with the TreeMaker and ServiceX dependencies pre-installed." \
+        org.label-schema.url="https://github.com/TreeMaker/TreeMaker" \
+        org.label-schema.vcs-ref=$VCS_REF \
+        org.label-schema.vcs-url=$VCS_URL \
+        org.label-schema.vendor="FNAL" \
+        org.label-schema.version=$VERSION \
+        org.label-schema.schema-version="1.0"
+
+USER    cmsusr
+WORKDIR /home/cmsusr
+
+ARG CMSSW_VERSION=CMSSW_10_2_21
+ARG CURRENT_USER
+ARG CURRENT_BRANCH
+ARG DOWNLOAD_URL
+ARG FILE_NAME
+
+COPY .github/ServiceX/scripts/setup.sh ./setup_servicex.sh
+COPY cmssw_src.tar.gz ./cmssw_src.tar.gz
+
+RUN sudo chown cmsusr setup_servicex.sh && \
+    sudo chmod +x setup_servicex.sh && \
+    ./setup_servicex.sh -c $CMSSW_VERSION -f $FILE_NAME -t ${HOME}/cmssw_src.tar.gz -u $DOWNLOAD_URL && \
+    rm ${HOME}/setup_servicex.sh && \
+    rm ${HOME}/cmssw_src.tar.gz
+
+ENTRYPOINT ["/bin/zsh"]

--- a/.github/ServiceX/Dockerfile
+++ b/.github/ServiceX/Dockerfile
@@ -1,5 +1,5 @@
 # Make the base image configurable:
-ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-07-fc019a29
+ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-22-2c2fe7c3
 
 # Set up the CMSSW base:
 FROM ${BASEIMAGE}

--- a/.github/ServiceX/scripts/setup.sh
+++ b/.github/ServiceX/scripts/setup.sh
@@ -4,6 +4,7 @@ CMSSWVER=CMSSW_10_2_21
 DIR="${HOME}"
 OFILE="testfile.root"
 OPATH="TreeMaker/Production/test/"
+TARBALL=""
 URL=""
 
 usage(){
@@ -15,6 +16,7 @@ usage(){
     echo "-d [dir]            project installation area for the CMSSW directory (default = ${DIR})"
     echo "-f [filename]       the output filename for the downloaded file (default = ${OFILE})"
     echo "-p [path]           the output path for the downloaded file (default = ${OPATH})"
+    echo "-t [tarball]        the name and path to the tarball containing the \$CMSSW_BASE/src files (default = ${TARBALL})"
     echo "-u [url]            a url to download (default = ${URL})"
     echo "-h                  display this message and exit"
 
@@ -22,7 +24,7 @@ usage(){
 }
 
 # process options
-while getopts "c:d:f:p:u:h" opt; do
+while getopts "c:d:f:p:t:u:h" opt; do
     case "$opt" in
     c) CMSSWVER=$OPTARG
     ;;
@@ -32,6 +34,8 @@ while getopts "c:d:f:p:u:h" opt; do
     ;;
     p) OPATH=$OPTARG
     ;;
+    t) TARBALL=$OPTARG
+    ;;
     u) URL=$OPTARG
     ;;
     h) usage 0
@@ -39,17 +43,36 @@ while getopts "c:d:f:p:u:h" opt; do
     esac
 done
 
-# Add these lines to the .bashrc file
-echo -e "\n \
-# Turn this on so that stdout isn't buffered - otherwise logs in kubectl don't\n \
-#   show up until much later!\n \
-export PYTHONUNBUFFERED=1\n \
-export X509_USER_PROXY=/etc/grid-security/x509up\n" >> ${HOME}/.bashrc
+# Add these lines to the .bashrc and .zshrc files
+lines="\n\
+# Needed to access FNAL EOS\n\
+export XrdSecGSISRVNAMES=\"cmseos.fnal.gov\"\n\
+# Turn this on so that stdout isn't buffered - otherwise logs in kubectl don't\n\
+#   show up until much later!\n\
+export PYTHONUNBUFFERED=1\n\
+export X509_USER_PROXY=/etc/grid-security/x509up\n"
+echo -e ${lines} >> ${HOME}/.bashrc
+echo -e ${lines} >> ${HOME}/.zshrc
 
-# Initialize the CMSSW environment
-echo -e "Running 'cmsenv' ... "
-cd ${DIR}/${CMSSWVER}/src
+# Checkout and initialize the CMSSW environment
+/opt/cms/entrypoint.sh
+
+# Untar and build the software
+echo "Sourcing the cmsset ... "
+source /opt/cms/cmsset_default.sh
+pwd
+ls -alh ./
+cd ${CMSSWVER}/src/
+pwd
+ls -alh ./
+echo "Unpacking ${TARBALL} into ${PWD} ..."
+tar -xzf ${TARBALL}
+pwd
+ls -alh ./
+echo "Setting the CMSSW environment ..."
 eval `scramv1 runtime -sh`
+echo "Compiling the CMSSW software ..."
+scramv1 b -j 8
 
 # Install missing python packages
 echo -e "Installing python packages via 'pip' ... "
@@ -59,7 +82,7 @@ python -m pip install --user --no-cache-dir -r ${CMSSW_BASE}/src/TreeMaker/.gith
 if [[ -n "$URL" ]]; then
     DESTINATION="${CMSSW_BASE}/src/${OPATH}/${OFILE}"
     echo -e "Downloading a file ...\n\tFrom: ${URL}\n\tDestination: ${DESTINATION}"
-    wget ${URL} -O ${DESTINATION}
+    wget --progress=dot:giga ${URL} -O ${DESTINATION}
 fi
 
 # Return to the ${HOME} directory

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -95,11 +95,48 @@ jobs:
   # The build needs to run inside a container because it needs access to the CMSSW version of python,
   #   which is accessed after 'cmsenv', which relies on having access to /cvmfs/cms.cern.ch/.
   service-x-build:
+    name: Mirror, run GitLab CI, produce ServiceX Docker image
     runs-on: ubuntu-latest
     needs: [build]
     if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
     steps:
-    - name: Reset User on Push
+    - name: Redefine branch on pull_request
+      if: github.event_name == 'pull_request'
+      run: |
+        echo ::set-env name=current_branch::${{ github.head_ref }}
+    - name: Redefine branch on push
+      if: github.event_name == 'push'
+      run: |
+        echo ::set-env name=current_branch::$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')
+    - name: Reset user on push
+      if: github.event_name == 'push'
+      run: echo ::set-env name=current_user::$(echo ${{ github.repository }} | sed -E 's|/.*||')
+    - name: Look at key environment variables
+      run: echo -e "GITHUB_REF=${{ github.ref }}\nGITHUB_HEAD_REF=${{ github.head_ref }}\nGITHUB_BASE_REF=${{ github.base_ref }}\nGITHUB_ACTOR=${{ github.actor }}\nGITHUB_REPOSITORY=${{ github.repository }}\nGITHUB_SHA=${{ github.sha }}\nUSER=${{ env.current_user }}\nBANCH=${{ env.current_branch }}\nTIME=${{ steps.current-time.outputs.formattedTime }}"
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - uses: actions/checkout@v1
+    - name: Mirror + trigger CI
+      uses: aperloff/gitlab-mirror-and-ci-action@master
+      with:
+        args: "https://gitlab.cern.ch/treemaker/TreeMaker"
+      env:
+        GITLAB_HOSTNAME: "gitlab.cern.ch"
+        GITLAB_USERNAME: "aperloff"
+        GITLAB_PASSWORD: ${{ secrets.GITLAB_PASSWORD }} # Generate here: https://gitlab.com/profile/personal_access_tokens and add to GitHub secrets
+        GITLAB_PROJECT_ID: "90027"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret and add to GitHub secrets
+        CHECKOUT_BRANCH: ${{ env.current_branch }}
+        POLL_TIMEOUT: 60
+
+  service-x-build-cvmfs:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
+    steps:
+    - name: Reset user on push
       if: github.event_name == 'push'
       run: echo ::set-env name=current_user::$(echo ${{ github.repository }} | sed -E 's|/.*||')
     - name: Build a Service-X compatible Docker image
@@ -111,10 +148,10 @@ jobs:
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker --entrypoint "/bin/bash"
       run: docker run ${{ env.docker_options }} ${{ env.base_image }} -c "${{ env.script_dir }}/setup-root.sh && /run.sh -l -c \"${{ env.script_dir }}/setup.sh -c ${{ env.cmssw_ver }} -f ${{ env.file_name }} -u ${{ env.download_url }}\""
     - name: Commit the changes
-      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-servicex
+      run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-servicex-cvmfs
     - name: Log into registry
       if: env.current_user == 'TreeMaker'
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Publish the new docker image
       if: env.current_user == 'TreeMaker'
-      run: docker push treemaker/treemaker:${{ env.current_branch }}-servicex
+      run: docker push treemaker/treemaker:${{ env.current_branch }}-servicex-cvmfs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,104 @@
+# Stages ----------------------------------------------------------------------
+stages:
+    - tar
+    - build
+
+# Before Script ---------------------------------------------------------------
+before_script:
+    - export DATE=$(date +"%Y-%m-%d")
+
+# Job templates ---------------------------------------------------------------
+.job_template_tar:
+    stage: tar
+    variables:
+        CVMFS_MOUNTS: "none"
+    tags:
+        - docker-privileged
+    image: docker:latest
+    services:
+        - docker:dind
+    variables:
+        DOCKER_DRIVER: overlay2
+        NO_CACHE: "true"
+    script:
+        - echo --------- OUTER CONTAINER -------------
+        - pwd
+        - ls -alh ./
+        - ls -alh ../
+        - docker system df -v
+        - docker info
+        - echo --------- INNER CONTAINER -------------
+        - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:/home/cmsuser/workdir/ ${BASE_IMAGE} -- -i -c "cd ${CMSSW_VERSION}/src/ && tar -czf cmssw_src.tar.gz --exclude .git* ./* && mv cmssw_src.tar.gz ../../workdir/  && cd ../../workdir/ && pwd && ls -alh ./ && cd /home/cmsuser/"
+        - echo --------- OUTER CONTAINER -------------
+        - pwd
+        - ls -alh ./
+        - ls -alh ../
+        - docker system df -v
+    artifacts:
+        when: on_success
+        name: "$CI_JOB_NAME-$CI_JOB_STAGE-$CI_COMMIT_REF_NAME"
+        paths:
+            - ./cmssw_src.tar.gz
+        expire_in: 1 day
+
+.job_template_build:
+    stage: build
+    variables:
+        DOCKER_DRIVER: overlay2
+        NO_CACHE: "true"
+        CONTEXT_DIR: "./"
+        DOCKERFILE_DIR: ".github/ServiceX/"
+        IMAGE_NAME: treemaker
+    tags:
+        - docker-privileged-xl
+    image:
+        name: gitlab-registry.cern.ch/ci-tools/docker-image-builder
+        entrypoint: [""]
+    script:
+        # Build and push the image from the Dockerfile at the root of the project.
+        # To push to a specific docker tag, amend the --destination parameter, e.g. --destination $CI_REGISTRY_IMAGE:$CI_BUILD_REF_NAME
+        # See https://docs.gitlab.com/ee/ci/variables/predefined_variables.html#variables-reference for available variables
+        - echo "Building Docker image with TreeMaker and ServiceX dependencies on ${DATE}"
+        - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+        - echo ${CI_PROJECT_DIR}/${CONTEXT_DIR}/
+        - ls -alh ${CI_PROJECT_DIR}/${CONTEXT_DIR}/
+        - /kaniko/executor --context ${CI_PROJECT_DIR}/${CONTEXT_DIR} --dockerfile ${CI_PROJECT_DIR}/${DOCKERFILE_DIR}/Dockerfile --destination "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${BRANCH_NAME}-${SUFFIX}" --build-arg=BUILD_DATE="${DATE}" --build-arg=VERSION="${DATE}" --build-arg=VCS_URL="${CI_REPOSITORY_URL}" --build-arg=VCS_REF="${CI_COMMIT_SHORT_SHA}" --build-arg=BASEIMAGE="${BASE_IMAGE}" --build-arg=CURRENT_USER="${CURRENT_USER}" --build-arg=CURRENT_BRANCH="${CURRENT_BRANCH}" --build-arg=DOWNLOAD_URL="${DOWNLOAD_URL}" --build-arg=FILE_NAME="${FILE_NAME}" --build-arg=CMSSW_VERSION="${CMSSW_VERSION}"
+
+# Jobs/Includes ---------------------------------------------------------------
+tar_treemaker_Run2_2017-servicex:
+    extends: .job_template_tar
+    variables:
+        BASE_IMAGE: index.docker.io/treemaker/treemaker:Run2_2017-latest
+        CMSSW_VERSION: CMSSW_10_2_21
+
+build_treemaker_Run2_2017-servicex:
+    extends: .job_template_build
+    dependencies:
+        - tar_treemaker_Run2_2017-servicex
+    variables:
+        BRANCH_NAME: Run2_2017
+        SUFFIX: servicex
+        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-07-fc019a29
+        CURRENT_USER: treemaker
+        CURRENT_BRANCH: Run2_2017
+        DOWNLOAD_URL: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
+        FILE_NAME: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
+        CMSSW_VERSION: CMSSW_10_2_21
+
+build_treemaker_Run2_2017-servicex-dockerhub:
+    extends: .job_template_build
+    dependencies:
+        - tar_treemaker_Run2_2017-servicex
+    variables:
+        CI_REGISTRY: https://index.docker.io/v1/
+        CI_REGISTRY_USER: ${DOCKER_USERNAME}
+        CI_REGISTRY_PASSWORD: ${DOCKER_PASSWORD}
+        CI_REGISTRY_IMAGE:  index.docker.io/treemaker
+        BRANCH_NAME: Run2_2017
+        SUFFIX: servicex
+        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-07-fc019a29
+        CURRENT_USER: treemaker
+        CURRENT_BRANCH: Run2_2017
+        DOWNLOAD_URL: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
+        FILE_NAME: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
+        CMSSW_VERSION: CMSSW_10_2_21

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,7 +78,7 @@ build_treemaker_Run2_2017-servicex:
     variables:
         BRANCH_NAME: Run2_2017
         SUFFIX: servicex
-        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-07-fc019a29
+        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-22-2c2fe7c3
         CURRENT_USER: treemaker
         CURRENT_BRANCH: Run2_2017
         DOWNLOAD_URL: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
@@ -96,7 +96,7 @@ build_treemaker_Run2_2017-servicex-dockerhub:
         CI_REGISTRY_IMAGE:  index.docker.io/treemaker
         BRANCH_NAME: Run2_2017
         SUFFIX: servicex
-        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-07-fc019a29
+        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-22-2c2fe7c3
         CURRENT_USER: treemaker
         CURRENT_BRANCH: Run2_2017
         DOWNLOAD_URL: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The script [setup.sh](./setup.sh) has options to allow installing a different fo
 * `-c [version]`: which CMSSW version to use (default = CMSSW_10_2_21)
 * `-a [protocol]`: which protocol to use for `git clone` (default = ssh, alternative = https)
 * `-j [cores]`: run CMSSW compilation on # cores (default = 8)
+* `-n [name]`: name of the CMSSW directory if not CMSSW_X_Y_Z (default = CMSSW_10_2_21)
+* `-d [dir]`: project installation area for the CMSSW directory (default = ${PWD})
+* `-D`: print additional debug statements (default = false)
 * `-h`: display help message and exit
 
 Several predefined scenarios are available for ease of production.


### PR DESCRIPTION
Add new workflow for building images compatible with ServiceX. This workflow mirrors the repo to CERN GitLab and then triggers a CI job, which builds the images. The image built by this workflow distinguishes itself by having CMSSW installed inside the image, not needing CVMFS.