### PR TITLE
[Run2_2017] ServiceX log modifications

### DIFF
--- a/.github/ServiceX/python/transformer.py
+++ b/.github/ServiceX/python/transformer.py
@@ -123,7 +123,7 @@ def callback(channel, method, properties, body):
 
 def transform_single_file(file_path, output_path, servicex=None):
     print("Transforming a single path: " + str(file_path) + " into " + output_path)
-    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16 dataset=file:' + str(file_path) + ' name=' + str(output_path) + ' run=True fork=False log=True')
+    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16 dataset=file:' + str(file_path) + ' name=' + str(output_path) + ' run=True fork=False log=True 2> log.txt')
     reason_bad = None
     if r != 0:
         reason_bad = "Error return from transformer: " + str(r)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ before_script:
         - ls -alh ../
         - docker system df -v
         - docker info
-        - sleep 120
+        - sleep 300
         - echo --------- INNER CONTAINER -------------
         - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:/home/cmsuser/workdir/ ${BASE_IMAGE} -- -i -c "cd ${CMSSW_VERSION}/src/ && tar -czf cmssw_src.tar.gz --exclude .git* ./* && mv cmssw_src.tar.gz ../../workdir/  && cd ../../workdir/ && pwd && ls -alh ./ && cd /home/cmsuser/"
         - echo --------- OUTER CONTAINER -------------


### PR DESCRIPTION
Increase the sleep time on the GitHub to GitLab transition to wait for DockerHub to be ready to serve the new image. Also add a stderr logfile to the transformer.