### PR TITLE
[Run2_2017] Output file path formatting for ServiceX

### DIFF
--- a/.github/ServiceX/Dockerfile
+++ b/.github/ServiceX/Dockerfile
@@ -37,7 +37,8 @@ RUN sudo chown cmsusr setup_servicex.sh && \
     sudo chmod +x setup_servicex.sh && \
     ./setup_servicex.sh -c $CMSSW_VERSION -f $FILE_NAME -t ${HOME}/cmssw_src.tar.gz -u $DOWNLOAD_URL && \
     rm ${HOME}/setup_servicex.sh && \
-    rm ${HOME}/cmssw_src.tar.gz
+    rm ${HOME}/cmssw_src.tar.gz && \
+    rm ${HOME}/requirements.txt
 
 # This part can eventually be removed when the atlas references are removed from ServiceX
 RUN sudo mkdir /home/atlas/ && \

--- a/.github/ServiceX/python/transformer.py
+++ b/.github/ServiceX/python/transformer.py
@@ -73,7 +73,7 @@ def callback(channel, method, properties, body):
         try:
             # Do the transform
             root_file = _file_path.replace('/', ':')
-            output_path = os.environ['HOME'] + '/' + root_file.replace('file:','')
+            output_path = os.environ['HOME'] + '/' + root_file.replace('file:','').replace(".root","_RA2AnalysisTree.root")
             transform_single_file(_file_path, output_path, servicex)
 
             tock = time.time()
@@ -123,7 +123,7 @@ def callback(channel, method, properties, body):
 
 def transform_single_file(file_path, output_path, servicex=None):
     print("Transforming a single path: " + str(file_path) + " into " + output_path)
-    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16 dataset=file:' + str(file_path) + ' name=' + str(output_path) + ' run=True fork=False log=True 2> log.txt')
+    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16 dataset=file:' + str(file_path) + ' name=' + str(output_path).replace("_RA2AnalysisTree.root","") + ' run=True fork=False log=True 2> log.txt && pwd && ls -alh ./ && ls -alh /home/cmsusr/ && ls -alh /home/atlas/')
     reason_bad = None
     if r != 0:
         reason_bad = "Error return from transformer: " + str(r)


### PR DESCRIPTION
1. Remove the `requirements.txt` file from the final image. It just doesn't need to be there.
2. Fix the output file naming in `transformer.py`, which is necessary to make the whole thing work. `unitTest.py` automatically appends the suffix, `_RA2AnalysisTree.root` to the `name` parameter, which is why there is so much python manipulation. This may be unnecessary in the future, but is needed while using `unitTest.py`.