### PR TITLE
[Run2_2017] More ServiceX workflow improvements

### DIFF
--- a/.github/ServiceX/python/transformer.py
+++ b/.github/ServiceX/python/transformer.py
@@ -123,7 +123,7 @@ def callback(channel, method, properties, body):
 
 def transform_single_file(file_path, output_path, servicex=None):
     print("Transforming a single path: " + str(file_path) + " into " + output_path)
-    r = os.system('cd CMSSW_10_2_21/src/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16v3 dataset=file:' + str(file_path) + ' name=' + str(output_path) + ' run=True fork=False log=True')
+    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16 dataset=file:' + str(file_path) + ' name=' + str(output_path) + ' run=True fork=False log=True')
     reason_bad = None
     if r != 0:
         reason_bad = "Error return from transformer: " + str(r)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ before_script:
         - ls -alh ../
         - docker system df -v
         - docker info
+        - sleep 120
         - echo --------- INNER CONTAINER -------------
         - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:/home/cmsuser/workdir/ ${BASE_IMAGE} -- -i -c "cd ${CMSSW_VERSION}/src/ && tar -czf cmssw_src.tar.gz --exclude .git* ./* && mv cmssw_src.tar.gz ../../workdir/  && cd ../../workdir/ && pwd && ls -alh ./ && cd /home/cmsuser/"
         - echo --------- OUTER CONTAINER -------------


### PR DESCRIPTION
Add a sleep statement to give DockerHub time to update its registry before pulling the needed image, pushed during the GitHub Action build job, in the GitLab ServiceX job. Also slightly modify the key statement in transformer.py to fix some paths.