### PR TITLE
[Run2_UL] Missing mode with folders

### DIFF
--- a/Production/test/condorSub/jobSubmitterTM.py
+++ b/Production/test/condorSub/jobSubmitterTM.py
@@ -184,11 +184,17 @@ class jobSubmitterTM(jobSubmitter):
 
         #add to finished files in case the files are folderized
         if self.useFolders:
+            if not hasattr(self,"checkedDirectories"):
+                setattr(self,"checkedDirectories",set())
+
             if hasattr(self,"output"):
-                finishedFilesPerJob = pyxrdfsls(self.output + "/" + job.name.replace('.','/'))
-                finishedFilesPerJobSplit = [finished.split('/') for finished in finishedFilesPerJob]
-                finishedFilesPerJob = ['.'.join(finished[-3:-1]) + "_" + finished[-1].replace("_RA2AnalysisTree.root","") for finished in finishedFilesPerJobSplit]
-                self.filesSet |= set(finishedFilesPerJob)
+                bottomDir = self.output + "/" + job.name.replace('.','/')
+                if bottomDir not in self.checkedDirectories:
+                    finishedFilesPerJob = pyxrdfsls(bottomDir)
+                    finishedFilesPerJobSplit = [finished.split('/') for finished in finishedFilesPerJob]
+                    finishedFilesPerJob = ['.'.join(finished[-3:-1]) + "_" + finished[-1].replace("_RA2AnalysisTree.root","") for finished in finishedFilesPerJobSplit]
+                    self.filesSet |= set(finishedFilesPerJob)
+                    self.checkedDirectories.add(bottomDir)
 
         # replace name if necessary
         if len(job.chainName)>0:


### PR DESCRIPTION
Make sure that missing mode works with folderized outputs. Currently missing mode only looks in the top level directory and sees all of the jobs as missing. Unfortunately, the actual job level outputs aren't available during the initialization of missing mode, but only during the job-by-job stage. For each job, the outputs in the bottom level folder are checked and the files which are missing from the list of finished files are added to the list of finished files. Thus, the final list of finished files is built up job-by-job. There is an optimization already in place to make sure that each bottom level directory is only checked once. This reduces the number of `xrdfs` calls.

In my testing, this works and correctly indicates no missing files for the V20 production when the `-f` option is used.