### PR TITLE
[Run2_2017] Store the index of the vertex associated to each track

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1100,6 +1100,7 @@ def makeTreeFromMiniAOD(self,process):
         from TreeMaker.Utils.candidateTrackMaker_cfi import candidateTrackFilter
         process.trackFilter = candidateTrackFilter.clone(
             vertexInputTag    = cms.InputTag("goodVertices"),
+            storedVerticesTag = cms.InputTag("primaryVertices","vtxref"),
             pfCandidatesTag   = cms.InputTag("packedPFCandidates"),
             lostTracksTag     = cms.InputTag("lostTracks"),
             lostEleTracksTag  = cms.InputTag("lostTracks","eleTracks"),
@@ -1136,6 +1137,7 @@ def makeTreeFromMiniAOD(self,process):
             'trackFilter:pfcandsfirsthit(Tracks_firstHit)',
             'trackFilter:pfcandsfrompv(Tracks_fromPV0)',
             'trackFilter:pfcandspvassociationquality(Tracks_pvAssociationQuality)',
+            'trackFilter:pfcandsvtxidx(Tracks_vertexIdx)',
         ])
         self.VectorVectorInt.extend([
             'trackFilter:trkshitpattern(Tracks_hitPattern)',

--- a/Utils/src/CandidateTrackFilter.cc
+++ b/Utils/src/CandidateTrackFilter.cc
@@ -66,9 +66,12 @@ public:
 		pfcands_frompv               = std::make_unique<vector<int>>();
 		pfcands_pvassociationquality = std::make_unique<vector<int>>();
 		pfcands_dzassociatedpv       = std::make_unique<vector<double>>();
+		pfcands_vtxidx               = std::make_unique<vector<int>>();
 	}
 
-	void fill(const reco::Vertex & primaryVertex, const pat::PackedCandidate & pfCand, const reco::Track & track, const reco::TransientTrack & transientTrack, bool trackMatch) {
+	void fill(const reco::Vertex & primaryVertex, const pat::PackedCandidate & pfCand,
+	          const reco::Track & track, const reco::TransientTrack & transientTrack,
+	          bool trackMatch, int vtxIdx) {
 		// basic information from the reco::Track
 		//   Reference: https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackReco/interface/Track.h
 		trks->push_back(track.momentum());
@@ -123,7 +126,8 @@ public:
 		pfcands_firsthit->push_back(pfCand.firstHit());
 		pfcands_frompv->push_back(pfCand.fromPV()); //fromPV() returns a number between 3 and 0 to define how tight the association with the PV is
 		pfcands_pvassociationquality->push_back(pfCand.pvAssociationQuality());
-		pfcands_dzassociatedpv->push_back(pfCand.dzAssociatedPV()); //returns the ip wrt the PV associated to this candidate 
+		pfcands_dzassociatedpv->push_back(pfCand.dzAssociatedPV()); //returns the ip wrt the PV associated to this candidate
+		pfcands_vtxidx->push_back(vtxIdx);
 	}
 
 	void put(edm::Event & iEvent) {
@@ -154,6 +158,7 @@ public:
 		iEvent.put(std::move(pfcands_frompv              ), "pfcandsfrompv");
 		iEvent.put(std::move(pfcands_pvassociationquality), "pfcandspvassociationquality");
 		iEvent.put(std::move(pfcands_dzassociatedpv      ), "pfcandsdzassociatedpv");
+		iEvent.put(std::move(pfcands_vtxidx              ), "pfcandsvtxidx");
 	}
 
 	// ----------member data ---------------------------
@@ -162,7 +167,8 @@ public:
 	std::unique_ptr<vector<bool>> trks_matchedtopfcand;
 	std::unique_ptr<vector<double>> trks_dzpv,trks_dzerrorpv,trks_dxypv,trks_dxyerrorpv,trks_normalizedchi2,trks_pterror,trks_etaerror,
 									trks_phierror,trks_qoverperror,trks_ip2d,trks_ip2dsig,trks_ip3d,trks_ip3dsig, pfcands_dzassociatedpv;
-	std::unique_ptr<vector<int>> trks_chg, trks_found, trks_lost, trks_quality, pfcands_numberofhits, pfcands_numberofpixelhits, pfcands_firsthit, pfcands_frompv, pfcands_pvassociationquality;
+	std::unique_ptr<vector<int>> trks_chg, trks_found, trks_lost, trks_quality, pfcands_numberofhits, pfcands_numberofpixelhits,
+								 pfcands_firsthit, pfcands_frompv, pfcands_pvassociationquality, pfcands_vtxidx;
 	std::unique_ptr<vector<vector<int>>> trks_hitpattern;
 };
 
@@ -174,9 +180,11 @@ public:
 private:
 	bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const override;
 	bool filterOnTrack(const pat::PackedCandidate & pfCand, const reco::Track & track) const;
+	int  getVertexIndex(const pat::PackedCandidate & pfCand, const edm::Handle<edm::View<reco::VertexRef> > & goodVertices) const;
 	void loopOverCollection(TrackInfos & infos, const edm::Handle<edm::View<pat::PackedCandidate> > & collection,
 							const edm::ESHandle<TransientTrackBuilder> & ttBuilder,
-							const reco::Vertex & primaryVertex, bool trackMatch) const;
+							const reco::Vertex & primaryVertex, const edm::Handle<edm::View<reco::VertexRef> > & goodVertices,
+							bool trackMatch) const;
 
 	// ----------member data ---------------------------
 	edm::InputTag pfCandidatesTag_;
@@ -184,11 +192,13 @@ private:
 	edm::InputTag lostEleTracksTag_;
 	edm::InputTag displacedStandAloneMuonsTag_;
 	edm::InputTag vertexInputTag_;
+	edm::InputTag storedVerticesTag_;
 	edm::EDGetTokenT<edm::View<pat::PackedCandidate>> pfCandidatesTok_;
 	edm::EDGetTokenT<edm::View<pat::PackedCandidate>> lostTracksTok_;
 	edm::EDGetTokenT<edm::View<pat::PackedCandidate>> lostEleTracksTok_;
 	edm::EDGetTokenT<edm::View<pat::PackedCandidate>> displacedStandAloneMuonsTok_;
 	edm::EDGetTokenT<edm::View<reco::Vertex>> vertexInputTok_;
+	edm::EDGetTokenT<edm::View<reco::VertexRef>> storedVerticesTok_;
 
 	double minPt_, maxEta_, maxdz_, maxdxy_, maxnormchi2_;
 	bool debug_, doFilter_, doDisplacedMuons_;
@@ -202,6 +212,7 @@ CandidateTrackFilter::CandidateTrackFilter(const edm::ParameterSet& iConfig) :
 	lostTracksTag_              (iConfig.getParameter<edm::InputTag>("lostTracksTag")),
 	lostEleTracksTag_           (iConfig.getParameter<edm::InputTag>("lostEleTracksTag")),
 	vertexInputTag_             (iConfig.getParameter<edm::InputTag>("vertexInputTag")),
+	storedVerticesTag_          (iConfig.getParameter<edm::InputTag>("storedVerticesTag")),
 	minPt_                      (iConfig.getParameter<double>       ("minPt")),
 	maxEta_                     (iConfig.getParameter<double>       ("maxEta")),
 	maxdz_                      (iConfig.getParameter<double>       ("maxdz")),
@@ -215,6 +226,7 @@ CandidateTrackFilter::CandidateTrackFilter(const edm::ParameterSet& iConfig) :
 	lostTracksTok_               = consumes<edm::View<pat::PackedCandidate>>(lostTracksTag_);
 	lostEleTracksTok_            = consumes<edm::View<pat::PackedCandidate>>(lostEleTracksTag_);
 	vertexInputTok_              = consumes<edm::View<reco::Vertex>>(vertexInputTag_);
+	storedVerticesTok_           = consumes<edm::View<reco::VertexRef>>(storedVerticesTag_);
 
 	if (iConfig.exists("displacedStandAloneMuonsTag")) {
 		displacedStandAloneMuonsTag_ = iConfig.getParameter<edm::InputTag>("displacedStandAloneMuonsTag"),
@@ -250,6 +262,7 @@ CandidateTrackFilter::CandidateTrackFilter(const edm::ParameterSet& iConfig) :
 	produces<vector<int> >                      ("pfcandsfrompv");
 	produces<vector<int> >                      ("pfcandspvassociationquality");
 	produces<vector<double> >                   ("pfcandsdzassociatedpv");
+	produces<vector<int> >                      ("pfcandsvtxidx");
 }
 
 CandidateTrackFilter::~CandidateTrackFilter() {
@@ -275,6 +288,12 @@ bool CandidateTrackFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 	if(!hasGoodVtx) return false;
 
 	//-------------------------------------------------------------------------------------------------
+	// get the Good Vertices Collection
+	//-------------------------------------------------------------------------------------------------
+	edm::Handle<edm::View<reco::VertexRef> > storedVertices;
+	iEvent.getByToken(storedVerticesTok_, storedVertices);
+
+	//-------------------------------------------------------------------------------------------------
 	// get TransientTrackBuilder from the EventSetup
 	//-------------------------------------------------------------------------------------------------
 	// https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideTransientTracks
@@ -295,19 +314,19 @@ bool CandidateTrackFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 	// loop over the various track containing collections
 	//-------------------------------------------------------------------------------------------------
 	if( pfCandidates.isValid() ){
-		loopOverCollection(infos,pfCandidates,ttBuilder,primaryVertex,true);
+		loopOverCollection(infos,pfCandidates,ttBuilder,primaryVertex,storedVertices,true);
 	} else {
 		edm::LogWarning("TreeMaker")<<"CandidateTrackFilter: Collection "<<pfCandidatesTag_<<" not found!";
 	}
 
 	if( lostTracks.isValid() ){
-		loopOverCollection(infos,lostTracks,ttBuilder,primaryVertex,false);
+		loopOverCollection(infos,lostTracks,ttBuilder,primaryVertex,storedVertices,false);
 	} else {
 		edm::LogWarning("TreeMaker")<<"CandidateTrackFilter: Collection "<<lostTracksTag_<<" not found!";
 	}
 
 	if( lostEleTracks.isValid() ){
-		loopOverCollection(infos,lostEleTracks,ttBuilder,primaryVertex,false);
+		loopOverCollection(infos,lostEleTracks,ttBuilder,primaryVertex,storedVertices,false);
 	} else {
 		edm::LogWarning("TreeMaker")<<"CandidateTrackFilter: Collection "<<lostEleTracksTag_<<" not found!";
 	}
@@ -322,7 +341,7 @@ bool CandidateTrackFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::
 		//-------------------------------------------------------------------------------------------------
 		// loop over displacedStandAloneMuons
 		//-------------------------------------------------------------------------------------------------
-		loopOverCollection(infos,displacedStandAloneMuons,ttBuilder,primaryVertex,false); //Do these overlap with the packedPFCandidate collection? Are they matched?
+		loopOverCollection(infos,displacedStandAloneMuons,ttBuilder,primaryVertex,storedVertices,false); //Do these overlap with the packedPFCandidate collection? Are they matched?
 	}
 
 	//-------------------------------------------------------------------------------------------------
@@ -340,9 +359,18 @@ bool CandidateTrackFilter::filterOnTrack(const pat::PackedCandidate & pfCand, co
 		   (std::abs(track.normalizedChi2()) <= maxnormchi2_); // cut on chi2
 }
 
+int CandidateTrackFilter::getVertexIndex(const pat::PackedCandidate & pfCand, const edm::Handle<edm::View<reco::VertexRef> > & storedVertices) const {
+	auto it = std::find_if(storedVertices->begin(), storedVertices->end(), [&pfCand](reco::VertexRef const& obj){
+					return obj == pfCand.vertexRef();
+				} );
+	if(it!=storedVertices->end()) return std::distance(storedVertices->begin(),it);
+	else return -1;
+}
+
 void CandidateTrackFilter::loopOverCollection(TrackInfos & infos, const edm::Handle<edm::View<pat::PackedCandidate> > & collection,
 											  const edm::ESHandle<TransientTrackBuilder> & ttBuilder,
-											  const reco::Vertex & primaryVertex, bool trackMatch) const {
+											  const reco::Vertex & primaryVertex, const edm::Handle<edm::View<reco::VertexRef> > & storedVertices,
+											  bool trackMatch) const {
 	//-------------------------------------------------------------------------------------------------
 	// loop over PFCandidates
 	//-------------------------------------------------------------------------------------------------
@@ -361,10 +389,15 @@ void CandidateTrackFilter::loopOverCollection(TrackInfos & infos, const edm::Han
 		if (!filterOnTrack(pfCand,track)) continue;
 
 		//-------------------------------------------------------------------------------------------------
+		// find the index of the associated vertex in the good vertices collection
+		//-------------------------------------------------------------------------------------------------
+		int vtxIdx = getVertexIndex(pfCand,storedVertices);
+
+		//-------------------------------------------------------------------------------------------------
 		// fill the track values and PFCandidate values we'd like to save
 		//-------------------------------------------------------------------------------------------------
 		auto transientTrack = ttBuilder->build(track);
-		infos.fill(primaryVertex,pfCand,track,transientTrack,trackMatch);
+		infos.fill(primaryVertex,pfCand,track,transientTrack,trackMatch,vtxIdx);
 	}
 }
 

--- a/Utils/src/PrimaryVerticesProducer.cc
+++ b/Utils/src/PrimaryVerticesProducer.cc
@@ -18,6 +18,7 @@
 class VertexInfos {
 public:
 	VertexInfos() {
+		vtx_ref      = std::make_unique<std::vector<reco::VertexRef>>();
 		vtx_position = std::make_unique<std::vector<math::XYZPoint>>();
 		vtx_time     = std::make_unique<std::vector<double>>();
 		vtx_isValid  = std::make_unique<std::vector<bool>>();
@@ -48,7 +49,12 @@ public:
 
 	}
 
+	void fillRef(const edm::Handle<reco::VertexCollection> & vertices, const size_t & i) {
+		vtx_ref->push_back(reco::VertexRef(vertices, i));
+	}
+
 	void put(edm::Event & iEvent) {
+		iEvent.put(std::move(vtx_ref),      "vtxref");
 		iEvent.put(std::move(vtx_position), "vtxposition");
 		iEvent.put(std::move(vtx_time),     "vtxtime");
 		iEvent.put(std::move(vtx_isValid),  "vtxisValid");
@@ -64,6 +70,7 @@ public:
 	}
 
 // ----------member data ---------------------------
+	std::unique_ptr<std::vector<reco::VertexRef>> vtx_ref;
 	std::unique_ptr<std::vector<math::XYZPoint>> vtx_position;
 	std::unique_ptr<std::vector<bool>> vtx_isValid, vtx_isFake, vtx_isGood;
 	std::unique_ptr<std::vector<double>> vtx_time, vtx_ndof, vtx_chi2, vtx_xError, vtx_yError, vtx_zError, vtx_tError;
@@ -99,6 +106,7 @@ saveVertices_(iConfig.getParameter<bool>("saveVertices"))
 	produces<int>("NVtx");
 	produces<int>("nAllVertices");
 	if (saveVertices_) {
+		produces<std::vector<reco::VertexRef> >("vtxref");
 		produces<std::vector<math::XYZPoint> > ("vtxposition");
 		produces<std::vector<double> >         ("vtxtime");
 		produces<std::vector<bool> >           ("vtxisValid");
@@ -160,6 +168,7 @@ PrimaryVerticesProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 				} );
 
 			infos.fill(vertex,it!=goodVertices->end());
+			infos.fillRef(vertices,i);
 		}
 		infos.put(iEvent);
 	}


### PR DESCRIPTION
Currently we store tracks and vertices in the TreeMaker ntuples. The reco::Tracks store the associated reco::VertexRef, but we don't look at that or store it. In the EMJ meeting on 08/10/2020 the idea of associating a track to a given PV came up. This PR adds a new std::vector<int> which lists the stored index for the vertex associated to each track in the ntuple. For the PV we didn't store the vector will contain an index of -1.

After running a unit test before an after the change the ntuple increased in size/event by ~0.7%.