### PR TITLE
Combine base clustering and jet grooming algorithms

### DIFF
--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -28,8 +28,8 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
         postFix='Clean',
         newPFCollection = True,
         nameNewPFCollection = cleanedCandidates.value(),
-        Cut = 'pt>170.',
-        addPruning = True,
+        Cut = 'pt>170.' if not self.tchannel else '',
+        addPruning = False,
         addSoftDropSubjets = True,
         addNsub = True,
         maxTau = 3,
@@ -43,7 +43,6 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     )
     JetAK8CleanTag = cms.InputTag("packedPatJetsAK8PFPuppiCleanSoftDrop")
 
-    # todo: avoid interference w/ this and full AK8 reclustering for tchannel
     process = self.transformJetSeq(process, "ak8GenJetsNoNu", {"SoftDrop":"ak8GenJetsNoNuSoftDrop"}, "recoGenJets")
     process = self.transformJetSeq(process, "ak8PFJetsPuppiClean", {"SoftDrop":"ak8PFJetsPuppiCleanSoftDrop"}, "recoPFJets")
 

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -43,6 +43,10 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     )
     JetAK8CleanTag = cms.InputTag("packedPatJetsAK8PFPuppiCleanSoftDrop")
 
+    # todo: avoid interference w/ this and full AK8 reclustering for tchannel
+    process = self.transformJetSeq(process, "ak8GenJetsNoNu", "ak8GenJetsNoNuSoftDrop", "recoGenJets")
+    process = self.transformJetSeq(process, "ak8PFJetsPuppiClean", "ak8PFJetsPuppiCleanSoftDrop", "recoPFJets")
+
     if doJERsmearing:
         # do central smearing and replace jet tag
         process, _, JetAK8CleanTag = JetDepot(process,

--- a/TreeMaker/python/doZinvBkg.py
+++ b/TreeMaker/python/doZinvBkg.py
@@ -44,8 +44,8 @@ def reclusterZinv(self, process, cleanedCandidates, suff):
     JetAK8CleanTag = cms.InputTag("packedPatJetsAK8PFPuppiCleanSoftDrop")
 
     # todo: avoid interference w/ this and full AK8 reclustering for tchannel
-    process = self.transformJetSeq(process, "ak8GenJetsNoNu", "ak8GenJetsNoNuSoftDrop", "recoGenJets")
-    process = self.transformJetSeq(process, "ak8PFJetsPuppiClean", "ak8PFJetsPuppiCleanSoftDrop", "recoPFJets")
+    process = self.transformJetSeq(process, "ak8GenJetsNoNu", {"SoftDrop":"ak8GenJetsNoNuSoftDrop"}, "recoGenJets")
+    process = self.transformJetSeq(process, "ak8PFJetsPuppiClean", {"SoftDrop":"ak8PFJetsPuppiCleanSoftDrop"}, "recoPFJets")
 
     if doJERsmearing:
         # do central smearing and replace jet tag

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -385,7 +385,8 @@ def makeTreeFromMiniAOD(self,process):
             )
 
             # todo: revamp jet toolbox to handle this
-            process = self.transformJetSeq(process, "ak8GenJetsNoNu", {"SoftDrop":"ak8GenJetsNoNuSoftDrop"}, "recoGenJets")
+            if not self.doZinv: # calling jet toolbox again for ak8 would break after this, so skip it
+                process = self.transformJetSeq(process, "ak8GenJetsNoNu", {"SoftDrop":"ak8GenJetsNoNuSoftDrop"}, "recoGenJets")
             process.ak8PFJetsPuppiNoCutSoftDrop.jetPtMin = cms.double(5.0) # to match central clustering
             process = self.transformJetSeq(process, "ak8PFJetsPuppiNoCut", {"SoftDrop":"ak8PFJetsPuppiNoCutSoftDrop"}, "recoPFJets")
 
@@ -995,7 +996,7 @@ def makeTreeFromMiniAOD(self,process):
             jetPtFilter = cms.double(0. if self.tchannel else 150),
             doHV = cms.bool(True if self.emerging else False),
         )
-        if self.tchannel:
+        if self.tchannel or self.doZinv:
             # avoid doing this twice
             process.ak8GenJetProperties.SoftDropGenJetTag = cms.InputTag("ak8GenJetsNoNuSoftDrop")
         self.VectorDouble.extend([

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -370,7 +370,8 @@ def makeTreeFromMiniAOD(self,process):
                 useExistingWeights=True,
                 dataTier='miniAOD',
                 runOnMC = self.geninfo,
-                postFix = 'NoCut',
+                Cut = 'pt>10.',
+                postFix = 'LowCut',
                 addPruning = False,
                 addSoftDropSubjets = True,
                 addNsub = True,
@@ -387,11 +388,11 @@ def makeTreeFromMiniAOD(self,process):
             # todo: revamp jet toolbox to handle this
             if not self.doZinv: # calling jet toolbox again for ak8 would break after this, so skip it
                 process = self.transformJetSeq(process, "ak8GenJetsNoNu", {"SoftDrop":"ak8GenJetsNoNuSoftDrop"}, "recoGenJets")
-            process.ak8PFJetsPuppiNoCutSoftDrop.jetPtMin = cms.double(5.0) # to match central clustering
-            process = self.transformJetSeq(process, "ak8PFJetsPuppiNoCut", {"SoftDrop":"ak8PFJetsPuppiNoCutSoftDrop"}, "recoPFJets")
+            process.ak8PFJetsPuppiLowCutSoftDrop.jetPtMin = cms.double(10) # to match central clustering
+            process = self.transformJetSeq(process, "ak8PFJetsPuppiLowCut", {"SoftDrop":"ak8PFJetsPuppiLowCutSoftDrop"}, "recoPFJets")
 
-            JetAK8Tag = cms.InputTag("packedPatJetsAK8PFPuppiNoCutSoftDrop")
-            SubjetTag = cms.InputTag("selectedPatJetsAK8PFPuppiNoCutSoftDropPacked:SubJets")
+            JetAK8Tag = cms.InputTag("packedPatJetsAK8PFPuppiLowCutSoftDrop")
+            SubjetTag = cms.InputTag("selectedPatJetsAK8PFPuppiLowCutSoftDropPacked:SubJets")
             SubjetName = cms.string("SoftDrop")
             GenJetAK8Tag = cms.InputTag("ak8GenJetsNoNu")
 
@@ -899,13 +900,13 @@ def makeTreeFromMiniAOD(self,process):
         storeProperties=2,
     )
     if self.tchannel:
-        process.JetPropertiesAK8.NsubjettinessTau1 = cms.vstring('NjettinessAK8PuppiNoCut:tau1')
-        process.JetPropertiesAK8.NsubjettinessTau2 = cms.vstring('NjettinessAK8PuppiNoCut:tau2')
-        process.JetPropertiesAK8.NsubjettinessTau3 = cms.vstring('NjettinessAK8PuppiNoCut:tau3')
-        process.JetPropertiesAK8.ecfN2b1 = cms.vstring('ak8PFJetsPuppiNoCutSoftDropValueMap:nb1AK8PuppiNoCutSoftDropN2')
-        process.JetPropertiesAK8.ecfN2b2 = cms.vstring('ak8PFJetsPuppiNoCutSoftDropValueMap:nb2AK8PuppiNoCutSoftDropN2')
-        process.JetPropertiesAK8.ecfN3b1 = cms.vstring('ak8PFJetsPuppiNoCutSoftDropValueMap:nb1AK8PuppiNoCutSoftDropN3')
-        process.JetPropertiesAK8.ecfN3b2 = cms.vstring('ak8PFJetsPuppiNoCutSoftDropValueMap:nb2AK8PuppiNoCutSoftDropN3')
+        process.JetPropertiesAK8.NsubjettinessTau1 = cms.vstring('NjettinessAK8PuppiLowCut:tau1')
+        process.JetPropertiesAK8.NsubjettinessTau2 = cms.vstring('NjettinessAK8PuppiLowCut:tau2')
+        process.JetPropertiesAK8.NsubjettinessTau3 = cms.vstring('NjettinessAK8PuppiLowCut:tau3')
+        process.JetPropertiesAK8.ecfN2b1 = cms.vstring('ak8PFJetsPuppiLowCutSoftDropValueMap:nb1AK8PuppiLowCutSoftDropN2')
+        process.JetPropertiesAK8.ecfN2b2 = cms.vstring('ak8PFJetsPuppiLowCutSoftDropValueMap:nb2AK8PuppiLowCutSoftDropN2')
+        process.JetPropertiesAK8.ecfN3b1 = cms.vstring('ak8PFJetsPuppiLowCutSoftDropValueMap:nb1AK8PuppiLowCutSoftDropN3')
+        process.JetPropertiesAK8.ecfN3b2 = cms.vstring('ak8PFJetsPuppiLowCutSoftDropValueMap:nb2AK8PuppiLowCutSoftDropN3')
         process.JetPropertiesAK8.softDropMass = cms.vstring('SoftDrop')
         process.JetPropertiesAK8.subjets = cms.vstring('SoftDrop')
         process.JetPropertiesAK8.SJbDiscriminatorCSV = cms.vstring('SoftDrop', 'pfCombinedInclusiveSecondaryVertexV2BJetTags')

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -346,6 +346,25 @@ def makeTreeFromMiniAOD(self,process):
                 verbosity = 2 if self.verbose else 0,
             )
 
+            # todo: revamp jet toolbox to handle this
+
+            process.ak8GenJetsNoNu = process.ak8GenJetsNoNuSoftDrop.clone(
+                oneShotTransform = cms.bool(True),
+                jetPtMin = process.ak8GenJetsNoNu.jetPtMin,
+                jetCollInstanceName = getattr(process.ak8GenJetsNoNu,'jetCollInstanceName',''),
+                writeCompound = getattr(process.ak8GenJetsNoNu,'writeCompound',False),
+                jetPtMinTransform = process.ak8GenJetsNoNuSoftDrop.jetPtMin,
+                jetTransformName = cms.string("SoftDrop"),
+                jetTransformCollName = process.ak8GenJetsNoNuSoftDrop.jetCollInstanceName,
+            )
+            del process.ak8GenJetsNoNuSoftDrop
+            process.ak8GenJetsNoNuSoftDrop = cms.EDAlias(
+                ak8GenJetsNoNu = cms.VPSet(
+                    cms.PSet(type = cms.string("recoBasicJets"), fromProductInstance = cms.string("SoftDrop"), toProductInstance = cms.string("")),
+                    cms.PSet(type = cms.string("recoGenJets"), fromProductInstance = cms.string("SoftDropSubJets"), toProductInstance = cms.string("SubJets")),
+                )
+            )
+
             JetAK8Tag = cms.InputTag("packedPatJetsAK8PFPuppiNoCutSoftDrop")
             SubjetTag = cms.InputTag("selectedPatJetsAK8PFPuppiNoCutSoftDropPacked:SubJets")
             SubjetName = cms.string("SoftDrop")

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -9,15 +9,17 @@ def transformJetSeq(self, process, baseModule, transformModule, jetType, transfo
     base = getattr(process, baseModule)
     transform = getattr(process, transformModule)
 
-    base = transform.clone(
-        oneShotTransform = cms.bool(True),
-        jetPtMin = base.jetPtMin,
-        jetCollInstanceName = getattr(base,'jetCollInstanceName',''),
-        writeCompound = getattr(base,'writeCompound',False),
-        jetTransformName = cms.string(transformName),
-        jetPtMinTransform = transform.jetPtMin,
-        jetTransformCollName = transform.jetCollInstanceName,
+    setattr(process, baseModule, transform.clone(
+            oneShotTransform = cms.bool(True),
+            jetPtMin = base.jetPtMin,
+            jetCollInstanceName = getattr(base,'jetCollInstanceName',''),
+            writeCompound = getattr(base,'writeCompound',False),
+            jetTransformName = cms.string(transformName),
+            jetPtMinTransform = transform.jetPtMin,
+            jetTransformCollName = transform.jetCollInstanceName,
+        )
     )
+    base = getattr(process, baseModule)
     delattr(process, transformModule)
     setattr(process, transformModule, cms.EDAlias(
             **{baseModule: cms.VPSet(

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -386,8 +386,8 @@ def makeTreeFromMiniAOD(self,process):
 
             # todo: revamp jet toolbox to handle this
             process = self.transformJetSeq(process, "ak8GenJetsNoNu", {"SoftDrop":"ak8GenJetsNoNuSoftDrop"}, "recoGenJets")
+            process.ak8PFJetsPuppiNoCutSoftDrop.jetPtMin = cms.double(5.0) # to match central clustering
             process = self.transformJetSeq(process, "ak8PFJetsPuppiNoCut", {"SoftDrop":"ak8PFJetsPuppiNoCutSoftDrop"}, "recoPFJets")
-#            process.ak8PFJetsPuppiNoCut.jetPtMinTransform = cms.double(5.0) # to match central clustering
 
             JetAK8Tag = cms.InputTag("packedPatJetsAK8PFPuppiNoCutSoftDrop")
             SubjetTag = cms.InputTag("selectedPatJetsAK8PFPuppiNoCutSoftDropPacked:SubJets")

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -365,7 +365,7 @@ def makeTreeFromMiniAOD(self,process):
             jetToolbox(process,
                 'ak8',
                 'jetSequence',
-                'out',
+                'noOutput',
                 PUMethod = 'Puppi',
                 useExistingWeights=True,
                 dataTier='miniAOD',

--- a/TreeMaker/python/maker.py
+++ b/TreeMaker/python/maker.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 # import functions to be assigned as class methods
-from TreeMaker.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD
+from TreeMaker.TreeMaker.makeTreeFromMiniAOD_cff import makeTreeFromMiniAOD, transformJetSeq
 from TreeMaker.TreeMaker.JetDepot import JetVariations
 from TreeMaker.TreeMaker.makeJetVars import makeJetVars, makeGoodJets, makeJetVarsAK8, makeMHTVars
 from TreeMaker.TreeMaker.doHadTauBkg import doHadTauBkg, makeJetVarsHadTau
@@ -221,6 +221,7 @@ class maker:
 
     # assign class methods from functions
     makeTreeFromMiniAOD = makeTreeFromMiniAOD
+    transformJetSeq = transformJetSeq
     JetVariations = JetVariations
     makeGoodJets = makeGoodJets
     makeJetVars = makeJetVars

--- a/setup.sh
+++ b/setup.sh
@@ -155,6 +155,7 @@ if [[ "$CMSSWVER" == "CMSSW_10_6_"* ]]; then
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:storeJERFactorIndex10620p1
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:AddJetAxis1_10620p1
 	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:PuppiReserve106X
+	git cms-merge-topic -u $ACCESS_CMSSW TreeMaker:OneShotTransforms106X
 fi
 
 # outside repositories


### PR DESCRIPTION
I realized that `FastjetJetProducer` reruns the entire jet clustering, including the jet area computation, each time it is called (e.g. to get softdrop jets). This is computationally expensive and could be avoided by running the base clustering and multiple jet grooming algorithms all in the same instance of the producer. This PR adds to our setup a CMSSW branch (https://github.com/cms-sw/cmssw/compare/CMSSW_10_6_X...TreeMaker:OneShotTransforms106X) that modifies `FastjetJetProducer` (and `VirtualJetProducer`) accordingly, as well as a helper function to transform jet reclustering sequences to use the new, combined approach.

For the workflow with AK8 reclustering, this results in a 33% speedup. For the workflow with both AK8 and AK15 reclustering, this results in a 38% speedup. Similar speedups are expected for workflows using the "cleaned" reclustering for the Z->inv background estimation (which is no longer enabled by default).

Most of the speedup in the AK8 reclustering workflow is subsequently eliminated by reducing the `jetPtMin` cut for `SoftDrop` from the default 100 GeV to 5 GeV. This value should probably be tuned further, which will recover some percentage of the speedup. (The AK8+AK15 workflow still has a 31% speedup in this case.)