### PR TITLE
[Run2_2017] Add a missing gen particle status code

### DIFF
--- a/Utils/src/GenParticlesProducer.cc
+++ b/Utils/src/GenParticlesProducer.cc
@@ -67,7 +67,7 @@ debug(iConfig.getParameter<bool>("debug")),
 quark_status_codes{23,51,52,71,72,73,91},
 lepton_status_codes{1,2},
 top_status_codes{22,51,52,62},
-boson_status_codes{22,51,52}
+boson_status_codes{22,51,52,62}
 {
     const auto& cids = iConfig.getParameter<std::vector<int>>("childIds");
     typicalChildIds.insert(cids.begin(),cids.end());


### PR DESCRIPTION
Add the status code 62 for W bosons. It was found to be missing when running over the Autumn18.WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8 sample.

Without this change you see a lot of errors like:
```
%MSG-i TreeMaker:  GenParticlesProducer:genParticles 05-May-2020 07:44:08 CDT  Run: 1 Event: 194032715
WARNING The last particle in the chain (24) does not have a status that corresponds to its type (status=62)
%MSG
```