### PR TITLE
[Run2_2017] More gfal-copy support

### DIFF
--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -90,6 +90,9 @@ if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"ro
 	export GFLAG="-g"
 	export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
 	export OUTDIR=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
+elif [[ "${OUTDIR}" == *"gsiftp://"* ]]; then
+	export CMDSTR="gfal-copy"
+	export GFLAG="-g"
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do


### PR DESCRIPTION
Add the ability to transfer files using the gfal-copy protocol if a gsiftp endpoint is specified as the output path.