### PR TITLE
[Run2_2017] Add an EMJ related branch and track sorting

### DIFF
--- a/Production/test/unitTest.py
+++ b/Production/test/unitTest.py
@@ -118,6 +118,8 @@ def defineTests(mytests, scenario, name, numevents, command, dataset, inputFiles
     mytests.append(Test("2018B26SepHEM",name,numevents,command,inputFilesConfig="Run2018B-26Sep2018_HEMmitigation-v1.JetHT",nstart=0,nfiles=10))
     mytests.append(Test("2018PromptReco",name,numevents,command,inputFilesConfig="Run2018D-PromptReco-v2.JetHT",nstart=244,nfiles=10))
     mytests.append(Test("2018ReReco17Sep",name,numevents,command,inputFilesConfig="Run2018B-17Sep2018-v1.JetHT",nstart=0,nfiles=10))
+    mytests.append(Test("Summer16v3sig","PrivateSamples.EMJ_2016_mMed-1000_mDark-20_kappa-0p12_aligned-down",numevents,"emerging=True deepAK8=False deepDoubleB=False doZinv=False nestedVectors=False splitLevel=99"+command,inputFilesConfig="PrivateSamples.EMJ_2016_mMed-1000_mDark-20_kappa-0p12_aligned-down",nstart=0,nfiles=10))
+    mytests.append(Test("Summer16v3sig","PrivateSamples.EMJ_2016_mMed-1000_mDark-20_ctau-1000_unflavored-down",numevents,"emerging=True deepAK8=False deepDoubleB=False doZinv=False nestedVectors=False splitLevel=99"+command,inputFilesConfig="PrivateSamples.EMJ_2016_mMed-1000_mDark-20_ctau-1000_unflavored-down",nstart=0,nfiles=10))
 
 def unitTest():
     # Read parameters

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1126,6 +1126,7 @@ def makeTreeFromMiniAOD(self,process):
             'trackFilter:trksip3d(Tracks_IP3DPV0)',
             'trackFilter:trksip3dsig(Tracks_IP3DSigPV0)',
             'trackFilter:pfcandsdzassociatedpv(Tracks_dzAssociatedPV)',
+            'trackFilter:vtxsumtrackpt2(PrimaryVertices_sumTrackPt2)'
         ])
         self.VectorInt.extend([
             'trackFilter:trkschg(Tracks_charge)',

--- a/Utils/src/CandidateTrackFilter.cc
+++ b/Utils/src/CandidateTrackFilter.cc
@@ -73,17 +73,12 @@ public:
 		vtx_sumtrackpt2              = std::make_unique<vector<double>>();
 	}
 
-	void calculateVertexQuantities(const int & nvtx) {
-		for (auto ivtx=0; ivtx<nvtx; ivtx++) {
-			auto it = pfcands_vtxidx->begin();
-			int index = -1;
-			double sumpt2 = 0;
-			while ((it = std::find(it, pfcands_vtxidx->end(), ivtx)) != pfcands_vtxidx->end()) {
-				index = std::distance(pfcands_vtxidx->begin(), it);
-				sumpt2 += trks->at(index).Perp2();
-				it++;
-			}
-			vtx_sumtrackpt2->push_back(sumpt2);
+	void calculateVertexQuantities(int nvtx) {
+		vtx_sumtrackpt2->resize(nvtx,0);
+		int current_vtx_idx = -1;
+		for (unsigned int itrk=0; itrk<trks->size(); itrk++) {
+			current_vtx_idx = pfcands_vtxidx->at(itrk);
+			vtx_sumtrackpt2->at(current_vtx_idx) += trks->at(itrk).Perp2();
 		}
 	}
 

--- a/Utils/src/PrimaryVerticesProducer.cc
+++ b/Utils/src/PrimaryVerticesProducer.cc
@@ -46,7 +46,6 @@ public:
 		vtx_zError->push_back(vertex.zError());
 		vtx_tError->push_back(vertex.tError());
 		vtx_ntracks->push_back(vertex.nTracks());
-
 	}
 
 	void fillRef(const edm::Handle<reco::VertexCollection> & vertices, const size_t & i) {


### PR DESCRIPTION
This PR does two things:
1. It adds a branch which contains the sum of the squares of the pT of the tracks associated to a given vertex. This increases the size of the ntuple by ~1% (tested using the EMJ settings on a Summer16v3 TTJets sample).
2. It sorts the tracks and their associated vectors by the track pT (decreasing pT)
