### PR TITLE
[Run2_UL] Add ClassAd containing input file(s) to HTCondor jobs

### DIFF
--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -114,18 +114,21 @@ class maker:
                 value = "\"" + ",".join(self.readFiles) + "\""
                 try:
                     chirp_command = "condor_chirp set_job_attr_delayed " + key + " " + value
+                    if self.verbose:
+                        print chirp_command
                     proc = subprocess.Popen(chirp_command.split(), shell = False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                     outs, errs = proc.communicate()
                 except Exception as e:
                     proc.kill()
-                    print "An exception occurred: {}".format(e)
+                    print "An exception occurred when adding classad {}: {}".format(key,e)
                 finally:
                     if proc.returncode:
                         print "WARNING::condor_chirp failed to set the attribute \'" + key + "\'" 
                     else:
-                        print "HTCondor classad \'" + key + "\' set to " + value
+                        if self.verbose:
+                            print "HTCondor classad \'" + key + "\' set to " + value
         except KeyError:
-            print "<Not on a condor worker node>"
+            pass
 
         # branches for treemaker
         self.VectorRecoCand                 = cms.vstring()

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+import os
+import subprocess
+
 # import functions to be assigned as class methods
 from TreeMaker.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD
 from TreeMaker.TreeMaker.JetDepot import JetVariations
@@ -102,6 +105,27 @@ class maker:
             self.readFiles.extend( [self.dataset] )
 
         self.readFiles = [(self.redir if val.startswith("/") else "")+val for val in self.readFiles]
+
+        # https://htcondor.readthedocs.io/en/latest/man-pages/condor_chirp.html?highlight=set_job_attr_delayed#chirp-commands
+        # https://github.com/cms-sw/cmssw/blob/master/FWCore/Services/plugins/CondorStatusUpdater.cc#L377-L410
+        try:
+            if os.environ["_CONDOR_CHIRP_CONFIG"]:
+                key = "ChirpTreeMakerReadFiles"
+                value = "\"" + ",".join(self.readFiles) + "\""
+                try:
+                    chirp_command = "condor_chirp set_job_attr_delayed " + key + " " + value
+                    proc = subprocess.Popen(chirp_command.split(), shell = False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    outs, errs = proc.communicate()
+                except Exception as e:
+                    proc.kill()
+                    print "An exception occurred: {}".format(e)
+                finally:
+                    if proc.returncode:
+                        print "WARNING::condor_chirp failed to set the attribute \'" + key + "\'" 
+                    else:
+                        print "HTCondor classad \'" + key + "\' set to " + value
+        except KeyError:
+            print "<Not on a condor worker node>"
 
         # branches for treemaker
         self.VectorRecoCand                 = cms.vstring()

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -123,6 +123,7 @@ class maker:
                     print "An exception occurred when adding classad {}: {}".format(key,e)
                 finally:
                     if proc.returncode:
+                        # TODO: Right now this is fairly permissive. We may want to make this an exception in the future.
                         print "WARNING::condor_chirp failed to set the attribute \'" + key + "\'" 
                     else:
                         if self.verbose:


### PR DESCRIPTION
Insert an HTCondor ClassAd into the job based upon the files being processed by TreeMaker. This needs to take place once the input file(s) have been found. The earliest location for this, which only gets run once, is withing `maker.py`. There is a check to make sure this is only done if the job is running on a condor worker node and on an interactive node.

The only dependencies this adds to `maker.py` are on the python modules `os` and `subprocess`.

I don't foresee any slowdown or adverse effects coming from this as it only takes place once and the command being run is very fast.