### PR TITLE
[Run2_2017] Fix relative path in jobSubmitterTM.py

### DIFF
--- a/Production/test/condorSub/jobSubmitterTM.py
+++ b/Production/test/condorSub/jobSubmitterTM.py
@@ -63,7 +63,7 @@ class jobSubmitterTM(jobSubmitter):
             if data and self.json=="":
                 # get from scenario
                 # data directory is next to condor directory
-                self.json = "../"+scenario.jsonfile
+                self.json = scenario.jsonfile
             if data and self.json=="":
                 raise Exception, "data was specified, but no json file was found"
 


### PR DESCRIPTION
The previous attempt at introducing path independence missed the jobSubmitterTM.py file, which was expecting a relative path. This is now fixed.