### PR TITLE
restrict gen-level hidden sector algorithms to SVJ signal samples

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1079,6 +1079,7 @@ def makeTreeFromMiniAOD(self,process):
     ## ----------------------------------------------------------------------------------------------
     if self.semivisible:
         process.HiddenSector = cms.EDProducer("HiddenSectorProducer",
+            signal = cms.bool(self.signal and "SVJ" in self.sample),
             JetTag = JetAK8Tag,
             MetTag = METTag,
             GenMetTag = cms.InputTag("genMetTrue"),
@@ -1086,15 +1087,13 @@ def makeTreeFromMiniAOD(self,process):
             GenJetTag = GenJetAK8Tag,
             coneSize = cms.double(0.8),
             DarkStableIDs = cms.vuint32(51,52,53),
-            DarkQuarkIDs = cms.vuint32(4900101),
-            DarkMediatorIDs = cms.vuint32(4900023),
+            DarkQuarkIDs = cms.vuint32(4900101,4900102),
+            DarkSMediatorIDs = cms.vuint32(4900023),
+            DarkTMediatorIDs = cms.vuint32(4900001,4900002,4900003,4900004,4900005,4900006),
             DarkHadronIDs = cms.vuint32(4900111,4900113,4900211,4900213),
             DarkGluonIDs = cms.vuint32(4900021),
             SMQuarkIDs = cms.vuint32(1,2,3,4,5,6),
         )
-        if self.tchannel:
-            process.HiddenSector.DarkQuarkIDs = [4900101,4900102]
-            process.HiddenSector.DarkMediatorIDs = [4900001,4900002,4900003,4900004,4900005,4900006]
         self.VarsDouble.extend([
             'HiddenSector:MJJ(MJJ_AK8)',
             'HiddenSector:Mmc(Mmc_AK8)',
@@ -1104,19 +1103,18 @@ def makeTreeFromMiniAOD(self,process):
             'HiddenSector:DeltaPhi2(DeltaPhi2_AK8)',
             'HiddenSector:DeltaPhiMin(DeltaPhiMin_AK8)',
         ])
-        if self.geninfo:
+        if self.geninfo and process.HiddenSector.signal:
             self.VectorBool.extend([
                 'HiddenSector:isHV(JetsAK8_isHV)'
             ])
-            if self.tchannel:
-                self.VectorInt.extend([
-                    'HiddenSector:hvCategory(GenJetsAK8_hvCategory)',
-                    'HiddenSector:MT2JetsID(GenJetsAK8_MT2JetsID)',
-                    'HiddenSector:genIndex(JetsAK8_genIndex)'
-                ])
-                self.VectorDouble.extend([
-                    'HiddenSector:darkPtFrac(GenJetsAK8_darkPtFrac)'
-                ])
+            self.VectorInt.extend([
+                'HiddenSector:hvCategory(GenJetsAK8_hvCategory)',
+                'HiddenSector:MT2JetsID(GenJetsAK8_MT2JetsID)',
+                'HiddenSector:genIndex(JetsAK8_genIndex)'
+            ])
+            self.VectorDouble.extend([
+                'HiddenSector:darkPtFrac(GenJetsAK8_darkPtFrac)'
+            ])
     ## ----------------------------------------------------------------------------------------------
     ## Photon information
     ## ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is both an optimization and a workaround for #600. The algorithms in `HiddenSectorProducer` that produce various gen-level jet IDs and related quantities for SVJ samples don't need to be run for SM samples (which won't contain any HV particles).

In addition, this PR removes some ambiguity in the module configuration. The `tchannel` flag is used to enable low-pT AK8 jet reclustering, which may be desired for any sample (signal, background, or data). However, this flag was also used to control some settings for the `HiddenSectorProducer` that were specific to t-channel SVJ signals, which is a different usage. The latter are now just controlled by the usual checks for an SVJ signal sample. Separate s- and t-channel mediator PDG ID lists are provided for the relevant algorithms so that everything can coexist.

attn: @jhiltbrand @Keane-Tan @cmadrid1