### PR TITLE
Faster constituent matching

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -880,9 +880,9 @@ def makeTreeFromMiniAOD(self,process):
             'JetPropertiesAK8:jerFactorDown(JetsAK8_jerFactorDown)',
         ])
 
-    # record final jet collections
-    self.JetsTags.extend([JetTag,JetAK8Tag])
-    self.JetsNames.extend(["Jets","JetsAK8"])
+    # record final jet collections (excluding AK4)
+    self.JetsTags.extend([JetAK8Tag])
+    self.JetsNames.extend(["JetsAK8"])
 
     ## ----------------------------------------------------------------------------------------------
     ## GenJet variables
@@ -1301,7 +1301,7 @@ def makeTreeFromMiniAOD(self,process):
             suffix = cms.string("ConstituentsIndex"),
             JetsTags = cms.VInputTag(self.JetsTags),
             JetsNames = cms.vstring(self.JetsNames),
-            CandTag = cms.InputTag("packedPFCandidates"),
+            CandTag = cms.InputTag("puppipackedPFCandidates"),
             properties = cms.vstring("PdgId"),
         )
         self.VectorLorentzVector.append("JetsConstituents")

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1302,6 +1302,7 @@ def makeTreeFromMiniAOD(self,process):
             JetsTags = cms.VInputTag(self.JetsTags),
             JetsNames = cms.vstring(self.JetsNames),
             CandTag = cms.InputTag("packedPFCandidates"),
+            properties = cms.vstring("PdgId"),
         )
         self.VectorLorentzVector.append("JetsConstituents")
         self.VectorInt.append("JetsConstituents:PdgId(JetsConstituents_PdgId)")

--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -36,7 +36,7 @@ class NamedPtrBase {
 	public:
 		//constructor
 		NamedPtrBase() : name(""), fraction(false) {}
-		NamedPtrBase(std::string name_, edm::stream::EDProducer<>* edprod, const edm::ParameterSet& iConfig) : 
+		NamedPtrBase(const std::string& name_, edm::stream::EDProducer<>* edprod, const edm::ParameterSet& iConfig) :
 			name(name_),
 			fraction(name.find("Fraction")!=std::string::npos),
 			response(name.find("response")!=std::string::npos)
@@ -65,7 +65,7 @@ class NamedPtr : public NamedPtrBase {
 	public:
 		//constructor
 		NamedPtr() : NamedPtrBase() {}
-		NamedPtr(std::string name_, edm::stream::EDProducer<>* edprod, const edm::ParameterSet& iConfig) : NamedPtrBase(name_,edprod,iConfig), ptr(std::make_unique<std::vector<T>>()) {
+		NamedPtr(const std::string& name_, edm::stream::EDProducer<>* edprod, const edm::ParameterSet& iConfig) : NamedPtrBase(name_,edprod,iConfig), ptr(std::make_unique<std::vector<T>>()) {
 			edprod->produces<std::vector<T>>(name);
 		}
 		//destructor
@@ -80,7 +80,7 @@ class NamedPtr : public NamedPtrBase {
 };
 
 // factory
-typedef edmplugin::PluginFactory<NamedPtrBase *(std::string, edm::stream::EDProducer<>*, const edm::ParameterSet&)> NamedPtrFactory;
+typedef edmplugin::PluginFactory<NamedPtrBase *(const std::string&, edm::stream::EDProducer<>*, const edm::ParameterSet&)> NamedPtrFactory;
 EDM_REGISTER_PLUGINFACTORY(NamedPtrFactory, "NamedPtrFactory");
 #define DEFINE_NAMED_PTR(type) DEFINE_EDM_PLUGIN(NamedPtrFactory,NamedPtr_##type,#type)
 #define DEFAULT_NAMED_PTR(type,name) DEFINE_EDM_PLUGIN(NamedPtrFactory,NamedPtr_##type,#name)
@@ -545,12 +545,12 @@ JetProperties::JetProperties(const edm::ParameterSet& iConfig)
 	}
 
 	//get lists of desired properties
-	std::vector<std::string> props = iConfig.getParameter<std::vector<std::string>> ("properties");
+	const auto& props = iConfig.getParameter<std::vector<std::string>> ("properties");
 
 	auto fac = NamedPtrFactory::get();
 	Ptrs_.reserve(props.size());
 	//register your products
-	for(auto& p : props){
+	for(const auto& p : props){
 		Ptrs_.push_back(fac->create(p,p,this,iConfig));
 	}	
 }

--- a/Utils/src/JetsConstituents.cc
+++ b/Utils/src/JetsConstituents.cc
@@ -24,7 +24,7 @@ typedef math::PtEtaPhiELorentzVector LorentzVector;
 typedef edm::Ptr<reco::Candidate> CandPtr;
 struct ptr_cand_hash : public std::unary_function<CandPtr, std::size_t> {
 	std::size_t operator()(const CandPtr& ptr) const {
-		return size_t(ptr.product());
+		return ptr.key() ^ ptr.id().processIndex() ^ ptr.id().productIndex();
 	}
 };
 typedef std::unordered_set<CandPtr,ptr_cand_hash> CandPtrSet;

--- a/Utils/src/JetsConstituents.cc
+++ b/Utils/src/JetsConstituents.cc
@@ -14,6 +14,7 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
@@ -67,6 +68,13 @@ class CandProp_PdgId : public CandProp<int> {
 		void get_property(const reco::Candidate& cand) override { push_back(cand.pdgId()); }
 };
 DEFINE_CAND_PROP(PdgId);
+
+class CandProp_PuppiWeight : public CandProp<double> {
+	public:
+		using CandProp<double>::CandProp;
+		void get_property(const reco::Candidate& cand) override { push_back(((pat::PackedCandidate*)(&cand))->puppiWeight()); }
+};
+DEFINE_CAND_PROP(PuppiWeight);
 
 class JetsConstituents : public edm::stream::EDProducer<> {
 public:


### PR DESCRIPTION
Using a hash table makes find O(1) rather than O(n) for linear search, at the cost of some overhead (creating the hash table and keeping it in memory). The current measured speedup is about 40% faster than the linear search version. The hash function may be able to be optimized further.

This PR also introduces a factory pattern (based on JetProperties) to request and store constituent properties. Currently, only PdgId is implemented. A few minor optimizations are propagated back to JetProperties.