### PR TITLE
add r/f scale uncertainty recalculation for pythia-only

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -3,6 +3,7 @@
 
 import FWCore.ParameterSet.Config as cms
 import sys,os
+
 def makeTreeFromMiniAOD(self,process):
 
     ## ----------------------------------------------------------------------------------------------
@@ -13,6 +14,7 @@ def makeTreeFromMiniAOD(self,process):
     
     # files to process
     import FWCore.PythonUtilities.LumiList as LumiList
+    from TreeMaker.TreeMaker.TMEras import TMeras
     process.maxEvents = cms.untracked.PSet(
         input = cms.untracked.int32(self.numevents)
     )
@@ -95,12 +97,16 @@ def makeTreeFromMiniAOD(self,process):
         from TreeMaker.Utils.pdfweightproducer_cfi import PDFWeightProducer
         process.PDFWeights = PDFWeightProducer.clone(
             recalculatePDFs = cms.bool(self.signal),
+            recalculateScales = cms.bool(False),
             normalize = (not "SVJ" in self.sample), # skip normalization only for SVJ signals
             pdfSetName = cms.string("NNPDF31_lo_as_0130"),
         )
         if "SVJ" in self.sample: # skip trying to get scale and PDF weights for SVJ signals
             process.PDFWeights.nScales = 0
             process.PDFWeights.nPDFs = 0
+            process.PDFWeights.nEM = 2
+            process.PDFWeights.recalculateScales = True
+        TMeras.TM2016.toModify(process.PDFWeights, pdfSetName = cms.string("NNPDF23_lo_as_0130_qed"))
         self.VectorDouble.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights','PDFWeights:PSweights'])
 
     ## ----------------------------------------------------------------------------------------------
@@ -249,7 +255,6 @@ def makeTreeFromMiniAOD(self,process):
         levels  = ['L1FastJet','L2Relative','L3Absolute']
         if self.residual: levels.append('L2L3Residual')
         
-        from TreeMaker.TreeMaker.TMEras import TMeras
         from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
         
         # rerun DeepCSV on AK4 jets for 2016 80X MC

--- a/Utils/BuildFile.xml
+++ b/Utils/BuildFile.xml
@@ -22,5 +22,6 @@
 <use name="rootmath"/>
 <use name="lhapdf"/>
 <use name="fastjet"/>
+<use name="pythia8"/>
 <use name="PhysicsTools/Heppy"/>
 <flags   EDM_PLUGIN="1"/>

--- a/Utils/python/pdfweightproducer_cfi.py
+++ b/Utils/python/pdfweightproducer_cfi.py
@@ -4,7 +4,10 @@ PDFWeightProducer = cms.EDProducer("PDFWeightProducer",
     nScales = cms.uint32(9),
     nPDFs = cms.uint32(100),
     nPSs = cms.uint32(14),
+    nQCD = cms.uint32(0),
+    nEM = cms.uint32(0),
     normalize = cms.bool(True),
+    pythiaSettings = cms.vstring(),
 )
 
 from TreeMaker.TreeMaker.TMEras import TMeras

--- a/Utils/python/pdfweightproducer_cfi.py
+++ b/Utils/python/pdfweightproducer_cfi.py
@@ -8,6 +8,7 @@ PDFWeightProducer = cms.EDProducer("PDFWeightProducer",
     nEM = cms.uint32(0),
     normalize = cms.bool(True),
     pythiaSettings = cms.vstring(),
+    debug = cms.bool(False),
 )
 
 from TreeMaker.TreeMaker.TMEras import TMeras

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -2,6 +2,8 @@
 #include <cmath>
 #include <memory>
 #include <mutex>
+#include <vector>
+#include <string>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -12,11 +14,13 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
+#include "FWCore/Utilities/interface/Exception.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 #include "TVector2.h"
+
+#include <Pythia8/Pythia.h>
 
 enum class wtype { scale = 0, pdf = 1, ps = 2 };
 
@@ -81,12 +85,13 @@ private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
   // ----------member data ---------------------------
-  unsigned nScales_, nPDFs_, nPSs_;
-  bool norm_, recalculatePDFs_;
+  unsigned nScales_, nPDFs_, nPSs_, nQCD_, nEM_;
+  bool norm_, recalculatePDFs_, recalculateScales_;
   std::string pdfSetName_;
   edm::GetterOfProducts<LHEEventProduct> getterOfProducts_;
   edm::EDGetTokenT<GenEventInfoProduct> genProductToken_;
   static std::mutex mutex_;
+  std::unique_ptr<Pythia8::Pythia> pythia_;
 };
 
 std::mutex PDFWeightProducer::mutex_;
@@ -95,8 +100,11 @@ PDFWeightProducer::PDFWeightProducer(const edm::ParameterSet& iConfig) :
   nScales_(iConfig.getParameter<unsigned>("nScales")),
   nPDFs_(iConfig.getParameter<unsigned>("nPDFs")),
   nPSs_(iConfig.getParameter<unsigned>("nPSs")),
+  nQCD_(iConfig.getParameter<unsigned>("nQCD")),
+  nEM_(iConfig.getParameter<unsigned>("nEM")),
   norm_(iConfig.getParameter<bool>("normalize")),
   recalculatePDFs_(iConfig.getParameter<bool>("recalculatePDFs")),
+  recalculateScales_(iConfig.getParameter<bool>("recalculateScales")),
   getterOfProducts_(edm::ProcessMatch("*"), this), 
   genProductToken_(consumes<GenEventInfoProduct>(edm::InputTag("generator")))
 {
@@ -104,6 +112,19 @@ PDFWeightProducer::PDFWeightProducer(const edm::ParameterSet& iConfig) :
   if(!pdfSetName_.empty()){
      LHAPDF::initPDFSet(1,pdfSetName_);
      LHAPDF::setVerbosity(0);
+  }
+  if(recalculateScales_){
+    pythia_ = std::make_unique<Pythia8::Pythia>("../share/Pythia8/xmldoc",false);
+    //from https://github.com/cms-sw/cmssw/blob/master/FastSimulation/ParticleDecay/src/PythiaDecays.cc
+    pythia_->settings.flag("ProcessLevel:all", false);
+    pythia_->settings.flag("Print:quiet", true);
+    //following https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+    const auto& manual_settings = iConfig.getParameter<std::vector<std::string>>("pythiaSettings");
+    for(const auto& s : manual_settings){
+      if(!pythia_->readString(s))
+        throw cms::Exception("PythiaError") << "Pythia 8 did not accept \"" << s << "\"." << std::endl;
+    }
+    pythia_->init();
   }
 
   callWhenNewProductsRegistered(getterOfProducts_);
@@ -164,24 +185,15 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
     }
 
     //if pdf weights still not found, recalculate them
-    //taken from https://github.com/cms-sw/cmssw/blob/master/ElectroWeakAnalysis/Utilities/src/PdfWeightProducer.cc
-    //not sure what to do about missing scale weights
+    //taken from https://github.com/cms-sw/cmssw/blob/CMSSW_10_2_X/ElectroWeakAnalysis/Utilities/src/PdfWeightProducer.cc
     if(!found_pdfs and recalculatePDFs_){
       float Q = genHandle->pdf()->scalePDF;
 
       int id1 = genHandle->pdf()->id.first;
       double x1 = genHandle->pdf()->x.first;
-      double pdf1 = genHandle->pdf()->xPDF.first;
 
       int id2 = genHandle->pdf()->id.second;
       double x2 = genHandle->pdf()->x.second;
-      double pdf2 = genHandle->pdf()->xPDF.second;
-      if(pdf1 <= 0 && pdf2 <= 0) {
-         std::lock_guard<std::mutex> lock(mutex_);
-         LHAPDF::usePDFMember(1,0);
-         pdf1 = LHAPDF::xfx(1, x1, Q, id1)/x1;
-         pdf2 = LHAPDF::xfx(1, x2, Q, id2)/x2;
-      }
 
       unsigned nweights = 1;
       if(LHAPDF::numberPDF(1)>1) nweights += LHAPDF::numberPDF(1);
@@ -200,6 +212,70 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
         }
       }
       found_pdfs = true;
+    }
+
+    //if rf scale weights still not found, recalculate them
+    //based on https://gitlab.cern.ch/cms-desy-top/TopAnalysis/-/blob/Htottbar_2016/ZTopUtils/plugins/EventWeightMCSystematicRecalc.cc
+    if(!found_scales and recalculateScales_){
+      double kUp = 2;
+      double kDn = 0.5;
+      float Q = genHandle->pdf()->scalePDF;
+
+      //factorization scale
+      int id1 = genHandle->pdf()->id.first;
+      double x1 = genHandle->pdf()->x.first;
+
+      int id2 = genHandle->pdf()->id.second;
+      double x2 = genHandle->pdf()->x.second;
+
+      double pdf1, pdf1up, pdf1dn;
+      double pdf2, pdf2up, pdf2dn;
+      {
+         std::lock_guard<std::mutex> lock(mutex_);
+         LHAPDF::usePDFMember(1,0);
+         pdf1 = LHAPDF::xfx(1, x1, Q, id1)/x1;
+         pdf2 = LHAPDF::xfx(1, x2, Q, id2)/x2;
+         pdf1up = LHAPDF::xfx(1, x1, kUp*Q, id1)/x1;
+         pdf2up = LHAPDF::xfx(1, x2, kUp*Q, id2)/x2;
+         pdf1dn = LHAPDF::xfx(1, x1, kDn*Q, id1)/x1;
+         pdf2dn = LHAPDF::xfx(1, x2, kDn*Q, id2)/x2;
+      }
+      //for debugging
+      //std::cout << "pdf1 = " << pdf1 << ", pdf1up = " << pdf1up << ", pdf1dn = " << pdf1dn << ", pdf2 = " << pdf2 << ", pdf2up = " << pdf2up << ", pdf2dn = " << pdf2dn << std::endl;
+
+      double weightFacUp = (pdf1up*pdf2up)/(pdf1*pdf2);
+      double weightFacDn = (pdf1dn*pdf2dn)/(pdf1*pdf2);
+
+      //renormalization scale
+      //compute directly from Pythia for consistency
+      auto coup = pythia_->couplingsPtr;
+      double Q2 = Q*Q;
+      double alpEM = coup->alphaEM(Q2);
+      double alpEMup = coup->alphaEM(kUp*kUp*Q2);
+      double alpEMdn = coup->alphaEM(kDn*kDn*Q2);
+      double alpS = coup->alphaS(Q2);
+      double alpSup = coup->alphaS(kUp*kUp*Q2);
+      double alpSdn = coup->alphaS(kDn*kDn*Q2);
+      //for debugging
+      //std::cout << "alpEM = " << alpEM << ", alpEMup = " << alpEMup << ", alpEMdn = " << alpEMdn << ", alpS = " << alpS << ", alpSup = " << alpSup << ", alpSdn = " << alpSdn << std::endl;
+
+      //weights require process-dependent information about number of QCD and EM vertices
+      double weightRenUp = std::pow(alpEMup/alpEM, nEM_) * std::pow(alpSup/alpS, nQCD_);
+      double weightRenDn = std::pow(alpEMdn/alpEM, nEM_) * std::pow(alpSdn/alpS, nQCD_);
+
+      //compute all variations to be consistent w/ what madgraph provides:
+      //[mur=1, muf=1], [mur=1, muf=2], [mur=1, muf=0.5], [mur=2, muf=1], [mur=2, muf=2], [mur=2, muf=0.5], [mur=0.5, muf=1], [mur=0.5, muf=2], [mur=0.5, muf=0.5]
+      *scaleweights = {
+        1.0,
+        weightFacUp,
+        weightFacDn,
+        weightRenUp,
+        weightRenUp*weightFacUp,
+        weightRenUp*weightFacDn,
+        weightRenDn,
+        weightRenDn*weightFacUp,
+        weightRenDn*weightFacDn
+      };
     }
   }
 

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -86,7 +86,7 @@ private:
   
   // ----------member data ---------------------------
   unsigned nScales_, nPDFs_, nPSs_, nQCD_, nEM_;
-  bool norm_, recalculatePDFs_, recalculateScales_;
+  bool norm_, recalculatePDFs_, recalculateScales_, debug_;
   std::string pdfSetName_;
   edm::GetterOfProducts<LHEEventProduct> getterOfProducts_;
   edm::EDGetTokenT<GenEventInfoProduct> genProductToken_;
@@ -105,6 +105,7 @@ PDFWeightProducer::PDFWeightProducer(const edm::ParameterSet& iConfig) :
   norm_(iConfig.getParameter<bool>("normalize")),
   recalculatePDFs_(iConfig.getParameter<bool>("recalculatePDFs")),
   recalculateScales_(iConfig.getParameter<bool>("recalculateScales")),
+  debug_(iConfig.getParameter<bool>("debug")),
   getterOfProducts_(edm::ProcessMatch("*"), this), 
   genProductToken_(consumes<GenEventInfoProduct>(edm::InputTag("generator")))
 {
@@ -240,8 +241,8 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
          pdf1dn = LHAPDF::xfx(1, x1, kDn*Q, id1)/x1;
          pdf2dn = LHAPDF::xfx(1, x2, kDn*Q, id2)/x2;
       }
-      //for debugging
-      //std::cout << "pdf1 = " << pdf1 << ", pdf1up = " << pdf1up << ", pdf1dn = " << pdf1dn << ", pdf2 = " << pdf2 << ", pdf2up = " << pdf2up << ", pdf2dn = " << pdf2dn << std::endl;
+      if(debug_)
+        edm::LogInfo("TreeMaker") << "PDFWeightProducer: pdf1 = " << pdf1 << ", pdf1up = " << pdf1up << ", pdf1dn = " << pdf1dn << ", pdf2 = " << pdf2 << ", pdf2up = " << pdf2up << ", pdf2dn = " << pdf2dn << std::endl;
 
       double weightFacUp = (pdf1up*pdf2up)/(pdf1*pdf2);
       double weightFacDn = (pdf1dn*pdf2dn)/(pdf1*pdf2);
@@ -256,8 +257,8 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       double alpS = coup->alphaS(Q2);
       double alpSup = coup->alphaS(kUp*kUp*Q2);
       double alpSdn = coup->alphaS(kDn*kDn*Q2);
-      //for debugging
-      //std::cout << "alpEM = " << alpEM << ", alpEMup = " << alpEMup << ", alpEMdn = " << alpEMdn << ", alpS = " << alpS << ", alpSup = " << alpSup << ", alpSdn = " << alpSdn << std::endl;
+      if(debug_)
+        edm::LogInfo("TreeMaker") << "PDFWeightProducer: alpEM = " << alpEM << ", alpEMup = " << alpEMup << ", alpEMdn = " << alpEMdn << ", alpS = " << alpS << ", alpSup = " << alpSup << ", alpSdn = " << alpSdn << std::endl;
 
       //weights require process-dependent information about number of QCD and EM vertices
       double weightRenUp = std::pow(alpEMup/alpEM, nEM_) * std::pow(alpSup/alpS, nQCD_);


### PR DESCRIPTION
This PR adds the capability to recalculate renormalization and factorization scale uncertainties for MC samples generated with Pythia only.

The renormalization scale calculation relies on user input regarding the number of EM and QCD vertices in the physics process. Pythia functions are used directly to calculate the EM and strong couplings to ensure consistency.

Also, a bug is fixed: the 2017/18 PDF set was also used for 2016 by default, but 2016 MC uses a different PDF set.