### PR TITLE
[Run2_UL] Update the GitHub Actions and GitLab Pipeline scripts

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -83,7 +83,7 @@ jobs:
         output_name: Summer16.QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_opendata
         integration_test_image: treemaker/treemaker:${{ env.current_branch }}-latest
         docker_options: -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --name treemaker
-      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd ${{ env.cmssw_ver }}/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99 && rm ${{ env.file_name }} && cd /home/cmsuser/"
+      run: docker run ${{ env.docker_options }} ${{ env.integration_test_image }} -- -i -c "cd ${{ env.cmssw_ver }}/src/ && cmsenv && cd TreeMaker/Production/test/ && wget ${{ env.download_url }} -O ${{ env.file_name }} && python unitTest.py test=0 scenario=${{ env.era }} dataset=file:${{ env.file_name }} name=${{ env.output_name }} run=True fork=False log=False clean=99 && rm ${{ env.file_name }} && cd ${HOME}"
     - name: Commit the changes
       run: docker commit -c 'ENTRYPOINT ["/run.sh"]' -c 'CMD []' treemaker treemaker/treemaker:${{ env.current_branch }}-cache
     - name: Log into registry

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ before_script:
         - docker info
         - sleep 300
         - echo --------- INNER CONTAINER -------------
-        - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:/home/cmsuser/workdir/ ${BASE_IMAGE} -- -i -c "tar -czf ${CMSSW_VERSION}.tar.gz --exclude .git* ${CMSSW_VERSION} && mv ${CMSSW_VERSION}.tar.gz /home/cmsuser/workdir/  && cd /home/cmsuser/workdir/ && pwd && ls -alh ./ && cd /home/cmsuser/"
+        - docker run --rm -i -e CVMFS_MOUNTS="none" -v ${PWD}/:/home/cmsusr/workdir/ ${BASE_IMAGE} -- -i -c "tar -czf ${CMSSW_VERSION}.tar.gz --exclude .git* ${CMSSW_VERSION} && mv ${CMSSW_VERSION}.tar.gz ${HOME}/workdir/  && cd ${HOME}/workdir/ && pwd && ls -alh ./ && cd ${HOME}"
         - echo --------- OUTER CONTAINER -------------
         - pwd
         - ls -alh ./


### PR DESCRIPTION
This PR makes two changes:
1. Change cmsuser to cmsusr in the GitLab pipeline yaml file.
2. Use the HOME variable to reduce the dependence on the exact home path of the system. This is helpful both for the GitLab pipeline and for the jobs within the GitHub action.

These changes mirror those made in #575, but for the Run2_UL branch.