### PR TITLE
[Run2_2017] Change how the current running site is detected

### DIFF
--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -86,7 +86,7 @@ fi
 echo "CMSSITE currently set to: ${CMSSITE}"
 if [[ -z "$CMSSITE" ]] || [[ "$CMSSITE" == "" ]]; then
 	echo -e "\tGetting CMSSITE from the job ClassAd"
-	CMSSITE=$(getFromClassAd JOB_GLIDEIN_CMSSite)
+	CMSSITE=$(getFromClassAd MachineAttrGLIDEIN_CMSSite0)
 	echo -e "\tCMSSITE is now set to: ${CMSSITE}"
 fi
 export CMDSTR="xrdcp"

--- a/Production/test/condorSub/step2Neff.sh
+++ b/Production/test/condorSub/step2Neff.sh
@@ -52,13 +52,22 @@ if [[ $CMSEXIT -ne 0 ]]; then
 fi
 
 # copy output to eos
+echo "CMSSITE currently set to: ${CMSSITE}"
+if [[ -z "$CMSSITE" ]] || [[ "$CMSSITE" == "" ]]; then
+    echo -e "\tGetting CMSSITE from the job ClassAd"
+    CMSSITE=$(getFromClassAd MachineAttrGLIDEIN_CMSSite0)
+    echo -e "\tCMSSITE is now set to: ${CMSSITE}"
+fi
 export CMDSTR="xrdcp"
 export GFLAG=""
-if [[ ( "$CMSSITE" == "T1_US_FNAL" && "$USER" == "cmsgli" && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
+if [[ ( "$CMSSITE" == *"T1_US_FNAL"* && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
     export CMDSTR="gfal-copy"
-	export GFLAG="-g"
+    export GFLAG="-g"
     export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
     export OUTDIR=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
+elif [[ "${OUTDIR}" == *"gsiftp://"* ]]; then
+    export CMDSTR="gfal-copy"
+    export GFLAG="-g"
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do

--- a/Production/test/lnbatch.sh
+++ b/Production/test/lnbatch.sh
@@ -26,7 +26,7 @@ fi
 mkdir -p $TODIR
 lndir -silent -ignorelinks $FROMDIR $TODIR	
 
-if [[ "${TODIR}/CACHEDIR.TAG" ]]; then
+if [[ -L "${TODIR}/CACHEDIR.TAG" ]]; then
 	unlink ${TODIR}/CACHEDIR.TAG
 	cp ${TODIR}/$FROMDIR/CACHEDIR.TAG $TODIR
 fi

--- a/Production/test/lnbatch.sh
+++ b/Production/test/lnbatch.sh
@@ -25,3 +25,8 @@ fi
 
 mkdir -p $TODIR
 lndir -silent -ignorelinks $FROMDIR $TODIR	
+
+if [[ "${TODIR}/CACHEDIR.TAG" ]]; then
+	unlink ${TODIR}/CACHEDIR.TAG
+	cp ${TODIR}/$FROMDIR/CACHEDIR.TAG $TODIR
+fi


### PR DESCRIPTION
Change the ClassAd used to detect the site where the job is currently running. This change relies upon https://github.com/kpedro88/CondorProduction/pull/11. The change has been verified and can be seen working for the attached job logs in [1], which correspond to the job configuration file in [2].

[1]
[Fall17.TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8_144_1574.stdout.txt](https://github.com/TreeMaker/TreeMaker/files/4705102/Fall17.TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8_144_1574.stdout.txt)
[Fall17.TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8_155_1574.stdout.txt](https://github.com/TreeMaker/TreeMaker/files/4705103/Fall17.TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8_155_1574.stdout.txt)
[Fall17.TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8_165_1574.stdout.txt](https://github.com/TreeMaker/TreeMaker/files/4705104/Fall17.TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8_165_1574.stdout.txt)

[2]
[jobExecCondor_Fall17.TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8.jdl.txt](https://github.com/TreeMaker/TreeMaker/files/4705106/jobExecCondor_Fall17.TTJets_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8.jdl.txt)