### PR TITLE
move to CMSSW_10_6_29_patch1

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,5 @@
 # Make the base image configurable:
-ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-12-03-857162bc
+ARG BASEIMAGE=gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29_patch1-2022-01-04-f15a56a0
 
 # Set up the CMSSW base:
 FROM ${BASEIMAGE}
@@ -21,7 +21,7 @@ LABEL   org.label-schema.build-date=$BUILD_DATE \
 USER    cmsusr
 WORKDIR /home/cmsusr
 
-ARG CMSSW_VERSION=CMSSW_10_6_29
+ARG CMSSW_VERSION=CMSSW_10_6_29_patch1
 
 COPY .docker/setupStandalone.sh ./setupStandalone.sh
 COPY ${CMSSW_VERSION}.tar.gz ./${CMSSW_VERSION}.tar.gz

--- a/.docker/setupStandalone.sh
+++ b/.docker/setupStandalone.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-CMSSWVER=CMSSW_10_6_29
+CMSSWVER=CMSSW_10_6_29_patch1
 DIR="${HOME}"
 TARBALL=""
 URL=""

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,7 +10,7 @@ on:
 env:
   current_branch: $(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')
   current_user: ${{ github.actor }}
-  cmssw_ver: CMSSW_10_6_29
+  cmssw_ver: CMSSW_10_6_29_patch1
 
 jobs:
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ tar_treemaker_Run2_UL:
     extends: .job_template_tar
     variables:
         BASE_IMAGE: index.docker.io/treemaker/treemaker:Run2_UL-latest
-        CMSSW_VERSION: CMSSW_10_6_29
+        CMSSW_VERSION: CMSSW_10_6_29_patch1
 
 build_treemaker_Run2_UL-standalone:
     extends: .job_template_build
@@ -84,7 +84,7 @@ build_treemaker_Run2_UL-standalone:
     variables:
         BRANCH_NAME: Run2_UL
         SUFFIX: standalone
-        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29-2021-12-03-857162bc
-        CMSSW_VERSION: CMSSW_10_6_29
+        BASE_IMAGE: gitlab-registry.cern.ch/treemaker/cmssw-docker/cmssw:CMSSW_10_6_29_patch1-2022-01-04-f15a56a0
+        CMSSW_VERSION: CMSSW_10_6_29_patch1
         DOCKER_GROUP: treemaker
         DOCKER_REGISTRY: https://index.docker.io/v1/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following installation instructions assume the user wants to process Run 2 u
 wget https://raw.githubusercontent.com/TreeMaker/TreeMaker/Run2_UL/setup.sh
 chmod +x setup.sh
 ./setup.sh
-cd CMSSW_10_6_29/src/
+cd CMSSW_10_6_29_patch1/src/
 cmsenv
 cd TreeMaker/Production/test
 ```
@@ -33,10 +33,10 @@ The script [setup.sh](./setup.sh) has options to allow installing a different fo
 * `-f [fork]`: which fork to download (`git@github.com:fork/TreeMaker.git`, default = TreeMaker)
 * `-b [branch]`: which branch to download (`-b branch`, default = Run2_UL)
 * `-B`: configure some settings for checkout within batch setups
-* `-c [version]`: which CMSSW version to use (default = CMSSW_10_6_29)
+* `-c [version]`: which CMSSW version to use (default = CMSSW_10_6_29_patch1)
 * `-a [protocol]`: which protocol to use for `git clone` (default = ssh, alternative = https)
 * `-j [cores]`: run CMSSW compilation on # cores (default = 8)
-* `-n [name]`: name of the CMSSW directory if not CMSSW_X_Y_Z (default = CMSSW_10_6_29)
+* `-n [name]`: name of the CMSSW directory if not CMSSW_X_Y_Z (default = CMSSW_10_6_29_patch1)
 * `-d [dir]`: project installation area for the CMSSW directory (default = ${PWD})
 * `-D`: print additional debug statements (default = false)
 * `-h`: display help message and exit

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-CMSSWVER=CMSSW_10_6_29
+CMSSWVER=CMSSW_10_6_29_patch1
 FORK=TreeMaker
 BRANCH=Run2_UL
 ACCESS=ssh
@@ -154,7 +154,6 @@ fi
 if [[ "$CMSSWVER" == "CMSSW_10_6_"* ]]; then
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:storeJERFactorIndex10620p1
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:AddJetAxis1_10620p1
-	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:SpeedupPuppi106X
 fi
 
 # outside repositories


### PR DESCRIPTION
The latest [10_6_X release](https://github.com/cms-sw/cmssw/releases/tag/CMSSW_10_6_29_patch1) includes my patch to speed up PUPPI. Moving to the new release means that we no longer have to merge and compile it in the local release area.