### PR TITLE
[Run2_2017] Fix naming of Counts/Offsets branches

### DIFF
--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -427,7 +427,7 @@ class TreeNestedVector : public TreeObject<std::vector<std::vector<Base>>> {
 				}
 				else {
 					this->tree->Branch((this->nameInTree).c_str(),GetSubType().c_str(),&values,32000,this->splitLevel);
-					if (!associated) this->tree->Branch((this->nameInTree+(storeOffsets ? "Counts" : "Offsets")).c_str(),"vector<int>",&offsets,32000,this->splitLevel);
+					if (!associated) this->tree->Branch((this->nameInTree+(storeOffsets ? "Offsets" : "Counts")).c_str(),"vector<int>",&offsets,32000,this->splitLevel);
 				}
 			}
 		}


### PR DESCRIPTION
Prior to this PR the naming of the counts/offsets branches was backwards. The option 'storeOffsets` is false by default [1] and thus the name `Counts` should be in the third (false) position of the ternary operator.

[1] https://github.com/TreeMaker/TreeMaker/blob/Run2_2017/TreeMaker/python/maker.py#L63
