### PR TITLE
[Run2_2017] Fix a bug with the CI/CD in GitHub and GitLab

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -83,7 +83,7 @@ jobs:
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
         integration_test_image: treemaker/treemaker:${{ env.current_branch }}-latest
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker
-      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd ${{ env.cmssw_ver }}/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99 && rm ${{ env.file_name }} && cd ${HOME}"
+      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "pushd . && cd ${{ env.cmssw_ver }}/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99 && rm ${{ env.file_name }} && popd"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ before_script:
     variables:
         DOCKER_DRIVER: overlay2
         NO_CACHE: "true"
+        CONTAINER_HOME: "/home/cmsusr/"
     script:
         - echo --------- OUTER CONTAINER -------------
         - pwd
@@ -29,7 +30,7 @@ before_script:
         - docker info
         - sleep 300
         - echo --------- INNER CONTAINER -------------
-        - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:/home/cmsusr/workdir/ ${BASE_IMAGE} -- -i -c "tar -czf ${CMSSW_VERSION}.tar.gz --exclude .git* ${CMSSW_VERSION} && mv ${CMSSW_VERSION}.tar.gz ${HOME}/workdir/  && cd ${HOME}/workdir/ && pwd && ls -alh ./ && cd ${HOME}"
+        - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:${CONTAINER_HOME}/workdir/ ${BASE_IMAGE} -- -i -c "tar -czf ${CMSSW_VERSION}.tar.gz --exclude .git* ${CMSSW_VERSION} && mv ${CMSSW_VERSION}.tar.gz ${CONTAINER_HOME}/workdir/  && cd ${CONTAINER_HOME}/workdir/ && pwd && ls -alh ./ && cd ${CONTAINER_HOME}"
         - echo --------- OUTER CONTAINER -------------
         - pwd
         - ls -alh ./


### PR DESCRIPTION
GitLab CI/CD and GitHub Actions both override the HOME environment variable inside of containers, so that is not a safe variable to use (https://github.com/actions/runner/issues/863). Inside, this PR uses other workarounds for these variables. This fixes unforeseen bugs which were introduced in #575.