### PR TITLE
Option to save counts rather offsets when saving nested vectors in a flat way

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ Brief explanation of the options in [maker.py](./TreeMaker/python/maker.py)
 * `saveMinimalGenParticles`: save only the hard scatter gen particles coming from top decays, boson decays, semi-visible jets, or SUSY particles (default=True)
 * `saveGenTops`: save the 4-vectors of the generated tops and the TTbar reweighting scale factor (default=False)
 * `doMT2`: switch to enable the storage of the MT2 variable (default=False)
-* `nestedVectors`: switch to change from saving vector<\vector<T>> to saving vector<T> values and vector<\int> offsets (default=True)
+* `nestedVectors`: switch to change from saving vector<\vector<T>> to saving vector<T> values and vector<\int> counts (default=True)
+* `nestedCounts`: if set to False, stores offsets rather than counts when using `nestedVectors=False` (default=True)
 
 The following parameters take their default values from the specified scenario:
 * `globaltag`: global tag for CMSSW database conditions (ref. [FrontierConditions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions))

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Brief explanation of the options in [maker.py](./TreeMaker/python/maker.py)
 * `saveGenTops`: save the 4-vectors of the generated tops and the TTbar reweighting scale factor (default=False)
 * `doMT2`: switch to enable the storage of the MT2 variable (default=False)
 * `nestedVectors`: switch to change from saving vector<\vector<T>> to saving vector<T> values and vector<\int> counts (default=True)
-* `nestedCounts`: if set to False, stores offsets rather than counts when using `nestedVectors=False` (default=True)
+* `storeOffsets`: if set to True, stores offsets rather than counts when using `nestedVectors=False` (default=False)
 
 The following parameters take their default values from the specified scenario:
 * `globaltag`: global tag for CMSSW database conditions (ref. [FrontierConditions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions))

--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -66,7 +66,7 @@ class TreeMaker : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 		edm::Service<TFileService> fs;
 		string treeName;
 		TTree* tree;	
-		bool doLorentz, sortBranches, debugTitles, nestedVectors;
+		bool doLorentz, sortBranches, debugTitles, nestedVectors, nestedCounts;
 		int splitLevel;
 		vector<string> VarTypeNames;
 		vector<TreeTypes> VarTypes;
@@ -376,8 +376,8 @@ class TreeNestedVector : public TreeObject<std::vector<std::vector<Base>>> {
 
 		// Constructor
 		TreeNestedVector() : TreeObject<Top>() {}
-		TreeNestedVector(string tempFull_, string title_="", bool nestedVectors_=true, bool associated_=false, int splitLevel_=0) :
-			TreeObject<Top>(tempFull_,title_,splitLevel_), nestedVectors(nestedVectors_), associated(associated_) {}
+		TreeNestedVector(string tempFull_, string title_="", bool nestedVectors_=true, bool nestedCounts_=true, bool associated_=false, int splitLevel_=0) :
+			TreeObject<Top>(tempFull_,title_,splitLevel_), nestedVectors(nestedVectors_), nestedCounts(nestedCounts_), associated(associated_) {}
 		// Destructor
 		~TreeNestedVector() override {}
 		
@@ -389,11 +389,11 @@ class TreeNestedVector : public TreeObject<std::vector<std::vector<Base>>> {
 			else 				return;
 			for(auto& sub : all) {
 				accum.insert(std::end(accum), std::begin(sub), std::end(sub));
-				if (!associated) offsets.insert(std::end(offsets), accum.size());
+				if (!associated) offsets.insert(std::end(offsets), nestedCounts ? sub.size() : accum.size());
 			}
 			// This protects against the case where there were >=1 empty sub-vectors, and only empty vectors
 			// Thus, nothing will be in the output (accum) vector, but the offsets would be all '0'
-			if (!associated && accum.size() == 0) offsets.clear();
+			if (!nestedCounts && !associated && accum.size() == 0) offsets.clear();
 		}
 		void SetConsumes(edm::ConsumesCollector && iC) override{
 			tok = iC.consumes<Top>(this->tag);
@@ -427,7 +427,7 @@ class TreeNestedVector : public TreeObject<std::vector<std::vector<Base>>> {
 				}
 				else {
 					this->tree->Branch((this->nameInTree).c_str(),GetSubType().c_str(),&values,32000,this->splitLevel);
-					if (!associated) this->tree->Branch((this->nameInTree+"Offsets").c_str(),"vector<int>",&offsets,32000,this->splitLevel);
+					if (!associated) this->tree->Branch((this->nameInTree+(nestedCounts ? "Counts" : "Offsets")).c_str(),"vector<int>",&offsets,32000,this->splitLevel);
 				}
 			}
 		}
@@ -454,7 +454,7 @@ class TreeNestedVector : public TreeObject<std::vector<std::vector<Base>>> {
 	protected:
 		// Member variables
 		edm::EDGetTokenT<Top> tok;
-		bool nestedVectors{}, associated{};
+		bool nestedVectors{}, nestedCounts{}, associated{};
 		Sub values;
 		vector<int> offsets;
 };

--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -385,7 +385,7 @@ class TreeNestedVector : public TreeObject<std::vector<std::vector<Base>>> {
 		// From: https://stackoverflow.com/questions/17294629/merging-flattening-sub-vectors-into-a-single-vector-c-converting-2d-to-1d
 		void flatten(Top const& all, Sub &accum, vector<int> &offsets) {
 			// Don't store any offsets if there are no sub-vectors
-			if (!associated && all.size() > 0)	offsets.insert(std::end(offsets),0);
+			if (!associated && all.size() > 0){ if(!nestedCounts) offsets.insert(std::end(offsets),0); }
 			else 				return;
 			for(auto& sub : all) {
 				accum.insert(std::end(accum), std::begin(sub), std::end(sub));

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -63,6 +63,7 @@ def makeTreeFromMiniAOD(self,process):
         AssocVectorVectorXYZPoint      = self.AssocVectorVectorXYZVector,
         TitleMap                       = self.TitleMap,
         nestedVectors                  = self.nestedVectors,
+        nestedCounts                   = self.nestedCounts,
         splitLevel                     = self.splitLevel,
     )
 

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -63,7 +63,7 @@ def makeTreeFromMiniAOD(self,process):
         AssocVectorVectorXYZPoint      = self.AssocVectorVectorXYZVector,
         TitleMap                       = self.TitleMap,
         nestedVectors                  = self.nestedVectors,
-        nestedCounts                   = self.nestedCounts,
+        storeOffsets                   = self.storeOffsets,
         splitLevel                     = self.splitLevel,
     )
 

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -162,7 +162,7 @@ class maker:
         if self.nestedVectors:
             print " Saving nested vectors as vector<vector<T>>"
             if self.nestedCounts:
-                print " Saving counts(not offsets) for nested vectors"
+                print " Saving counts (not offsets) for nested vectors"
         else: print " Saving nested vectors as vector<T> + vector<int>"
         print " TTree split level: "+str(self.splitLevel)
         print " "

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -60,6 +60,7 @@ class maker:
         self.getParamDefault("saveGenTops", False)
         self.getParamDefault("doMT2",False)
         self.getParamDefault("nestedVectors", True)
+        self.getParamDefault("nestedCounts", True)
         self.getParamDefault("splitLevel", 0)
         
         # take command line input (w/ defaults from scenario if specified)
@@ -158,7 +159,10 @@ class maker:
         print " Storing a minimal set of GenParticles: "+str(self.saveMinimalGenParticles)
         print " Storing the GenTops: "+str(self.saveGenTops)
         print " Saving the MT2 variable: "+str(self.doMT2)
-        if self.nestedVectors: print " Saving nested vectors as vector<vector<T>>"
+        if self.nestedVectors:
+            print " Saving nested vectors as vector<vector<T>>"
+            if self.nestedCounts:
+                print " Saving counts(not offsets) for nested vectors"
         else: print " Saving nested vectors as vector<T> + vector<int>"
         print " TTree split level: "+str(self.splitLevel)
         print " "

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -60,7 +60,7 @@ class maker:
         self.getParamDefault("saveGenTops", False)
         self.getParamDefault("doMT2",False)
         self.getParamDefault("nestedVectors", True)
-        self.getParamDefault("nestedCounts", True)
+        self.getParamDefault("storeOffsets", False)
         self.getParamDefault("splitLevel", 0)
         
         # take command line input (w/ defaults from scenario if specified)
@@ -161,7 +161,7 @@ class maker:
         print " Saving the MT2 variable: "+str(self.doMT2)
         if self.nestedVectors:
             print " Saving nested vectors as vector<vector<T>>"
-            if self.nestedCounts:
+            if self.storeOffsets:
                 print " Saving counts (not offsets) for nested vectors"
         else: print " Saving nested vectors as vector<T> + vector<int>"
         print " TTree split level: "+str(self.splitLevel)

--- a/TreeMaker/python/treeMaker.py
+++ b/TreeMaker/python/treeMaker.py
@@ -15,7 +15,7 @@ debugTitles = cms.bool(False),
 #switches to vector<T> values, vector<int> skips
 nestedVectors = cms.bool(True),
 #if storing nested vectors, stores counts rather than offsets
-nestedCounts = cms.bool(True),
+storeOffsets = cms.bool(False),
 #split level for the TBranches
 splitLevel = cms.int32(0),
 # list of reco candidate objects: for each reco cand collection, the math::LorentzVector will be stored in a vector.

--- a/TreeMaker/python/treeMaker.py
+++ b/TreeMaker/python/treeMaker.py
@@ -14,6 +14,8 @@ debugTitles = cms.bool(False),
 #default: output vector<vector<T>>
 #switches to vector<T> values, vector<int> skips
 nestedVectors = cms.bool(True),
+#if storing nested vectors, stores counts rather than offsets
+nestedCounts = cms.bool(True),
 #split level for the TBranches
 splitLevel = cms.int32(0),
 # list of reco candidate objects: for each reco cand collection, the math::LorentzVector will be stored in a vector.

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -52,6 +52,7 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 	sortBranches = iConfig.getParameter<bool>("sortBranches");
 	debugTitles = iConfig.getParameter<bool>("debugTitles");
 	nestedVectors = iConfig.getParameter<bool>("nestedVectors");
+	nestedCounts = iConfig.getParameter<bool>("nestedCounts");
 	splitLevel = iConfig.getParameter<int>("splitLevel");
 
 	// parse the TitleMap
@@ -122,20 +123,20 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 				case TreeTypes::t_vlorentz  : tmp = new TreeObject<vector<math::PtEtaPhiELorentzVector>>(VarName,VarTitle,splitLevel); break;
 				case TreeTypes::t_vxyzv     : tmp = new TreeObject<vector<math::XYZVector>>(VarName,VarTitle,splitLevel); break;
 				case TreeTypes::t_vxyzp     : tmp = new TreeObject<vector<math::XYZPoint>>(VarName,VarTitle,splitLevel); break;
-				case TreeTypes::t_vvbool    : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors,false,splitLevel); break;
-				case TreeTypes::t_vvint     : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors,false,splitLevel); break;
-				case TreeTypes::t_vvdouble  : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors,false,splitLevel); break;
-				case TreeTypes::t_vvstring  : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors,false,splitLevel); break;
-				case TreeTypes::t_vvlorentz : tmp = new TreeNestedVector<math::PtEtaPhiELorentzVector>(VarName,VarTitle,nestedVectors,false,splitLevel); break;
-				case TreeTypes::t_vvxyzv    : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors,false,splitLevel); break;
-				case TreeTypes::t_vvxyzp    : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors,false,splitLevel); break;
-				case TreeTypes::t_avvbool   : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors,true,splitLevel); break;
-				case TreeTypes::t_avvint    : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors,true,splitLevel); break;
-				case TreeTypes::t_avvdouble : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors,true,splitLevel); break;
-				case TreeTypes::t_avvstring : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors,true,splitLevel); break;
-				case TreeTypes::t_avvlorentz: tmp = new TreeNestedVector<math::PtEtaPhiELorentzVector>(VarName,VarTitle,nestedVectors,true,splitLevel); break;
-				case TreeTypes::t_avvxyzv   : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors,true,splitLevel); break;
-				case TreeTypes::t_avvxyzp   : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors,true,splitLevel); break;
+				case TreeTypes::t_vvbool    : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
+				case TreeTypes::t_vvint     : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
+				case TreeTypes::t_vvdouble  : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
+				case TreeTypes::t_vvstring  : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
+				case TreeTypes::t_vvlorentz : tmp = new TreeNestedVector<math::PtEtaPhiELorentzVector>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
+				case TreeTypes::t_vvxyzv    : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
+				case TreeTypes::t_vvxyzp    : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
+				case TreeTypes::t_avvbool   : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
+				case TreeTypes::t_avvint    : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
+				case TreeTypes::t_avvdouble : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
+				case TreeTypes::t_avvstring : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
+				case TreeTypes::t_avvlorentz: tmp = new TreeNestedVector<math::PtEtaPhiELorentzVector>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
+				case TreeTypes::t_avvxyzv   : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
+				case TreeTypes::t_avvxyzp   : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
 				case TreeTypes::t_recocand  : tmp = new TreeRecoCand(VarName,VarTitle,doLorentz,splitLevel); break;
 			}
 			//if a known type was found, initialize and store the object

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -52,7 +52,7 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 	sortBranches = iConfig.getParameter<bool>("sortBranches");
 	debugTitles = iConfig.getParameter<bool>("debugTitles");
 	nestedVectors = iConfig.getParameter<bool>("nestedVectors");
-	nestedCounts = iConfig.getParameter<bool>("nestedCounts");
+	storeOffsets = iConfig.getParameter<bool>("storeOffsets");
 	splitLevel = iConfig.getParameter<int>("splitLevel");
 
 	// parse the TitleMap
@@ -123,20 +123,20 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 				case TreeTypes::t_vlorentz  : tmp = new TreeObject<vector<math::PtEtaPhiELorentzVector>>(VarName,VarTitle,splitLevel); break;
 				case TreeTypes::t_vxyzv     : tmp = new TreeObject<vector<math::XYZVector>>(VarName,VarTitle,splitLevel); break;
 				case TreeTypes::t_vxyzp     : tmp = new TreeObject<vector<math::XYZPoint>>(VarName,VarTitle,splitLevel); break;
-				case TreeTypes::t_vvbool    : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
-				case TreeTypes::t_vvint     : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
-				case TreeTypes::t_vvdouble  : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
-				case TreeTypes::t_vvstring  : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
-				case TreeTypes::t_vvlorentz : tmp = new TreeNestedVector<math::PtEtaPhiELorentzVector>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
-				case TreeTypes::t_vvxyzv    : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
-				case TreeTypes::t_vvxyzp    : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors,nestedCounts,false,splitLevel); break;
-				case TreeTypes::t_avvbool   : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
-				case TreeTypes::t_avvint    : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
-				case TreeTypes::t_avvdouble : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
-				case TreeTypes::t_avvstring : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
-				case TreeTypes::t_avvlorentz: tmp = new TreeNestedVector<math::PtEtaPhiELorentzVector>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
-				case TreeTypes::t_avvxyzv   : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
-				case TreeTypes::t_avvxyzp   : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors,nestedCounts,true,splitLevel); break;
+				case TreeTypes::t_vvbool    : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
+				case TreeTypes::t_vvint     : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
+				case TreeTypes::t_vvdouble  : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
+				case TreeTypes::t_vvstring  : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
+				case TreeTypes::t_vvlorentz : tmp = new TreeNestedVector<math::PtEtaPhiELorentzVector>(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
+				case TreeTypes::t_vvxyzv    : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
+				case TreeTypes::t_vvxyzp    : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
+				case TreeTypes::t_avvbool   : tmp = new TreeNestedVector<bool>(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
+				case TreeTypes::t_avvint    : tmp = new TreeNestedVector<int>(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
+				case TreeTypes::t_avvdouble : tmp = new TreeNestedVector<double>(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
+				case TreeTypes::t_avvstring : tmp = new TreeNestedVector<string>(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
+				case TreeTypes::t_avvlorentz: tmp = new TreeNestedVector<math::PtEtaPhiELorentzVector>(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
+				case TreeTypes::t_avvxyzv   : tmp = new TreeNestedVector<math::XYZVector>(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
+				case TreeTypes::t_avvxyzp   : tmp = new TreeNestedVector<math::XYZPoint>(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
 				case TreeTypes::t_recocand  : tmp = new TreeRecoCand(VarName,VarTitle,doLorentz,splitLevel); break;
 			}
 			//if a known type was found, initialize and store the object


### PR DESCRIPTION
Implements a command line option "nestedCounts"; if set to True, counts will be saved rather than offsets when saving nested arrays in a flattened way (i.e. using nestedVectors=False)