### PR TITLE
[Run2_2017] Correct user during GHA build job

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Reset User on Push
       if: github.event_name == 'push'
       run: echo ::set-env name=current_user::$(echo ${{ github.repository }} | sed -E 's|/.*||')
+    - name: Reset User on Pull Request
+      if: github.event_name == 'pull_request'
+      run: echo ::set-env name=current_user::${{ github.event.pull_request.head.repo.owner.login }}
     - name: Reset Branch on Pull Request
       if: github.event_name == 'pull_request'
       run: echo ::set-env name=current_branch::${{ github.head_ref }}
@@ -96,10 +99,6 @@ jobs:
     needs: [build]
     if: "!contains(github.event.head_commit.message, '[skip service-x]') && !contains(github.event.head_commit.message, '[skip publish]') && github.event_name != 'pull_request'"
     steps:
-    - name: Redefine branch on pull_request
-      if: github.event_name == 'pull_request'
-      run: |
-        echo ::set-env name=current_branch::${{ github.head_ref }}
     - name: Redefine branch on push
       if: github.event_name == 'push'
       run: |


### PR DESCRIPTION
This PR makes two changes:
1. Make sure that the correct fork is used during the GHA build stage on a PR event. Previously this only worked for forks contained in user accounts, but not for an organization.
2. Remove an unnecessary step in the build-standalone job.