### PR TITLE
[Run2_2017] Updates for the Docker images

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -22,13 +22,11 @@ USER    cmsusr
 WORKDIR /home/cmsusr
 
 ARG CMSSW_VERSION=CMSSW_10_2_21
-ARG CURRENT_USER
-ARG CURRENT_BRANCH
 
 COPY .docker/setupStandalone.sh ./setupStandalone.sh
-COPY cmssw_src.tar.gz ./cmssw_src.tar.gz
+COPY ${CMSSW_VERSION}.tar.gz ./${CMSSW_VERSION}.tar.gz
 
-RUN ./setupStandalone.sh -c $CMSSW_VERSION -t ${HOME}/cmssw_src.tar.gz && \
+RUN ./setupStandalone.sh -c $CMSSW_VERSION -t ${HOME}/${CMSSW_VERSION}.tar.gz && \
     rm ${HOME}/setupStandalone.sh && \
     rm ${HOME}/cmssw_src.tar.gz
 

--- a/.docker/setupStandalone.sh
+++ b/.docker/setupStandalone.sh
@@ -39,13 +39,15 @@ export XrdSecGSISRVNAMES=\"cmseos.fnal.gov\"\n"
 echo -e ${lines} >> ${HOME}/.bashrc
 echo -e ${lines} >> ${HOME}/.zshrc
 
-# Checkout a CMSSW release and source the cmsset if in a standalone CMSSW image
-if [[ -f /opt/cms/entrypoint.sh ]]; then
-	/opt/cms/entrypoint.sh
-fi
+# Source the cmsset if in a standalone CMSSW image
 if [[ -f /opt/cms/cmsset_default.sh ]]; then
 	echo "Sourcing the cmsset ... "
 	source /opt/cms/cmsset_default.sh
+fi
+
+# Setup a symlink if in a standalone CMSSW image
+if [[ -f /opt/cms/cmsset_default.sh ]]; then
+	sudo ln -s /opt/cms /cvmfs/cms.cern.ch
 fi
 
 # Move to the project installation area

--- a/.docker/setupStandalone.sh
+++ b/.docker/setupStandalone.sh
@@ -48,24 +48,33 @@ if [[ -f /opt/cms/cmsset_default.sh ]]; then
 	source /opt/cms/cmsset_default.sh
 fi
 
-# Move to the CMSSW directory and initialize the CMSSW environment
+# Move to the project installation area
 pwd
 ls -alh ./
-cd ${DIR}/${CMSSWVER}/src/
+cd ${DIR}
 pwd
 ls -alh ./
-echo "Setting the CMSSW environment ..."
-eval `scramv1 runtime -sh`
 
-# Untar and build the software, if provided
+# Untar the the CMSSW release, if provided, and change directories to the release area
 if [[ -n "$TARBALL" ]]; then
 	echo "Unpacking ${TARBALL} into ${PWD} ..."
 	tar -xzf ${TARBALL}
 	pwd
 	ls -alh ./
-	echo "Compiling the software ..."
-	scramv1 b -j 8
+	cd ${CMSSWVER/src/}
+	scram b ProjectRename
+	pwd
+	ls -alh ./
+else
+	cd ${CMSSWVER}/src/
+	pwd
+	ls -alh ./
 fi
+
+# Initialize the CMSSW environment
+echo "Setting the CMSSW environment ..."
+eval `scramv1 runtime -sh`
+echo "The CMSSW_BASE is ${CMSSW_BASE}"
 
 # Return to the ${HOME} directory
 echo -e "Returning to ${HOME} ... "

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Run the container and perform an integration test
       if: github.event_name == 'pull_request'
       env:
-        download_url: https://cernbox.cern.ch/index.php/s/5DRVyX4Z9EertGa/download
+        download_url: https://cernbox.cern.ch/index.php/s/DsfTPyDEgCjTmBQ/download
         file_name: eos.opendata.cms.MonteCarlo2016.RunIISummer16MiniAODv2.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.MINIAODSIM.PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1.70000.0048131D-3CB3-E611-813A-001E67DFFB31_100evt.root
         era: Summer16
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ before_script:
         - docker info
         - sleep 300
         - echo --------- INNER CONTAINER -------------
-        - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:/home/cmsuser/workdir/ ${BASE_IMAGE} -- -i -c "cd ${CMSSW_VERSION}/src/ && tar -czf cmssw_src.tar.gz --exclude .git* ./* && mv cmssw_src.tar.gz ../../workdir/  && cd ../../workdir/ && pwd && ls -alh ./ && cd /home/cmsuser/"
+        - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:/home/cmsuser/workdir/ ${BASE_IMAGE} -- -i -c "tar -czf ${CMSSW_VERSION}.tar.gz --exclude .git* ${CMSSW_VERSION} && mv ${CMSSW_VERSION}.tar.gz ../../workdir/  && cd ../../workdir/ && pwd && ls -alh ./ && cd /home/cmsuser/"
         - echo --------- OUTER CONTAINER -------------
         - pwd
         - ls -alh ./
@@ -39,7 +39,7 @@ before_script:
         when: on_success
         name: "$CI_JOB_NAME-$CI_JOB_STAGE-$CI_COMMIT_REF_NAME"
         paths:
-            - ./cmssw_src.tar.gz
+            - ./${CMSSW_VERSION}.tar.gz
         expire_in: 1 day
 
 .job_template_build:
@@ -63,7 +63,7 @@ before_script:
         - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
         - echo ${CI_PROJECT_DIR}/${CONTEXT_DIR}/
         - ls -alh ${CI_PROJECT_DIR}/${CONTEXT_DIR}/
-        - /kaniko/executor --context ${CI_PROJECT_DIR}/${CONTEXT_DIR} --dockerfile ${CI_PROJECT_DIR}/${DOCKERFILE_DIR}/Dockerfile --destination "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${BRANCH_NAME}-${SUFFIX}" --build-arg=BUILD_DATE="${DATE}" --build-arg=VERSION="${DATE}" --build-arg=VCS_URL="${CI_REPOSITORY_URL}" --build-arg=VCS_REF="${CI_COMMIT_SHORT_SHA}" --build-arg=BASEIMAGE="${BASE_IMAGE}" --build-arg=CURRENT_USER="${CURRENT_USER}" --build-arg=CURRENT_BRANCH="${CURRENT_BRANCH}" --build-arg=CMSSW_VERSION="${CMSSW_VERSION}"
+        - /kaniko/executor --context ${CI_PROJECT_DIR}/${CONTEXT_DIR} --dockerfile ${CI_PROJECT_DIR}/${DOCKERFILE_DIR}/Dockerfile --destination "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${BRANCH_NAME}-${SUFFIX}" --build-arg=BUILD_DATE="${DATE}" --build-arg=VERSION="${DATE}" --build-arg=VCS_URL="${CI_REPOSITORY_URL}" --build-arg=VCS_REF="${CI_COMMIT_SHORT_SHA}" --build-arg=BASEIMAGE="${BASE_IMAGE}" --build-arg=CMSSW_VERSION="${CMSSW_VERSION}"
 
 # Jobs/Includes ---------------------------------------------------------------
 tar_treemaker_Run2_2017:
@@ -80,8 +80,6 @@ build_treemaker_Run2_2017-standalone:
         BRANCH_NAME: Run2_2017
         SUFFIX: standalone
         BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-22-2c2fe7c3
-        CURRENT_USER: treemaker
-        CURRENT_BRANCH: Run2_2017
         CMSSW_VERSION: CMSSW_10_2_21
 
 build_treemaker_Run2_2017-standalone-dockerhub:
@@ -96,6 +94,4 @@ build_treemaker_Run2_2017-standalone-dockerhub:
         BRANCH_NAME: Run2_2017
         SUFFIX: standalone
         BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_2_21-2020-04-22-2c2fe7c3
-        CURRENT_USER: treemaker
-        CURRENT_BRANCH: Run2_2017
         CMSSW_VERSION: CMSSW_10_2_21


### PR DESCRIPTION
1. Update the CERNBox URL for the integration test file
2. Cleanup some unused Docker arguments
3. Change the way the TreeMaker software is added to the standalone image. Previously we had to recompile the software. Now we should be able to simply do a `scram b ProjectRename`.