### PR TITLE
Add feature to reduce the precision of single-precision floating point values

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Brief explanation of the options in [maker.py](./TreeMaker/python/maker.py)
 * `storeOffsets`: if set to True, stores offsets rather than counts when using `nestedVectors=False` (default=False)
 * `splitLevel`: split level for output TBranches (default=99)
 * `saveFloat`: convert doubles to floats in output (default=True)
+* `reduceFloatPrecision`: reduce the precision of the mantissa in the single precision floating point values in the output tree to the specified number of bits (default=-1 (off), minimum=0, maximum=23)
 
 The following parameters take their default values from the specified scenario:
 * `globaltag`: global tag for CMSSW database conditions (ref. [FrontierConditions](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions))

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -68,6 +68,7 @@ def makeTreeFromMiniAOD(self,process):
         storeOffsets                   = self.storeOffsets,
         splitLevel                     = self.splitLevel,
         saveFloat                      = self.saveFloat,
+        reduceFloatPrecision           = self.reduceFloatPrecision,
     )
 
     ## ----------------------------------------------------------------------------------------------

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -64,6 +64,7 @@ class maker:
         self.getParamDefault("storeOffsets", False, bool)
         self.getParamDefault("splitLevel", 99)
         self.getParamDefault("saveFloat", True, bool)
+        self.getParamDefault("reduceFloatPrecision", -1)
 
         # take command line input (w/ defaults from scenario if specified)
         self.getParamDefault("globaltag",self.scenario.globaltag)
@@ -172,6 +173,7 @@ class maker:
         else: print " Saving nested vectors as vector<T> + vector<int>"
         print " TTree split level: "+str(self.splitLevel)
         if self.saveFloat: print " Converting doubles to floats in output"
+        if self.reduceFloatPrecision >= 0 : print " Reducing the precision of the mantissa in the single precision floating point outputs to " + str(self.reduceFloatPrecision) + " bits"
         print " "
         print " scenario: "+self.scenarioName
         print " global tag: "+self.globaltag

--- a/TreeMaker/python/treeMaker.py
+++ b/TreeMaker/python/treeMaker.py
@@ -20,6 +20,8 @@ storeOffsets = cms.bool(False),
 splitLevel = cms.int32(0),
 #convert doubles to floats in output
 saveFloat = cms.bool(False),
+#reduce the mantissa in the single precision floating point values in the output
+reduceFloatPrecision = cms.int32(-1),
 # list of reco candidate objects: for each reco cand collection, the math::LorentzVector will be stored in a vector.
 VarsBool = cms.vstring(),
 VarsInt = cms.vstring(),

--- a/TreeMaker/src/TreeMaker.cc
+++ b/TreeMaker/src/TreeMaker.cc
@@ -55,6 +55,7 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 	storeOffsets = iConfig.getParameter<bool>("storeOffsets");
 	splitLevel = iConfig.getParameter<int>("splitLevel");
 	saveFloat = iConfig.getParameter<bool>("saveFloat");
+	reduceFloatPrecision = iConfig.getParameter<int>("reduceFloatPrecision");
 
 	// parse the TitleMap
 	stringstream skipMessage;
@@ -111,34 +112,34 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig) :
 			switch(VarTypes[v]){
 				case TreeTypes::t_bool      : tmp = new TreeObjectBool(VarName,VarTitle); break;
 				case TreeTypes::t_int       : tmp = new TreeObjectInt(VarName,VarTitle); break;
-				case TreeTypes::t_double    : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectDoubleToF(VarName,VarTitle)) : (TreeObjectBase*)(new TreeObjectDouble(VarName,VarTitle)); break;
+				case TreeTypes::t_double    : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectDoubleToF(VarName,VarTitle,0,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeObjectDouble(VarName,VarTitle)); break;
 				case TreeTypes::t_string    : tmp = new TreeObjectString(VarName,VarTitle); break;
-				case TreeTypes::t_lorentz   : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectLVToF(VarName,VarTitle,splitLevel)) : (TreeObjectBase*)(new TreeObjectLV(VarName,VarTitle,splitLevel)); break;
-				case TreeTypes::t_xyzv      : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectXYZVToF(VarName,VarTitle,splitLevel)) : (TreeObjectBase*)(new TreeObjectXYZV(VarName,VarTitle,splitLevel)); break;
-				case TreeTypes::t_xyzp      : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectXYZPToF(VarName,VarTitle,splitLevel)) : (TreeObjectBase*)(new TreeObjectXYZP(VarName,VarTitle,splitLevel)); break;
+				case TreeTypes::t_lorentz   : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectLVToF(VarName,VarTitle,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeObjectLV(VarName,VarTitle,splitLevel)); break;
+				case TreeTypes::t_xyzv      : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectXYZVToF(VarName,VarTitle,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeObjectXYZV(VarName,VarTitle,splitLevel)); break;
+				case TreeTypes::t_xyzp      : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectXYZPToF(VarName,VarTitle,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeObjectXYZP(VarName,VarTitle,splitLevel)); break;
 				case TreeTypes::t_vbool     : tmp = new TreeObjectVBool(VarName,VarTitle,splitLevel); break;
 				case TreeTypes::t_vint      : tmp = new TreeObjectVInt(VarName,VarTitle,splitLevel); break;
-				case TreeTypes::t_vfloat    : tmp = new TreeObjectVFloat(VarName,VarTitle,splitLevel); break;
-				case TreeTypes::t_vdouble   : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectVDoubleToF(VarName,VarTitle,splitLevel)) : (TreeObjectBase*)(new TreeObjectVDouble(VarName,VarTitle,splitLevel)); break;
+				case TreeTypes::t_vfloat    : tmp = new TreeObjectVFloat(VarName,VarTitle,splitLevel,reduceFloatPrecision); break;
+				case TreeTypes::t_vdouble   : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectVDoubleToF(VarName,VarTitle,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeObjectVDouble(VarName,VarTitle,splitLevel)); break;
 				case TreeTypes::t_vstring   : tmp = new TreeObjectVString(VarName,VarTitle,splitLevel); break;
-				case TreeTypes::t_vlorentz  : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectVLVToF(VarName,VarTitle,splitLevel)) : (TreeObjectBase*)(new TreeObjectVLV(VarName,VarTitle,splitLevel)); break;
-				case TreeTypes::t_vxyzv     : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectVXYZVToF(VarName,VarTitle,splitLevel)) : (TreeObjectBase*)(new TreeObjectVXYZV(VarName,VarTitle,splitLevel)); break;
-				case TreeTypes::t_vxyzp     : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectVXYZPToF(VarName,VarTitle,splitLevel)) : (TreeObjectBase*)(new TreeObjectVXYZP(VarName,VarTitle,splitLevel)); break;
+				case TreeTypes::t_vlorentz  : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectVLVToF(VarName,VarTitle,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeObjectVLV(VarName,VarTitle,splitLevel)); break;
+				case TreeTypes::t_vxyzv     : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectVXYZVToF(VarName,VarTitle,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeObjectVXYZV(VarName,VarTitle,splitLevel)); break;
+				case TreeTypes::t_vxyzp     : tmp = saveFloat ? (TreeObjectBase*)(new TreeObjectVXYZPToF(VarName,VarTitle,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeObjectVXYZP(VarName,VarTitle,splitLevel)); break;
 				case TreeTypes::t_vvbool    : tmp = new TreeNVBool(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
 				case TreeTypes::t_vvint     : tmp = new TreeNVInt(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
-				case TreeTypes::t_vvdouble  : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVDoubleToF(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)) : (TreeObjectBase*)(new TreeNVDouble(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)); break;
+				case TreeTypes::t_vvdouble  : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVDoubleToF(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeNVDouble(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)); break;
 				case TreeTypes::t_vvstring  : tmp = new TreeNVString(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel); break;
-				case TreeTypes::t_vvlorentz : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVLVToF(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)) : (TreeObjectBase*)(new TreeNVLV(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)); break;
-				case TreeTypes::t_vvxyzv    : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVXYZVToF(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)) : (TreeObjectBase*)(new TreeNVXYZV(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)); break;
-				case TreeTypes::t_vvxyzp    : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVXYZPToF(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)) : (TreeObjectBase*)(new TreeNVXYZP(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)); break;
+				case TreeTypes::t_vvlorentz : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVLVToF(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeNVLV(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)); break;
+				case TreeTypes::t_vvxyzv    : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVXYZVToF(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeNVXYZV(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)); break;
+				case TreeTypes::t_vvxyzp    : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVXYZPToF(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeNVXYZP(VarName,VarTitle,nestedVectors,storeOffsets,false,splitLevel)); break;
 				case TreeTypes::t_avvbool   : tmp = new TreeNVBool(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
 				case TreeTypes::t_avvint    : tmp = new TreeNVInt(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
-				case TreeTypes::t_avvdouble : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVDoubleToF(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)) : (TreeObjectBase*)(new TreeNVDouble(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)); break;
+				case TreeTypes::t_avvdouble : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVDoubleToF(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeNVDouble(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)); break;
 				case TreeTypes::t_avvstring : tmp = new TreeNVString(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel); break;
-				case TreeTypes::t_avvlorentz: tmp = saveFloat ? (TreeObjectBase*)(new TreeNVLVToF(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)) : (TreeObjectBase*)(new TreeNVLV(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)); break;
-				case TreeTypes::t_avvxyzv   : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVXYZVToF(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)) : (TreeObjectBase*)(new TreeNVXYZV(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)); break;
-				case TreeTypes::t_avvxyzp   : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVXYZPToF(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)) : (TreeObjectBase*)(new TreeNVXYZP(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)); break;
-				case TreeTypes::t_recocand  : tmp = saveFloat ? (TreeObjectBase*)(new TreeRecoCandToF(VarName,VarTitle,doLorentz,splitLevel)) : (TreeObjectBase*)(new TreeRecoCand(VarName,VarTitle,doLorentz,splitLevel)); break;
+				case TreeTypes::t_avvlorentz: tmp = saveFloat ? (TreeObjectBase*)(new TreeNVLVToF(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeNVLV(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)); break;
+				case TreeTypes::t_avvxyzv   : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVXYZVToF(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeNVXYZV(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)); break;
+				case TreeTypes::t_avvxyzp   : tmp = saveFloat ? (TreeObjectBase*)(new TreeNVXYZPToF(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeNVXYZP(VarName,VarTitle,nestedVectors,storeOffsets,true,splitLevel)); break;
+				case TreeTypes::t_recocand  : tmp = saveFloat ? (TreeObjectBase*)(new TreeRecoCandToF(VarName,VarTitle,doLorentz,splitLevel,reduceFloatPrecision)) : (TreeObjectBase*)(new TreeRecoCand(VarName,VarTitle,doLorentz,splitLevel)); break;
 			}
 			//if a known type was found, initialize and store the object
 			if(tmp) {


### PR DESCRIPTION
This PR adds a new feature to allow the user to set the number of bits used in the mantissa of single-precision floating point values. The idea is that if more of the bits in the mantissa are predictably set to zero, then the compression algorithm will be able to be more efficient.

I have tested the code and found no difference in total size or size/event before this PR or after this PR, but not changing the precision. When the precision was changed I found that the size/event decreased by ~3.5% (ever so slightly increasing as the number of events/file increased).

I haven't yet done:
- A scan over the precision to see the relationship between number of bits in the mantissa (i.e. space saved) and the loss of precision in any given branch.
- An analysis of the change in speed of the ntuplization process.