### PR TITLE
[Run2_2017] ServiceX transformer fix and manual workflow trigger

### DIFF
--- a/.github/ServiceX/python/transformer.py
+++ b/.github/ServiceX/python/transformer.py
@@ -123,7 +123,7 @@ def callback(channel, method, properties, body):
 
 def transform_single_file(file_path, output_path, servicex=None):
     print("Transforming a single path: " + str(file_path) + " into " + output_path)
-    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16 dataset=file:' + str(file_path) + ' name=' + str(output_path).replace("_RA2AnalysisTree.root","") + ' run=True fork=False log=True 2> log.txt && pwd && ls -alh ./ && ls -alh /home/cmsusr/ && ls -alh /home/atlas/')
+    r = os.system('cd CMSSW_10_2_21/src/TreeMaker/Production/test/ && source /opt/cms/cmsset_default.sh && eval `scramv1 runtime -sh` && python ${CMSSW_BASE}/src/TreeMaker/Production/test/unitTest.py test=0 scenario=Summer16 dataset=' + str(file_path) + ' name=' + str(output_path).replace("_RA2AnalysisTree.root","") + ' run=True fork=False log=True 2> log.txt && pwd && ls -alh ./ && ls -alh /home/cmsusr/ && ls -alh /home/atlas/')
     reason_bad = None
     if r != 0:
         reason_bad = "Error return from transformer: " + str(r)

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,6 +1,7 @@
 name: Docker Image CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ Run2_2017 ]
   pull_request:


### PR DESCRIPTION
This PR has two changes:
1. Fix a problem with a redundant `file:` prefix in the filename passed to `unittest.py` by the ServiceX transformer.
2. Allow the GitHub workflows to be manually triggered. Should behave as if the workflow was triggered by a push.