### PR TITLE
More speed improvements

### DIFF
--- a/TreeMaker/python/doLostLeptonBkg.py
+++ b/TreeMaker/python/doLostLeptonBkg.py
@@ -3,10 +3,10 @@ import FWCore.ParameterSet.Config as cms
 def doLostLeptonBkg(self,process,METTag):
     if self.geninfo:
         from TreeMaker.Utils.genLeptonRecoCand_cfi import genLeptonRecoCand
-        process.GenLeptons = genLeptonRecoCand.clone(
-            PrunedGenParticleTag  = cms.InputTag("prunedGenParticles"),
-            pfCandsTag  = cms.InputTag('packedPFCandidates')
-        )
+        process.GenLeptons = genLeptonRecoCand.clone()
+        # gen information on leptons
+        self.VectorRecoCand.extend(['GenLeptons:Muon(GenMuons)','GenLeptons:Electron(GenElectrons)','GenLeptons:Tau(GenTaus)'])
+        self.VectorBool.extend(['GenLeptons:TauHadronic(GenTaus_had)'])
 
     from TreeMaker.Utils.trackIsolationMaker_cfi import trackIsolationFilter
 
@@ -75,8 +75,5 @@ def doLostLeptonBkg(self,process,METTag):
             self.VectorDouble.extend(['TAP'+type+'Tracks:pfcandsdzpv(TAP'+type+'Tracks_dzpv)'])
             self.VectorInt.extend(['TAP'+type+'Tracks:pfcandschg(TAP'+type+'Tracks_charge)'])
             self.VectorInt.extend(['TAP'+type+'Tracks:pfcandsid(TAP'+type+'Tracks_id)'])
-    if self.geninfo: # gen information on leptons
-        self.VectorRecoCand.extend(['GenLeptons:Muon(GenMuons)','GenLeptons:Electron(GenElectrons)','GenLeptons:Tau(GenTaus)'])
-        self.VectorBool.extend(['GenLeptons:TauHadronic(GenTaus_had)'])
-    
+
     return process

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -947,6 +947,9 @@ def makeTreeFromMiniAOD(self,process):
             jetPtFilter = cms.double(0. if self.tchannel else 150),
             doHV = cms.bool(True if self.emerging else False),
         )
+        if self.tchannel:
+            # avoid doing this twice
+            process.ak8GenJetProperties.SoftDropGenJetTag = cms.InputTag("ak8GenJetsNoNuSoftDrop")
         self.VectorDouble.extend([
             'ak8GenJetProperties:softDropMass(GenJetsAK8_softDropMass)',
         ])

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -333,7 +333,7 @@ def makeTreeFromMiniAOD(self,process):
                 dataTier='miniAOD',
                 runOnMC = self.geninfo,
                 postFix = 'NoCut',
-                addPruning = True,
+                addPruning = False,
                 addSoftDropSubjets = True,
                 addNsub = True,
                 maxTau = 3,
@@ -862,7 +862,6 @@ def makeTreeFromMiniAOD(self,process):
         process.JetPropertiesAK8.ecfN2b2 = cms.vstring('ak8PFJetsPuppiNoCutSoftDropValueMap:nb2AK8PuppiNoCutSoftDropN2')
         process.JetPropertiesAK8.ecfN3b1 = cms.vstring('ak8PFJetsPuppiNoCutSoftDropValueMap:nb1AK8PuppiNoCutSoftDropN3')
         process.JetPropertiesAK8.ecfN3b2 = cms.vstring('ak8PFJetsPuppiNoCutSoftDropValueMap:nb2AK8PuppiNoCutSoftDropN3')
-        process.JetPropertiesAK8.prunedMass = cms.vstring('ak8PFJetsPuppiNoCutPrunedMass')
         process.JetPropertiesAK8.softDropMass = cms.vstring('SoftDrop')
         process.JetPropertiesAK8.subjets = cms.vstring('SoftDrop')
         process.JetPropertiesAK8.SJbDiscriminatorCSV = cms.vstring('SoftDrop', 'pfCombinedInclusiveSecondaryVertexV2BJetTags')
@@ -929,16 +928,6 @@ def makeTreeFromMiniAOD(self,process):
         # substructure for genjets
         from RecoJets.Configuration.RecoGenJets_cff import ak8GenJetsNoNu as ak8GenJetsNoNuDefault
         from RecoJets.JetProducers.SubJetParameters_cfi import SubJetParameters
-        process.ak8GenJetsPruned = ak8GenJetsNoNuDefault.clone(
-            SubJetParameters,
-            usePruning = cms.bool(True),
-            useExplicitGhosts = cms.bool(True),
-            writeCompound = cms.bool(True),
-            jetCollInstanceName=cms.string("SubJets"),
-            jetPtMin = 0. if self.tchannel else 170.,
-            doAreaFastjet = cms.bool(False),
-            src = GenParticlesForJetTag,
-        )
         process.ak8GenJetsSoftDrop = ak8GenJetsNoNuDefault.clone(
             useSoftDrop = cms.bool(True),
             zcut = cms.double(0.1),
@@ -953,7 +942,6 @@ def makeTreeFromMiniAOD(self,process):
 
         process.ak8GenJetProperties = genjetproperties.clone(
             GenJetTag = GenJetAK8Tag,
-            PrunedGenJetTag = cms.InputTag("ak8GenJetsPruned"),
             SoftDropGenJetTag = cms.InputTag("ak8GenJetsSoftDrop"),
             distMax = cms.double(0.8),
             jetPtFilter = cms.double(0. if self.tchannel else 150),

--- a/Utils/python/genLeptonRecoCand_cfi.py
+++ b/Utils/python/genLeptonRecoCand_cfi.py
@@ -2,5 +2,4 @@ import FWCore.ParameterSet.Config as cms
 
 genLeptonRecoCand = cms.EDProducer('GenLeptonRecoCand',
   PrunedGenParticleTag  = cms.InputTag("prunedGenParticles"),
-  pfCandTag  = cms.InputTag("packedPFCandidates"),
 )

--- a/Utils/src/GenLeptonRecoCand.cc
+++ b/Utils/src/GenLeptonRecoCand.cc
@@ -41,7 +41,7 @@
 class GenLeptonRecoCand : public edm::global::EDProducer<> {
 public:
   explicit GenLeptonRecoCand(const edm::ParameterSet&);
-  ~GenLeptonRecoCand() override;
+  ~GenLeptonRecoCand() override {}
 	
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 	
@@ -49,89 +49,26 @@ private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 	
   edm::InputTag PrunedGenParticleTag_;
-  edm::InputTag pfCandsTag_;
   edm::EDGetTokenT<edm::View<reco::GenParticle>> PrunedGenParticleTok_;
-  edm::EDGetTokenT<pat::PackedCandidateCollection> pfCandsTok_;
 	
   const reco::GenParticle* BosonFound(const reco::GenParticle * particle) const;
   const reco::GenParticle* TauFound(const reco::GenParticle * particle) const;
-
-  void GetTrkIso(const edm::Handle<pat::PackedCandidateCollection>& pfcands, const unsigned tkInd, float& trkiso, float& activity) const;
-  const int MatchToPFCand(const edm::Handle<pat::PackedCandidateCollection>& pfcands, const reco::GenParticle* gen_track) const;
-  const double GetGenRecoD3(const edm::Handle<pat::PackedCandidateCollection>& pfcands, const int tkInd, const reco::GenParticle* gen_track) const;
-	
-	
-  // ----------member data ---------------------------
 };
-
-//
-// constants, enums and typedefs
-//
-
-
-//
-// static data member definitions
-//
 
 //
 // constructors and destructor
 //
-GenLeptonRecoCand::GenLeptonRecoCand(const edm::ParameterSet& iConfig)
+GenLeptonRecoCand::GenLeptonRecoCand(const edm::ParameterSet& iConfig) :
+  PrunedGenParticleTag_(iConfig.getParameter<edm::InputTag >("PrunedGenParticleTag")),
+  PrunedGenParticleTok_(consumes<edm::View<reco::GenParticle>>(PrunedGenParticleTag_))
 {
   //register your product
-  PrunedGenParticleTag_ 				= 	iConfig.getParameter<edm::InputTag >("PrunedGenParticleTag");
-  pfCandsTag_ = 	iConfig.getParameter<edm::InputTag >("pfCandsTag");
-  PrunedGenParticleTok_ = consumes<edm::View<reco::GenParticle>>(PrunedGenParticleTag_);
-  pfCandsTok_ = consumes<pat::PackedCandidateCollection>(pfCandsTag_);
-  
 
-  produces<std::vector<reco::GenParticle>>("Boson");
-  produces<std::vector<int>>("BosonPDGId");
   produces<std::vector<reco::GenParticle>>("Muon");
-  produces<std::vector<bool>>("MuonTauDecay");
-  produces<std::vector<double>>("MuonGenRecoD3");
-  produces<std::vector<double>>("MuonTrkIso");
-  produces<std::vector<double>>("MuonTrkAct");
   produces<std::vector<reco::GenParticle>>("Electron");
-  produces<std::vector<bool>>("ElectronTauDecay");
-  produces<std::vector<double>>("ElectronGenRecoD3");
-  produces<std::vector<double>>("ElectronTrkIso");
-  produces<std::vector<double>>("ElectronTrkAct");
   produces<std::vector<reco::GenParticle>>("Tau");
   produces<std::vector<bool>>("TauHadronic");
-  produces<std::vector<reco::GenParticle>>("TauDecayCands");
-  produces<std::vector<int>>("TauDecayCandspdgID");
-  produces<std::vector<int>>("TauDecayCandsmomInd");
-  produces<std::vector<math::PtEtaPhiELorentzVector>>("TauLeadTrk");
-  produces<std::vector<double>>("TauLeadTrkGenRecoD3");
-  produces<std::vector<double>>("TauLeadTrkIso");
-  produces<std::vector<double>>("TauLeadTrkAct");
-  produces<std::vector<int>>("TauNProngs");
-  produces<std::vector<int>>("TauNNHads");
-  produces<std::vector<reco::GenParticle>>("TauNu");
-  produces<std::vector<double>>("TauNuMomPt");
-  /* Examples
-   *   produces<ExampleData2>();
-   * 
-   *   //if do put with a label
-   *   produces<ExampleData2>("label");
-   * 
-   *   //if you want to put into the Run
-   *   produces<ExampleData2,InRun>();
-   */
-  //now do what ever other initialization is needed
-	
 }
-
-
-GenLeptonRecoCand::~GenLeptonRecoCand()
-{
-	
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-	
-}
-
 
 //
 // member functions
@@ -142,36 +79,13 @@ void
 GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
   using namespace edm;	
-  auto selectedBoson = std::make_unique<std::vector<reco::GenParticle>>();
-  auto selectedBosonPDGId = std::make_unique<std::vector<int>>();
   auto selectedMuon = std::make_unique<std::vector<reco::GenParticle>>();
-  auto selectedMuonTauDecay = std::make_unique<std::vector<bool>>();
-  auto selectedMuonGenRecoD3 = std::make_unique<std::vector<double>>();
-  auto selectedMuonTrkIso = std::make_unique<std::vector<double>>();
-  auto selectedMuonTrkAct = std::make_unique<std::vector<double>>();
   auto selectedElectron = std::make_unique<std::vector<reco::GenParticle>>();
-  auto selectedElectronTauDecay = std::make_unique<std::vector<bool>>();
-  auto selectedElectronGenRecoD3 = std::make_unique<std::vector<double>>();
-  auto selectedElectronTrkIso = std::make_unique<std::vector<double>>();
-  auto selectedElectronTrkAct = std::make_unique<std::vector<double>>();
   auto selectedTau = std::make_unique<std::vector<reco::GenParticle>>();
   auto selectedTauHadronic = std::make_unique<std::vector<bool>>();
-  auto selectedTauDecayCands = std::make_unique<std::vector<reco::GenParticle>>();
-  auto selectedTauDecayCandspdgID = std::make_unique<std::vector<int>>();
-  auto selectedTauDecayCandsmomInd = std::make_unique<std::vector<int>>();
-  auto selectedTauLeadTrk = std::make_unique<std::vector<math::PtEtaPhiELorentzVector>>();
-  auto selectedTauLeadTrkd3 = std::make_unique<std::vector<double>>();
-  auto selectedTauLeadTrkIso = std::make_unique<std::vector<double>>();
-  auto selectedTauLeadTrkAct = std::make_unique<std::vector<double>>();
-  auto selectedTauNProngs = std::make_unique<std::vector<int>>();
-  auto selectedTauNNHads = std::make_unique<std::vector<int>>();
 
-  auto selectedTauNu = std::make_unique<std::vector<reco::GenParticle>>();
   Handle<edm::View<reco::GenParticle> > pruned;
   iEvent.getByToken(PrunedGenParticleTok_,pruned);
-
-  edm::Handle<pat::PackedCandidateCollection> pfcands;
-  iEvent.getByToken(pfCandsTok_, pfcands);
 
   for(size_t i=0; i<pruned->size();i++)
     {
@@ -179,76 +93,21 @@ GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSe
 	{
 	  const reco::GenParticle * FinalBoson = BosonFound(&(*pruned)[i]);
 	  size_t bosonDaughters = FinalBoson->numberOfDaughters();
-	  selectedBoson->push_back(*FinalBoson);
-	  selectedBosonPDGId->push_back(FinalBoson->pdgId());
 	  for(size_t ii=0;ii< bosonDaughters; ii++)
 	    {
 	      if(abs(FinalBoson->daughter(ii)->pdgId())== 11) 
 		{
 		  selectedElectron->push_back(*((reco::GenParticle*) FinalBoson->daughter(ii) ));
-		  selectedElectronTauDecay->push_back(false);
-		  int matchedPFCand(MatchToPFCand(pfcands, &selectedElectron->back()));
-		  selectedElectronGenRecoD3->push_back(GetGenRecoD3(pfcands, matchedPFCand, &selectedElectron->back()));
-		  float trkiso = 0.;
-		  float activity = 0.;
-		  GetTrkIso(pfcands, matchedPFCand, trkiso, activity);
-		  selectedElectronTrkIso->push_back(trkiso);
-		  selectedElectronTrkAct->push_back(activity);
 		}
-	      if(abs(FinalBoson->daughter(ii)->pdgId())== 13) 
+	      else if(abs(FinalBoson->daughter(ii)->pdgId())== 13) 
 		{
 		  selectedMuon->push_back(*((reco::GenParticle*) FinalBoson->daughter(ii) ));
-		  selectedMuonTauDecay->push_back(false);
-		  int matchedPFCand(MatchToPFCand(pfcands, &selectedMuon->back()));
-		  selectedMuonGenRecoD3->push_back(GetGenRecoD3(pfcands, matchedPFCand, &selectedMuon->back()));
-		  float trkiso = 0.;
-		  float activity = 0.;
-		  GetTrkIso(pfcands, matchedPFCand, trkiso, activity);
-		  selectedMuonTrkIso->push_back(trkiso);
-		  selectedMuonTrkAct->push_back(activity);
 		}
-	      if(abs(FinalBoson->daughter(ii)->pdgId())== 15) 
+	      else if(abs(FinalBoson->daughter(ii)->pdgId())== 15) 
 		{
 		  selectedTau->push_back(*((reco::GenParticle*) FinalBoson->daughter(ii) ));
 
-		  // 					selectedTauHadronic->push_back(0);
 		  const reco::GenParticle * FinalTauDecay = TauFound((reco::GenParticle*)FinalBoson->daughter(ii));
-
-		  for(size_t iii=0; iii<FinalTauDecay->numberOfDaughters();iii++)
-		    {
-		      // daughters of "final" taus before decaying
-		      if (FinalTauDecay->daughter(iii)->status()==1 
-			  || FinalTauDecay->daughter(iii)->pdgId()==111 ){                 // Stable particle or pi0
-			selectedTauDecayCandsmomInd->push_back(selectedTau->size()-1); // index to connect it to mom tau
-			selectedTauDecayCands->push_back(*((reco::GenParticle*) FinalTauDecay->daughter(iii) ));
-			selectedTauDecayCandspdgID->push_back(FinalTauDecay->daughter(iii)->pdgId());
-			if (abs(FinalTauDecay->daughter(iii)->pdgId())==16) 
-			  selectedTauNu->push_back( *((reco::GenParticle*) FinalTauDecay->daughter(iii)) );
-		      } else {                                                             // Neither stable particle nor pi0 (e.g. rho+-, a+-, K*+-, W+-)
-			for(size_t iiii=0; iiii<FinalTauDecay->daughter(iii)->numberOfDaughters();iiii++){
-			  // granddaughters of "final" taus before decaying
-			  if (FinalTauDecay->daughter(iii)->daughter(iiii)->status()==1 
-			      || FinalTauDecay->daughter(iii)->daughter(iiii)->pdgId()==111){ // Stable particle or pi0
-			    selectedTauDecayCandsmomInd->push_back(selectedTau->size()-1); // index to connect it to mom tau
-			    selectedTauDecayCands->push_back(*((reco::GenParticle*) FinalTauDecay->daughter(iii)->daughter(iiii) ));
-			    selectedTauDecayCandspdgID->push_back(FinalTauDecay->daughter(iii)->daughter(iiii)->pdgId());
-			  } else {                                                            // Neither stable particle nor pi0 (e.g. eta, K0S)
-			    for(size_t iiiii=0; iiiii<FinalTauDecay->daughter(iii)->daughter(iiii)->numberOfDaughters();iiiii++){
-			      // greatgranddaughters of "final" taus before decaying
-			      selectedTauDecayCandsmomInd->push_back(selectedTau->size()-1); // index to connect it to mom tau
-			      selectedTauDecayCands->push_back(*((reco::GenParticle*) FinalTauDecay->daughter(iii)->daughter(iiii)->daughter(iiiii) ));
-			      selectedTauDecayCandspdgID->push_back(FinalTauDecay->daughter(iii)->daughter(iiii)->daughter(iiiii)->pdgId());
-			      if (FinalTauDecay->daughter(iii)->daughter(iiii)->daughter(iiiii)->status()!=1 
-				  && FinalTauDecay->daughter(iii)->daughter(iiii)->daughter(iiiii)->pdgId()!=111){ // Stable particle or pi0
-				printf("WARNING: This is a tau's greatgranddaughter, but it's still neither stable nor pi0/eta/K0S. pdgId=%d. stauts=%d\n",
-				       FinalTauDecay->daughter(iii)->daughter(iiii)->daughter(iiiii)->pdgId(),
-				       FinalTauDecay->daughter(iii)->daughter(iiii)->daughter(iiiii)->status());						    
-			      }
-			    }
-			  }
-			}
-		      }
-		    }
 
 		  bool hadTauDecay=true;
 		  for(size_t iii=0; iii<FinalTauDecay->numberOfDaughters();iii++)
@@ -256,119 +115,26 @@ GenLeptonRecoCand::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSe
 		      if(abs(FinalTauDecay->daughter(iii)->pdgId())== 11) 
 			{
 			  selectedElectron->push_back(*((reco::GenParticle*) FinalTauDecay->daughter(iii) ));
-			  selectedElectronTauDecay->push_back(true);
-			  int matchedPFCand(MatchToPFCand(pfcands, &selectedElectron->back()));
-			  selectedElectronGenRecoD3->push_back(GetGenRecoD3(pfcands, matchedPFCand, &selectedElectron->back()));
-			  float trkiso = 0.;
-			  float activity = 0.;
-			  GetTrkIso(pfcands, matchedPFCand, trkiso, activity);
-			  selectedElectronTrkIso->push_back(trkiso);
-			  selectedElectronTrkAct->push_back(activity);
 			  hadTauDecay=false;
 			}
 		      else if(abs(FinalTauDecay->daughter(iii)->pdgId())== 13) 
 			{
 			  selectedMuon->push_back(*((reco::GenParticle*) FinalTauDecay->daughter(iii) ));
-			  selectedMuonTauDecay->push_back(true);
-			  int matchedPFCand(MatchToPFCand(pfcands, &selectedMuon->back()));
-			  selectedMuonGenRecoD3->push_back(GetGenRecoD3(pfcands, matchedPFCand, &selectedMuon->back()));
-			  float trkiso = 0.;
-			  float activity = 0.;
-			  GetTrkIso(pfcands, matchedPFCand, trkiso, activity);
-			  selectedMuonTrkIso->push_back(trkiso);
-			  selectedMuonTrkAct->push_back(activity);
 			  hadTauDecay=false;
 			}
-		      // store all decay productes of the tau in a new colleciton
           }
 		  selectedTauHadronic->push_back(hadTauDecay);
 		}
-	    }
+	  }
 
 	}
 	  
     }
 
-  if (selectedTauNu->size()!=selectedTau->size()) printf("WARNING: number of tau neutrino stored and number of taus do not matched %6d %6d\n",int(selectedTauNu->size()),int(selectedTau->size()));
-
-  // Now get properties of leading track from tau
-  for (unsigned int itau(0); itau<selectedTauHadronic->size(); itau++) {
-    unsigned int nNHad(0), nTrk(0);
-    std::vector<int> tau_trks;
-    for (unsigned int icand(0); icand<selectedTauDecayCands->size(); icand++) {
-      unsigned int pdgID = abs(selectedTauDecayCandspdgID->at(icand));
-      if ((unsigned)abs(selectedTauDecayCandsmomInd->at(icand)) != itau) continue;
-      if (pdgID<100) continue;
-      if (pdgID==211 || pdgID==321) {
-  	nTrk++;
-  	tau_trks.push_back(icand);
-     }
-      else {
-  	nNHad++;
-     }
-    }
-    selectedTauNProngs->push_back(nTrk);
-    selectedTauNNHads->push_back(nNHad);
-    if (nTrk>0) {
-      // find the leading track
-      double maxPt(0.);
-      int leadTrk(0);
-      for (int tau_trk : tau_trks) {
-  	if (selectedTauDecayCands->at(tau_trk).pt()>maxPt) {
-  	  maxPt=tau_trk;
-  	  leadTrk=tau_trk;
-  	}
-      }
-      math::PtEtaPhiELorentzVector p4(selectedTauDecayCands->at(leadTrk).px(),selectedTauDecayCands->at(leadTrk).py(),selectedTauDecayCands->at(leadTrk).pz(),selectedTauDecayCands->at(leadTrk).energy());
-      selectedTauLeadTrk->push_back(p4);
-      // now get iso and act from matched PF track
-      int matched_track = MatchToPFCand(pfcands, &selectedTauDecayCands->at(leadTrk));
-      if (matched_track>=0) {
-  	//	printf("Matched gen pion to iso track: ptg = %3.3f, pttk = %3.3f --> d3 = %3.3f\n", selectedTauLeadTrkPT[icand], TAPPionTracks->at(matched_TAP_track).Pt(), mind3);
-	float trkiso = 0.;
-	float activity = 0.;
-	GetTrkIso(pfcands, matched_track, trkiso, activity);
-	selectedTauLeadTrkIso->push_back(trkiso);
-	selectedTauLeadTrkAct->push_back(activity);	
-  	selectedTauLeadTrkd3->push_back(GetGenRecoD3(pfcands, matched_track, &selectedTauDecayCands->at(leadTrk)));
-      } else {
-  	selectedTauLeadTrkIso->push_back(-999.);
-  	selectedTauLeadTrkAct->push_back(-999.);
-  	selectedTauLeadTrkd3->push_back(-999.);
-     }
-    } else {
-      //      printf("No hadronic tracks!\n");
-      selectedTauLeadTrkIso->push_back(-999.);
-      selectedTauLeadTrkAct->push_back(-999.);
-      selectedTauLeadTrk->emplace_back(0,0,0,0);
-      selectedTauLeadTrkd3->push_back(-999.);
-    }
-  }
-  
-  iEvent.put(std::move(selectedBoson),"Boson");
-  iEvent.put(std::move(selectedBosonPDGId),"BosonPDGId");
   iEvent.put(std::move(selectedMuon),"Muon");
-  iEvent.put(std::move(selectedMuonTauDecay),"MuonTauDecay");
-  iEvent.put(std::move(selectedMuonGenRecoD3),"MuonGenRecoD3");
-  iEvent.put(std::move(selectedMuonTrkIso),"MuonTrkIso");
-  iEvent.put(std::move(selectedMuonTrkAct),"MuonTrkAct");
   iEvent.put(std::move(selectedElectron),"Electron");
-  iEvent.put(std::move(selectedElectronTauDecay),"ElectronTauDecay");
-  iEvent.put(std::move(selectedElectronGenRecoD3),"ElectronGenRecoD3");
-  iEvent.put(std::move(selectedElectronTrkIso),"ElectronTrkIso");
-  iEvent.put(std::move(selectedElectronTrkAct),"ElectronTrkAct");
   iEvent.put(std::move(selectedTau),"Tau");
   iEvent.put(std::move(selectedTauHadronic),"TauHadronic");
-  iEvent.put(std::move(selectedTauDecayCands),"TauDecayCands");
-  iEvent.put(std::move(selectedTauDecayCandspdgID),"TauDecayCandspdgID");
-  iEvent.put(std::move(selectedTauDecayCandsmomInd),"TauDecayCandsmomInd");
-  iEvent.put(std::move(selectedTauLeadTrk),"TauLeadTrk");
-  iEvent.put(std::move(selectedTauLeadTrkd3),"TauLeadTrkGenRecoD3");
-  iEvent.put(std::move(selectedTauLeadTrkIso),"TauLeadTrkIso");
-  iEvent.put(std::move(selectedTauLeadTrkAct),"TauLeadTrkAct");
-  iEvent.put(std::move(selectedTauNProngs),"TauNProngs");
-  iEvent.put(std::move(selectedTauNNHads),"TauNNHads");
-  iEvent.put(std::move(selectedTauNu),"TauNu");
 
 }
 
@@ -400,61 +166,6 @@ const reco::GenParticle* GenLeptonRecoCand::TauFound(const reco::GenParticle * p
     }
   return particle;
 	
-}
-
-
-void GenLeptonRecoCand::GetTrkIso(const edm::Handle<pat::PackedCandidateCollection>& pfcands, const unsigned tkInd, float& trkiso, float& activity) const {
-  if (tkInd>pfcands->size()) {
-	  trkiso = -999.;
-	  activity = -999.;
-	  return;
-  }
-  trkiso = 0.;
-  activity = 0.;
-  double r_iso = 0.3;
-  for (unsigned int iPF(0); iPF<pfcands->size(); iPF++) {
-    const pat::PackedCandidate &pfc = pfcands->at(iPF);
-    if (pfc.charge()==0) continue;
-    if (iPF==tkInd) continue; // don't count track in its own sum
-    float dz_other = pfc.dz();
-    if( fabs(dz_other) > 0.1 ) continue;
-    double dr = deltaR(pfc, pfcands->at(tkInd));
-    // activity annulus
-    if (dr >= r_iso && dr <= 0.4) activity += pfc.pt();
-    // mini iso cone
-    if (dr <= r_iso) trkiso += pfc.pt();
-  }
-  trkiso = trkiso/pfcands->at(tkInd).pt();
-  activity = activity/pfcands->at(tkInd).pt();
-}
-
-const int GenLeptonRecoCand::MatchToPFCand(const edm::Handle<pat::PackedCandidateCollection>& pfcands, const reco::GenParticle* gen_track) const {
-  int pdgId=abs(gen_track->pdgId());
-  if (pdgId!=11&&pdgId!=13) pdgId=211;
-  double mind3=99999.;
-  int matched_track=-1;
-  for (unsigned int iPF(0); iPF<pfcands->size(); iPF++) {
-    const pat::PackedCandidate &pfc = pfcands->at(iPF);
-    if (pfc.charge()==0) continue;
-    if (abs(pfc.pdgId())!=pdgId) continue;
-    TVector3 genTrk3(gen_track->px(), gen_track->py(), gen_track->pz());
-    TVector3 pf3(pfc.px(), pfc.py(), pfc.pz());
-    double d3 = (genTrk3-pf3).Mag();
-    if (d3<mind3) {
-      mind3=d3;
-      matched_track=iPF;
-    }
-  }
-  return matched_track;
-}
-
-const double GenLeptonRecoCand::GetGenRecoD3(const edm::Handle<pat::PackedCandidateCollection>& pfcands, const int tkInd, const reco::GenParticle* gen_track) const {
-  if (tkInd<0||tkInd>(int)pfcands->size()) return -999.;
-  const pat::PackedCandidate &pfc = pfcands->at(tkInd);
-  TVector3 genTrk3(gen_track->px(), gen_track->py(), gen_track->pz());
-  TVector3 pf3(pfc.px(), pfc.py(), pfc.pz());
-  double d3 = (genTrk3-pf3).Mag();
-  return d3;
 }
 
 //define this as a plug-in

--- a/Utils/src/GoodJetsProducer.cc
+++ b/Utils/src/GoodJetsProducer.cc
@@ -231,7 +231,7 @@ GoodJetsProducer::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetu
 
 			//save good jets, potentially regardless of id or pt
 			if (good || saveAllId_) {
-				prodJets->push_back(Jet(iJet));
+				prodJets->push_back(iJet);
 				jetsMask->push_back(good);
 				leptonMask->push_back(isLepton);
 			}

--- a/setup.sh
+++ b/setup.sh
@@ -154,6 +154,7 @@ fi
 if [[ "$CMSSWVER" == "CMSSW_10_6_"* ]]; then
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:storeJERFactorIndex10620p1
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:AddJetAxis1_10620p1
+	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:PuppiReserve106X
 fi
 
 # outside repositories


### PR DESCRIPTION
Tested on UL17 TTToSemiLeptonic, using the default workflow + tchannel (AK8 reclustering):
1. Clean out `GenLeptonRecoCand`: 0.4% faster
2. Remove pruned mass: 14% faster
3. Avoid copy: 0.3% faster
4. Puppi speedups (see https://github.com/cms-sw/cmssw/pull/37718): ~5% faster
5. Avoid duplicate genjet softdrop computation: 2% faster

Overall improvement in this workflow is 19.3%.

For comparison, the workflow with both tchannel & boosted (AK15 clustering) improves by 10.75%. The default workflow with no reclustering improves by 3.3%.

The majority of the improvement comes from disabling jet pruning in the AK8 clustering. The extent of this improvement suggests a similar possibility for SoftDrop (which is still used), which will be pursued next.