### PR TITLE
[Run2_2017] Flattened associated nested vector bugfix

### DIFF
--- a/TreeMaker/interface/TreeMaker.h
+++ b/TreeMaker/interface/TreeMaker.h
@@ -385,8 +385,8 @@ class TreeNestedVector : public TreeObject<std::vector<std::vector<Base>>> {
 		// From: https://stackoverflow.com/questions/17294629/merging-flattening-sub-vectors-into-a-single-vector-c-converting-2d-to-1d
 		void flatten(Top const& all, Sub &accum, vector<int> &offsets) {
 			// Don't store any offsets if there are no sub-vectors
-			if (!associated && all.size() > 0){ if(storeOffsets) offsets.insert(std::end(offsets),0); }
-			else 				return;
+			if (all.size() == 0) return;
+			if (!associated && storeOffsets) { offsets.insert(std::end(offsets),0); }
 			for(auto& sub : all) {
 				accum.insert(std::end(accum), std::begin(sub), std::end(sub));
 				if (!associated) offsets.insert(std::end(offsets), storeOffsets ? accum.size() : sub.size());


### PR DESCRIPTION
Fix a bug which wasn't storing the values for branches which were flattened associated nested vectors. This bug affected the JetsAK8_subjets_* branches, which existed in the tree, but weren't filled. The bugfix has been tested; the values appear to be of the correct scale and the correct number of counts/offsets branches exist. This fix increases the size of the ntuple by only 0.5%. The size of the vectors can be compared for the buggy version [1] and the new/fixed version [2].

[1]
```bash
root [2] PreSelection->Scan("@JetsAK8.size():@JetsAK8_subjets.size():@JetsAK8_subjetsCounts.size():@JetsAK8_subjets_bDiscriminatorCSV.size():@JetsAK8_subjets_jecFactor.size()")
************************************************************************
*    Row   * @JetsAK8. * @JetsAK8_ * @JetsAK8_ * @JetsAK8_ * @JetsAK8_ *
************************************************************************
*        0 *         2 *         3 *         2 *         0 *         0 *
*        1 *         2 *         2 *         2 *         0 *         0 *
*        2 *         3 *         6 *         3 *         0 *         0 *
*        3 *         2 *         4 *         2 *         0 *         0 *
*        4 *         2 *         4 *         2 *         0 *         0 *
*        5 *         1 *         2 *         1 *         0 *         0 *
*        6 *         2 *         4 *         2 *         0 *         0 *
*        7 *         1 *         2 *         1 *         0 *         0 *
*        8 *         3 *         6 *         3 *         0 *         0 *
*        9 *         3 *         6 *         3 *         0 *         0 *
*       10 *         2 *         4 *         2 *         0 *         0 *
*       11 *         3 *         6 *         3 *         0 *         0 *
*       12 *         3 *         4 *         3 *         0 *         0 *
*       13 *         2 *         2 *         2 *         0 *         0 *
*       14 *         3 *         5 *         3 *         0 *         0 *
*       15 *         1 *         2 *         1 *         0 *         0 *
*       16 *         3 *         6 *         3 *         0 *         0 *
*       17 *         4 *         4 *         4 *         0 *         0 *
*       18 *         2 *         4 *         2 *         0 *         0 *
*       19 *         4 *         6 *         4 *         0 *         0 *
*       20 *         2 *         4 *         2 *         0 *         0 *
*       21 *         2 *         2 *         2 *         0 *         0 *
*       22 *         2 *         4 *         2 *         0 *         0 *
*       23 *         3 *         6 *         3 *         0 *         0 *
*       24 *         2 *         4 *         2 *         0 *         0 *
```

[2]
```bash
root [2] PreSelection->Scan("@JetsAK8.size():@JetsAK8_subjets.size():@JetsAK8_subjetsCounts.size():@JetsAK8_subjets_bDiscriminatorCSV.size():@JetsAK8_subjets_jecFactor.size()")
************************************************************************
*    Row   * @JetsAK8. * @JetsAK8_ * @JetsAK8_ * @JetsAK8_ * @JetsAK8_ *
************************************************************************
*        0 *         3 *         6 *         3 *         6 *         6 *
*        1 *         3 *         6 *         3 *         6 *         6 *
*        2 *         5 *        10 *         5 *        10 *        10 *
*        3 *         4 *         6 *         4 *         6 *         6 *
*        4 *         3 *         6 *         3 *         6 *         6 *
*        5 *         4 *         8 *         4 *         8 *         8 *
*        6 *         3 *         6 *         3 *         6 *         6 *
*        7 *         2 *         4 *         2 *         4 *         4 *
*        8 *         5 *         8 *         5 *         8 *         8 *
*        9 *         3 *         6 *         3 *         6 *         6 *
*       10 *         3 *         6 *         3 *         6 *         6 *
*       11 *         2 *         4 *         2 *         4 *         4 *
*       12 *         3 *         4 *         3 *         4 *         4 *
*       13 *         3 *         6 *         3 *         6 *         6 *
*       14 *         6 *         8 *         6 *         8 *         8 *
*       15 *         4 *         8 *         4 *         8 *         8 *
*       16 *         4 *         6 *         4 *         6 *         6 *
*       17 *         3 *         6 *         3 *         6 *         6 *
*       18 *         3 *         4 *         3 *         4 *         4 *
*       19 *         3 *         6 *         3 *         6 *         6 *
*       20 *         5 *        10 *         5 *        10 *        10 *
*       21 *         4 *         6 *         4 *         6 *         6 *
*       22 *         1 *         2 *         1 *         2 *         2 *
*       23 *         3 *         6 *         3 *         6 *         6 *
*       24 *         2 *         4 *         2 *         4 *         4 *
```