### PR TITLE
[Run2_2017] Add missing EMJ variable

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1142,8 +1142,9 @@ def makeTreeFromMiniAOD(self,process):
             'trackFilter:trksip2dsig(Tracks_IP2dSigPV0)',
             'trackFilter:trksip3d(Tracks_IP3DPV0)',
             'trackFilter:trksip3dsig(Tracks_IP3DSigPV0)',
+            'trackFilter:pfcandsenergy(Tracks_pfEnergy)',
             'trackFilter:pfcandsdzassociatedpv(Tracks_dzAssociatedPV)',
-            'trackFilter:vtxsumtrackpt2(PrimaryVertices_sumTrackPt2)'
+            'trackFilter:vtxsumtrackpt2(PrimaryVertices_sumTrackPt2)',
         ])
         self.VectorInt.extend([
             'trackFilter:trkschg(Tracks_charge)',

--- a/Utils/src/CandidateTrackFilter.cc
+++ b/Utils/src/CandidateTrackFilter.cc
@@ -63,6 +63,7 @@ public:
 		trks_quality                 = std::make_unique<vector<int>>();
 		trks_hitpattern              = std::make_unique<vector<vector<int>>>();
 		trks_matchedtopfcand         = std::make_unique<vector<bool>>();
+		pfcands_energy               = std::make_unique<vector<double>>();
 		pfcands_numberofhits         = std::make_unique<vector<int>>();
 		pfcands_numberofpixelhits    = std::make_unique<vector<int>>();
 		pfcands_firsthit             = std::make_unique<vector<int>>();
@@ -141,6 +142,7 @@ public:
 
 		// information from the pat::PackedCandidate
 		//   Reference: https://github.com/cms-sw/cmssw/blob/master/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+		pfcands_energy->push_back(pfCand.energy());
 		pfcands_numberofhits->push_back(pfCand.numberOfHits());
 		pfcands_numberofpixelhits->push_back(pfCand.numberOfPixelHits());
 		pfcands_firsthit->push_back(pfCand.firstHit());
@@ -172,6 +174,7 @@ public:
 		iEvent.put(std::move(trks_quality                ), "trksquality");
 		iEvent.put(std::move(trks_hitpattern             ), "trkshitpattern");
 		iEvent.put(std::move(trks_matchedtopfcand        ), "trksmatchedtopfcand");
+		iEvent.put(std::move(pfcands_energy              ), "pfcandsenergy");
 		iEvent.put(std::move(pfcands_numberofhits        ), "pfcandsnumberofhits");
 		iEvent.put(std::move(pfcands_numberofpixelhits   ), "pfcandsnumberofpixelhits");
 		iEvent.put(std::move(pfcands_firsthit            ), "pfcandsfirsthit");
@@ -238,6 +241,7 @@ public:
 		applyPermutationInPlace(trks_quality,idx);
 		applyPermutationInPlace(trks_hitpattern,idx);
 		applyPermutationInPlace(trks_matchedtopfcand,idx);
+		applyPermutationInPlace(pfcands_energy,idx);
 		applyPermutationInPlace(pfcands_numberofhits,idx);
 		applyPermutationInPlace(pfcands_numberofpixelhits,idx);
 		applyPermutationInPlace(pfcands_firsthit,idx);
@@ -252,8 +256,8 @@ public:
 	std::unique_ptr<vector<math::XYZPoint>> trks_referencepoint;
 	std::unique_ptr<vector<bool>> trks_matchedtopfcand;
 	std::unique_ptr<vector<double>> trks_dzpv,trks_dzerrorpv,trks_dxypv,trks_dxyerrorpv,trks_normalizedchi2,trks_pterror,trks_etaerror,
-									trks_phierror,trks_qoverperror,trks_ip2d,trks_ip2dsig,trks_ip3d,trks_ip3dsig, pfcands_dzassociatedpv,
-									vtx_sumtrackpt2;
+									trks_phierror,trks_qoverperror,trks_ip2d,trks_ip2dsig,trks_ip3d,trks_ip3dsig, pfcands_energy,
+									pfcands_dzassociatedpv, vtx_sumtrackpt2;
 	std::unique_ptr<vector<int>> trks_chg, trks_found, trks_lost, trks_quality, pfcands_numberofhits, pfcands_numberofpixelhits,
 								 pfcands_firsthit, pfcands_frompv, pfcands_pvassociationquality, pfcands_vtxidx;
 	std::unique_ptr<vector<vector<int>>> trks_hitpattern;
@@ -343,6 +347,7 @@ CandidateTrackFilter::CandidateTrackFilter(const edm::ParameterSet& iConfig) :
 	produces<vector<int> >                  ("trksquality");
 	produces<vector<vector<int>> >          ("trkshitpattern");
 	produces<vector<bool> >                 ("trksmatchedtopfcand");
+	produces<vector<double> >               ("pfcandsenergy");
 	produces<vector<int> >                  ("pfcandsnumberofhits");
 	produces<vector<int> >                  ("pfcandsnumberofpixelhits");
 	produces<vector<int> >                  ("pfcandsfirsthit");


### PR DESCRIPTION
This PR adds the PFCandidate energy to the ntuple. This variable is needed for the GNN-based EMJ tagger which is based on ParticleNet. This PR adds roughly 5.8% to the size of the ntuple. While this is a sizeable amount, it is understandable given that this quantity will be saved for every track in the event.