### PR TITLE
[Run2_2017] Update CERNBox URL

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ build_treemaker_Run2_2017-servicex:
         BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-22-2c2fe7c3
         CURRENT_USER: treemaker
         CURRENT_BRANCH: Run2_2017
-        DOWNLOAD_URL: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
+        DOWNLOAD_URL: https://cernbox.cern.ch/index.php/s/DsfTPyDEgCjTmBQ/download
         FILE_NAME: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
         CMSSW_VERSION: CMSSW_10_2_21
 
@@ -100,6 +100,6 @@ build_treemaker_Run2_2017-servicex-dockerhub:
         BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-22-2c2fe7c3
         CURRENT_USER: treemaker
         CURRENT_BRANCH: Run2_2017
-        DOWNLOAD_URL: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
+        DOWNLOAD_URL: https://cernbox.cern.ch/index.php/s/DsfTPyDEgCjTmBQ/download
         FILE_NAME: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
         CMSSW_VERSION: CMSSW_10_2_21


### PR DESCRIPTION
Update the CERNBox download url for the file being used in the ServiceX tests. The previous one seems to have expired.