### PR TITLE
[Run2_2017] ServiceX Proxy Exporter

### DIFF
--- a/.github/ServiceX/scripts/proxy-exporter.sh
+++ b/.github/ServiceX/scripts/proxy-exporter.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-#sudo mkdir -p /etc/grid-security
-#sudo chown cmsuser /etc/grid-security
+sudo mkdir -p /etc/grid-security
+sudo chown cmsusr /etc/grid-security
 
 
 while true; do
-    #sudo cp /etc/grid-security-ro/x509up /etc/grid-security
-    #sudo chown cmsuser /etc/grid-security/x509up
-    #chmod 600 /etc/grid-security/x509up
+    sudo cp /etc/grid-security-ro/x509up /etc/grid-security
+    sudo chown cmsusr /etc/grid-security/x509up
+    chmod 600 /etc/grid-security/x509up
 
     # Refresh every hour
     sleep 3600


### PR DESCRIPTION
Implement the proxy exporter needed by ServiceX. Previously I had a concern about the sudo commands in this script, but it seems like everything is in place in the self contained Docker images used by ServiceX. The `cmsusr` account already has sudo privileges. For the CVMFS based images we might need to implement sudo privileges for the `cmsuser` account, but that is a future problem.