### PR TITLE
[Run2_UL] Update the PDF Weight Code

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -117,13 +117,19 @@ def makeTreeFromMiniAOD(self,process):
         process.PDFWeights = PDFWeightProducer.clone(
             recalculatePDFs = cms.bool(self.signal),
             recalculateScales = cms.bool(False),
-            normalize = (not "SVJ" in self.sample), # skip normalization only for SVJ signals
+            normalize = (not any(s in self.sample for s in ["SVJ","EMJ"])), # skip normalization only for SVJ and EMJ signals
             pdfSetName = cms.string("NNPDF31_nlo_as_0118"),
         )
         if "SVJ" in self.sample: # skip trying to get scale and PDF weights for SVJ signals
             process.PDFWeights.nScales = 0
             process.PDFWeights.nPDFs = 0
             process.PDFWeights.nEM = 2
+            process.PDFWeights.recalculateScales = True
+        if "EMJ" in self.sample: # skip trying to get scale and PDF weights for EMJ signals
+            process.PDFWeights.nScales = 0
+            process.PDFWeights.nPDFs = 0
+            process.PDFWeights.nQCD = 2
+            process.PDFWeights.nEM = 0
             process.PDFWeights.recalculateScales = True
         self.VectorFloat.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights','PDFWeights:PSweights'])
 

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -192,9 +192,11 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
 
       int id1 = genHandle->pdf()->id.first;
       double x1 = genHandle->pdf()->x.first;
+      id1 = std::abs(id1) == 21 ? 0 : id1;
 
       int id2 = genHandle->pdf()->id.second;
       double x2 = genHandle->pdf()->x.second;
+      id2 = std::abs(id2) == 21 ? 0 : id2;
 
       unsigned nweights = 1;
       if(LHAPDF::numberPDF(1)>1) nweights += LHAPDF::numberPDF(1);
@@ -210,6 +212,12 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
           pdfweights->push_back(newpdf1*newpdf2);
           if(i==0 and norm_) norm = 1/pdfweights->back();
           pdfweights->back() *= norm;
+          if(debug_) {
+            edm::LogInfo("TreeMaker") << "PDFWeightProducer: index = " << i << ", x1 = " << x1 << ", x2 = " << x2
+                                      << ", Q = " << Q << ", id1 = " << id1 << ", id2 = " << id2
+                                      << ", newpdf1 = " << newpdf1 << ", newpdf2 = " << newpdf2
+                                      << ", norm = " << norm << ", pdfweight = " << pdfweights->back() << std::endl;
+          }
         }
       }
       found_pdfs = true;
@@ -225,9 +233,11 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       //factorization scale
       int id1 = genHandle->pdf()->id.first;
       double x1 = genHandle->pdf()->x.first;
+      id1 = std::abs(id1) == 21 ? 0 : id1;
 
       int id2 = genHandle->pdf()->id.second;
       double x2 = genHandle->pdf()->x.second;
+      id2 = std::abs(id2) == 21 ? 0 : id2;
 
       double pdf1, pdf1up, pdf1dn;
       double pdf2, pdf2up, pdf2dn;
@@ -242,7 +252,10 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
          pdf2dn = LHAPDF::xfx(1, x2, kDn*Q, id2)/x2;
       }
       if(debug_)
-        edm::LogInfo("TreeMaker") << "PDFWeightProducer: pdf1 = " << pdf1 << ", pdf1up = " << pdf1up << ", pdf1dn = " << pdf1dn << ", pdf2 = " << pdf2 << ", pdf2up = " << pdf2up << ", pdf2dn = " << pdf2dn << std::endl;
+        edm::LogInfo("TreeMaker") << "PDFWeightProducer: x1 = " << x1 << ", x2 = " << x2 << ", Q = " << Q
+                                  << ", id1 = " << id1 << ", id2 = " << id2 << ", kUp = " << kUp << ", pdf1 = " << pdf1
+                                  << ", pdf1up = " << pdf1up << ", pdf1dn = " << pdf1dn << ", pdf2 = " << pdf2
+                                  << ", pdf2up = " << pdf2up << ", pdf2dn = " << pdf2dn << std::endl;
 
       float weightFacUp = (pdf1up*pdf2up)/(pdf1*pdf2);
       float weightFacDn = (pdf1dn*pdf2dn)/(pdf1*pdf2);
@@ -258,7 +271,9 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       double alpSup = coup->alphaS(kUp*kUp*Q2);
       double alpSdn = coup->alphaS(kDn*kDn*Q2);
       if(debug_)
-        edm::LogInfo("TreeMaker") << "PDFWeightProducer: alpEM = " << alpEM << ", alpEMup = " << alpEMup << ", alpEMdn = " << alpEMdn << ", alpS = " << alpS << ", alpSup = " << alpSup << ", alpSdn = " << alpSdn << std::endl;
+        edm::LogInfo("TreeMaker") << "PDFWeightProducer: alpEM = " << alpEM << ", alpEMup = " << alpEMup
+                                  << ", alpEMdn = " << alpEMdn << ", alpS = " << alpS << ", alpSup = " << alpSup\
+                                  << ", alpSdn = " << alpSdn << std::endl;
 
       //weights require process-dependent information about number of QCD and EM vertices
       float weightRenUp = std::pow(alpEMup/alpEM, nEM_) * std::pow(alpSup/alpS, nQCD_);

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -82,6 +82,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  int lhapdfPDGID(const int pdgid) const { return std::abs(pdgid) == 21 ? 0 : pdgid; }
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
   // ----------member data ---------------------------
@@ -190,13 +191,11 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
     if(!found_pdfs and recalculatePDFs_){
       float Q = genHandle->pdf()->scalePDF;
 
-      int id1 = genHandle->pdf()->id.first;
+      int id1 = lhapdfPDGID(genHandle->pdf()->id.first);
       double x1 = genHandle->pdf()->x.first;
-      id1 = std::abs(id1) == 21 ? 0 : id1;
 
-      int id2 = genHandle->pdf()->id.second;
+      int id2 = lhapdfPDGID(genHandle->pdf()->id.second);
       double x2 = genHandle->pdf()->x.second;
-      id2 = std::abs(id2) == 21 ? 0 : id2;
 
       unsigned nweights = 1;
       if(LHAPDF::numberPDF(1)>1) nweights += LHAPDF::numberPDF(1);
@@ -231,13 +230,11 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       float Q = genHandle->pdf()->scalePDF;
 
       //factorization scale
-      int id1 = genHandle->pdf()->id.first;
+      int id1 = lhapdfPDGID(genHandle->pdf()->id.first);
       double x1 = genHandle->pdf()->x.first;
-      id1 = std::abs(id1) == 21 ? 0 : id1;
 
-      int id2 = genHandle->pdf()->id.second;
+      int id2 = lhapdfPDGID(genHandle->pdf()->id.second);
       double x2 = genHandle->pdf()->x.second;
-      id2 = std::abs(id2) == 21 ? 0 : id2;
 
       double pdf1, pdf1up, pdf1dn;
       double pdf2, pdf2up, pdf2dn;
@@ -272,7 +269,7 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       double alpSdn = coup->alphaS(kDn*kDn*Q2);
       if(debug_)
         edm::LogInfo("TreeMaker") << "PDFWeightProducer: alpEM = " << alpEM << ", alpEMup = " << alpEMup
-                                  << ", alpEMdn = " << alpEMdn << ", alpS = " << alpS << ", alpSup = " << alpSup\
+                                  << ", alpEMdn = " << alpEMdn << ", alpS = " << alpS << ", alpSup = " << alpSup
                                   << ", alpSdn = " << alpSdn << std::endl;
 
       //weights require process-dependent information about number of QCD and EM vertices


### PR DESCRIPTION
Make sure the PDF and scale weights are recalculated when running over EMJ samples. Also update the PDFWeightProducer to correctly handle when the incoming partons are gluons. Rather than setting the pdgid to 21, as is the usual convention, the LHAPDF code wants the pdgid to be 0, as in [-5, -4, -3, -2, -1, 21, 1, 2, 3, 4, 5]. This is the same convention shown in the LHAPDF set for [NNPDF 3.1 NLO 0118](https://lhapdfsets.web.cern.ch/current/NNPDF31_nlo_as_0118/NNPDF31_nlo_as_0118.info). The idea for using 0 rather than 21 for the PDGID came from the [LHAPDF6 Design Guide](https://lhapdf.hepforge.org/design.html).

I did my best to confirm that the updated values are correct. I tried to make sure that the relative sizes of `newpdf1` and `newpdf2` were correct given `Q`, `x1`, `x2`, and Figure 3.1 (pg 23) from [arXiv:1706.00428](https://arxiv.org/pdf/1706.00428.pdf). As best I can tell, the values being returned are correct. 101 non-zero values are being returned for the PDF weights and 9 non-zero values are being returned for the scale weights.

This PR relies upon #597.