### PR TITLE
[Run2_UL] Update to CMSSW_10_6_29

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,5 @@
 # Make the base image configurable:
-ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_25-2021-05-20-563715a3
+ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-05-20-563715a3
 
 # Set up the CMSSW base:
 FROM ${BASEIMAGE}
@@ -21,7 +21,7 @@ LABEL   org.label-schema.build-date=$BUILD_DATE \
 USER    cmsusr
 WORKDIR /home/cmsusr
 
-ARG CMSSW_VERSION=CMSSW_10_6_25
+ARG CMSSW_VERSION=CMSSW_10_6_29
 
 COPY .docker/setupStandalone.sh ./setupStandalone.sh
 COPY ${CMSSW_VERSION}.tar.gz ./${CMSSW_VERSION}.tar.gz

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,5 @@
 # Make the base image configurable:
-ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-05-20-563715a3
+ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-12-03-857162bc
 
 # Set up the CMSSW base:
 FROM ${BASEIMAGE}

--- a/.docker/setupStandalone.sh
+++ b/.docker/setupStandalone.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-CMSSWVER=CMSSW_10_6_25
+CMSSWVER=CMSSW_10_6_29
 DIR="${HOME}"
 TARBALL=""
 URL=""

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,7 +10,7 @@ on:
 env:
   current_branch: $(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')
   current_user: ${{ github.actor }}
-  cmssw_ver: CMSSW_10_6_25
+  cmssw_ver: CMSSW_10_6_29
 
 jobs:
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ tar_treemaker_Run2_UL:
     extends: .job_template_tar
     variables:
         BASE_IMAGE: index.docker.io/treemaker/treemaker:Run2_UL-latest
-        CMSSW_VERSION: CMSSW_10_6_25
+        CMSSW_VERSION: CMSSW_10_6_29
 
 build_treemaker_Run2_UL-standalone:
     extends: .job_template_build
@@ -84,7 +84,7 @@ build_treemaker_Run2_UL-standalone:
     variables:
         BRANCH_NAME: Run2_UL
         SUFFIX: standalone
-        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_25-2021-05-20-563715a3
-        CMSSW_VERSION: CMSSW_10_6_25
+        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-05-20-563715a3
+        CMSSW_VERSION: CMSSW_10_6_29
         DOCKER_GROUP: treemaker
         DOCKER_REGISTRY: https://index.docker.io/v1/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ build_treemaker_Run2_UL-standalone:
     variables:
         BRANCH_NAME: Run2_UL
         SUFFIX: standalone
-        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-05-20-563715a3
+        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-12-03-857162bc
         CMSSW_VERSION: CMSSW_10_6_29
         DOCKER_GROUP: treemaker
         DOCKER_REGISTRY: https://index.docker.io/v1/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following installation instructions assume the user wants to process Run 2 u
 wget https://raw.githubusercontent.com/TreeMaker/TreeMaker/Run2_UL/setup.sh
 chmod +x setup.sh
 ./setup.sh
-cd CMSSW_10_6_25/src/
+cd CMSSW_10_6_29/src/
 cmsenv
 cd TreeMaker/Production/test
 ```
@@ -33,10 +33,10 @@ The script [setup.sh](./setup.sh) has options to allow installing a different fo
 * `-f [fork]`: which fork to download (`git@github.com:fork/TreeMaker.git`, default = TreeMaker)
 * `-b [branch]`: which branch to download (`-b branch`, default = Run2_UL)
 * `-B`: configure some settings for checkout within batch setups
-* `-c [version]`: which CMSSW version to use (default = CMSSW_10_6_25)
+* `-c [version]`: which CMSSW version to use (default = CMSSW_10_6_29)
 * `-a [protocol]`: which protocol to use for `git clone` (default = ssh, alternative = https)
 * `-j [cores]`: run CMSSW compilation on # cores (default = 8)
-* `-n [name]`: name of the CMSSW directory if not CMSSW_X_Y_Z (default = CMSSW_10_6_25)
+* `-n [name]`: name of the CMSSW directory if not CMSSW_X_Y_Z (default = CMSSW_10_6_29)
 * `-d [dir]`: project installation area for the CMSSW directory (default = ${PWD})
 * `-D`: print additional debug statements (default = false)
 * `-h`: display help message and exit

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-CMSSWVER=CMSSW_10_6_25
+CMSSWVER=CMSSW_10_6_29
 FORK=TreeMaker
 BRANCH=Run2_UL
 ACCESS=ssh


### PR DESCRIPTION
Update the CMSSW version from 10_6_25 to 10_6_29 in order to take advantage of some updates to the PDF sets in 10_6_29. I have already setup TreeMaker within CMSSW_10_6_29, so I know that the code will compile and run. I have also created the [standalone docker image](gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-12-03-857162bc) needed by some of the CI jobs.