### PR TITLE
[Run2_2017] Change the name of the PrimaryVertices_position branch

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1094,7 +1094,7 @@ def makeTreeFromMiniAOD(self,process):
     ## Emerging jets
     ## ----------------------------------------------------------------------------------------------
     if self.emerging:
-        self.VectorXYZPoint.extend(['primaryVertices:vtxposition(PrimaryVertices_position)'])
+        self.VectorXYZPoint.extend(['primaryVertices:vtxposition(PrimaryVertices)'])
         self.VectorDouble.extend([
             'primaryVertices:vtxtime(PrimaryVertices_time)',
             'primaryVertices:vtxndof(PrimaryVertices_ndof)',


### PR DESCRIPTION
Change the name of the `PrimaryVertices_position` branch to correspond to the same convention as the `GenVertices` branch. Since both of them are primarily a position, they don't need the '_position' suffix.