### PR TITLE
Arg updates and bug fixes

### DIFF
--- a/Production/test/condorSub/dict_Summer20UL16APV_qcd.py
+++ b/Production/test/condorSub/dict_Summer20UL16APV_qcd.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16APV",
-   "args": "boostedsemivisible=True emerging=True",
+   "args": "boostedsemivisible=True emerging=True tchannel=True",
    "samples": [
 
        ['Summer20UL16APV.QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16APV_qcd_pt.py
+++ b/Production/test/condorSub/dict_Summer20UL16APV_qcd_pt.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16APV",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL16APV.QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16APV_ttbar.py
+++ b/Production/test/condorSub/dict_Summer20UL16APV_ttbar.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16APV",
-   "args": "saveMinimalGenParticles=False boostedsemivisible=True",
+   "args": "saveMinimalGenParticles=False",
    "samples": [
 
        ['Summer20UL16APV.TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16APV_ttjets.py
+++ b/Production/test/condorSub/dict_Summer20UL16APV_ttjets.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16APV",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL16APV.TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16APV_wjetslep.py
+++ b/Production/test/condorSub/dict_Summer20UL16APV_wjetslep.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16APV",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL16APV.WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16APV_zjets.py
+++ b/Production/test/condorSub/dict_Summer20UL16APV_zjets.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16APV",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL16APV.ZJetsToNuNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16_qcd.py
+++ b/Production/test/condorSub/dict_Summer20UL16_qcd.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16",
-   "args": "boostedsemivisible=True emerging=True",
+   "args": "boostedsemivisible=True emerging=True tchannel=True",
    "samples": [
 
        ['Summer20UL16.QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16_qcd_pt.py
+++ b/Production/test/condorSub/dict_Summer20UL16_qcd_pt.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL16.QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16_ttbar.py
+++ b/Production/test/condorSub/dict_Summer20UL16_ttbar.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16",
-   "args": "saveMinimalGenParticles=False boostedsemivisible=True",
+   "args": "saveMinimalGenParticles=False",
    "samples": [
 
        ['Summer20UL16.TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16_ttjets.py
+++ b/Production/test/condorSub/dict_Summer20UL16_ttjets.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL16.TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16_wjetslep.py
+++ b/Production/test/condorSub/dict_Summer20UL16_wjetslep.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL16.WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL16_zjets.py
+++ b/Production/test/condorSub/dict_Summer20UL16_zjets.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL16",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL16.ZJetsToNuNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL17_qcd.py
+++ b/Production/test/condorSub/dict_Summer20UL17_qcd.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL17",
-   "args": "boostedsemivisible=True emerging=True",
+   "args": "boostedsemivisible=True emerging=True tchannel=True",
    "samples": [
 
        ['Summer20UL17.QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraph-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL17_qcd_pt.py
+++ b/Production/test/condorSub/dict_Summer20UL17_qcd_pt.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL17",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
         ['Summer20UL17.QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL17_ttbar.py
+++ b/Production/test/condorSub/dict_Summer20UL17_ttbar.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL17",
-   "args": "saveMinimalGenParticles=False boostedsemivisible=True",
+   "args": "saveMinimalGenParticles=False",
    "samples": [
 
        ['Summer20UL17.TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL17_ttjets.py
+++ b/Production/test/condorSub/dict_Summer20UL17_ttjets.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL17",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL17.TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL17_wjetslep.py
+++ b/Production/test/condorSub/dict_Summer20UL17_wjetslep.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL17",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL17.WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL17_zjets.py
+++ b/Production/test/condorSub/dict_Summer20UL17_zjets.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL17",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL17.ZJetsToNuNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL18_qcd.py
+++ b/Production/test/condorSub/dict_Summer20UL18_qcd.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL18",
-   "args": "boostedsemivisible=True emerging=True",
+   "args": "boostedsemivisible=True emerging=True tchannel=True",
    "samples": [
 
        ['Summer20UL18.QCD_HT1000to1500_TuneCP5_PSWeights_13TeV-madgraph-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL18_qcd_pt.py
+++ b/Production/test/condorSub/dict_Summer20UL18_qcd_pt.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL18",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL18.QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL18_ttbar.py
+++ b/Production/test/condorSub/dict_Summer20UL18_ttbar.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL18",
-   "args": "saveMinimalGenParticles=False boostedsemivisible=True",
+   "args": "saveMinimalGenParticles=False",
    "samples": [
 
        ['Summer20UL18.TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL18_ttjets.py
+++ b/Production/test/condorSub/dict_Summer20UL18_ttjets.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL18",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL18.TTJets_DiLept_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL18_wjetslep.py
+++ b/Production/test/condorSub/dict_Summer20UL18_wjetslep.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL18",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL18.WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_Summer20UL18_zjets.py
+++ b/Production/test/condorSub/dict_Summer20UL18_zjets.py
@@ -1,7 +1,7 @@
 flist = {
 
    "scenario": "Summer20UL18",
-   "args": "boostedsemivisible=True",
+   "args": "boostedsemivisible=True tchannel=True",
    "samples": [
 
        ['Summer20UL18.ZJetsToNuNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8'],

--- a/Production/test/condorSub/dict_UL2016B_HIPM_jetht.py
+++ b/Production/test/condorSub/dict_UL2016B_HIPM_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2016B-UL2016_HIPM-ver2-v3.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2016B_HIPM_met.py
+++ b/Production/test/condorSub/dict_UL2016B_HIPM_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016B-UL2016_HIPM-ver2-v1.HTMHT"],
         ["Run2016B-UL2016_HIPM-ver2-v2.MET"],

--- a/Production/test/condorSub/dict_UL2016B_HIPM_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2016B_HIPM_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016B-UL2016_HIPM-ver2-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2016C_HIPM_jetht.py
+++ b/Production/test/condorSub/dict_UL2016C_HIPM_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2016C-UL2016_HIPM-v2.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2016C_HIPM_met.py
+++ b/Production/test/condorSub/dict_UL2016C_HIPM_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016C-UL2016_HIPM-v1.HTMHT"],
         ["Run2016C-UL2016_HIPM-v2.MET"],

--- a/Production/test/condorSub/dict_UL2016C_HIPM_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2016C_HIPM_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016C-UL2016_HIPM-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2016D_HIPM_jetht.py
+++ b/Production/test/condorSub/dict_UL2016D_HIPM_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2016D-UL2016_HIPM-v2.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2016D_HIPM_met.py
+++ b/Production/test/condorSub/dict_UL2016D_HIPM_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016D-UL2016_HIPM-v1.HTMHT"],
         ["Run2016D-UL2016_HIPM-v2.MET"],

--- a/Production/test/condorSub/dict_UL2016D_HIPM_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2016D_HIPM_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016D-UL2016_HIPM-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2016E_HIPM_jetht.py
+++ b/Production/test/condorSub/dict_UL2016E_HIPM_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2016E-UL2016_HIPM-v2.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2016E_HIPM_met.py
+++ b/Production/test/condorSub/dict_UL2016E_HIPM_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016E-UL2016_HIPM-v1.HTMHT"],
         ["Run2016E-UL2016_HIPM-v2.MET"],

--- a/Production/test/condorSub/dict_UL2016E_HIPM_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2016E_HIPM_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016E-UL2016_HIPM-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2016F_HIPM_jetht.py
+++ b/Production/test/condorSub/dict_UL2016F_HIPM_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2016F-UL2016_HIPM-v2.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2016F_HIPM_met.py
+++ b/Production/test/condorSub/dict_UL2016F_HIPM_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016F-UL2016_HIPM-v1.HTMHT"],
         ["Run2016F-UL2016_HIPM-v2.MET"],

--- a/Production/test/condorSub/dict_UL2016F_HIPM_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2016F_HIPM_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16APV_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016F-UL2016_HIPM-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2016F_jetht.py
+++ b/Production/test/condorSub/dict_UL2016F_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2016F-UL2016-v2.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2016F_met.py
+++ b/Production/test/condorSub/dict_UL2016F_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016F-UL2016-v1.HTMHT"],
         ["Run2016F-UL2016-v2.MET"],

--- a/Production/test/condorSub/dict_UL2016F_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2016F_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016F-UL2016-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2016G_jetht.py
+++ b/Production/test/condorSub/dict_UL2016G_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2016G-UL2016-v2.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2016G_met.py
+++ b/Production/test/condorSub/dict_UL2016G_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016G-UL2016-v1.HTMHT"],
         ["Run2016G-UL2016-v2.MET"],

--- a/Production/test/condorSub/dict_UL2016G_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2016G_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016G-UL2016-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2016H_jetht.py
+++ b/Production/test/condorSub/dict_UL2016H_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2016H-UL2016-v2.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2016H_met.py
+++ b/Production/test/condorSub/dict_UL2016H_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016H-UL2016-v1.HTMHT"],
         ["Run2016H-UL2016-v2.MET"],

--- a/Production/test/condorSub/dict_UL2016H_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2016H_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL16_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2016H-UL2016-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2017B_jetht.py
+++ b/Production/test/condorSub/dict_UL2017B_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2017B-UL2017-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2017B_met.py
+++ b/Production/test/condorSub/dict_UL2017B_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017B-UL2017-v1.HTMHT"],
         ["Run2017B-UL2017-v1.MET"],

--- a/Production/test/condorSub/dict_UL2017B_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2017B_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017B-UL2017-v1.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2017C_jetht.py
+++ b/Production/test/condorSub/dict_UL2017C_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2017C-UL2017-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2017C_met.py
+++ b/Production/test/condorSub/dict_UL2017C_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017C-UL2017-v1.HTMHT"],
         ["Run2017C-UL2017-v1.MET"],

--- a/Production/test/condorSub/dict_UL2017C_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2017C_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017C-UL2017-v1.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2017D_jetht.py
+++ b/Production/test/condorSub/dict_UL2017D_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2017D-UL2017-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2017D_met.py
+++ b/Production/test/condorSub/dict_UL2017D_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017D-UL2017-v1.HTMHT"],
         ["Run2017D-UL2017-v1.MET"],

--- a/Production/test/condorSub/dict_UL2017D_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2017D_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017D-UL2017-v1.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2017E_jetht.py
+++ b/Production/test/condorSub/dict_UL2017E_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2017E-UL2017-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2017E_met.py
+++ b/Production/test/condorSub/dict_UL2017E_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017E-UL2017-v1.HTMHT"],
         ["Run2017E-UL2017-v1.MET"],

--- a/Production/test/condorSub/dict_UL2017E_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2017E_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017E-UL2017-v1.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2017F_jetht.py
+++ b/Production/test/condorSub/dict_UL2017F_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2017F-UL2017-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2017F_met.py
+++ b/Production/test/condorSub/dict_UL2017F_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017F-UL2017-v2.HTMHT"],
         ["Run2017F-UL2017-v1.MET"],

--- a/Production/test/condorSub/dict_UL2017F_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2017F_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL17_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2017F-UL2017-v1.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2018A_jetht.py
+++ b/Production/test/condorSub/dict_UL2018A_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2018A-UL2018-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2018A_met.py
+++ b/Production/test/condorSub/dict_UL2018A_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2018A-UL2018-v2.MET"],
    ]

--- a/Production/test/condorSub/dict_UL2018A_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2018A_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2018A-UL2018-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2018B_jetht.py
+++ b/Production/test/condorSub/dict_UL2018B_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2018B-UL2018-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2018B_met.py
+++ b/Production/test/condorSub/dict_UL2018B_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2018B-UL2018-v2.MET"],
    ]

--- a/Production/test/condorSub/dict_UL2018B_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2018B_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2018B-UL2018-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2018C_jetht.py
+++ b/Production/test/condorSub/dict_UL2018C_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2018C-UL2018-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2018C_met.py
+++ b/Production/test/condorSub/dict_UL2018C_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2018C-UL2018-v1.MET"],
    ]

--- a/Production/test/condorSub/dict_UL2018C_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2018C_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2018C-UL2018-v2.SingleMuon"],
    ]

--- a/Production/test/condorSub/dict_UL2018D_jetht.py
+++ b/Production/test/condorSub/dict_UL2018D_jetht.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
-    "args": "boostedsemivisible=True emerging=True",
+    "args": "boostedsemivisible=True emerging=True tchannel=True",
     "samples": [
         ["Run2018D-UL2018-v1.JetHT"],
    ]

--- a/Production/test/condorSub/dict_UL2018D_met.py
+++ b/Production/test/condorSub/dict_UL2018D_met.py
@@ -1,5 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2018D-UL2018-v1.MET"],
    ]

--- a/Production/test/condorSub/dict_UL2018D_singlemuon.py
+++ b/Production/test/condorSub/dict_UL2018D_singlemuon.py
@@ -1,6 +1,6 @@
 flist = {
     "scenario": "Summer20UL18_DATA",
-    "args": "boostedsemivisible=True",
+    "args": "boostedsemivisible=True tchannel=True",
     "samples": [
         ["Run2018D-UL2018-v3.SingleMuon"],
    ]

--- a/Production/test/condorSub/jobSubmitterTM.py
+++ b/Production/test/condorSub/jobSubmitterTM.py
@@ -119,7 +119,7 @@ class jobSubmitterTM(jobSubmitter):
                         nJobs += 1
 
                 if self.maxJobs >= 0:
-                    print "Limiting to max {0} jobs".format(self.maxJobs)
+                    if self.verbose: print "Limiting to max {0} jobs".format(self.maxJobs)
                     nJobs = min([nJobs, self.maxJobs])
 
                 netJobs = nJobs - int(firstJob)

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1359,6 +1359,10 @@ def makeTreeFromMiniAOD(self,process):
             CandTag = cms.InputTag("puppipackedPFCandidates"),
             properties = cms.vstring("PdgId"),
         )
+        # if jets have not been reclustered, use the default miniAOD candidate collection
+        # WARNING: the case where some jet collections are reclustered, but others are not, will not work properly (todo)
+        if not self.boostedsemivisible and not self.tchannel:
+            process.JetsConstituents.CandTag = cms.InputTag("packedPFCandidates")
         self.VectorLorentzVector.append("JetsConstituents")
         self.VectorInt.append("JetsConstituents:PdgId(JetsConstituents_PdgId)")
         self.VectorVectorInt.extend(["JetsConstituents:{}{}({}{})".format(JetsName,process.JetsConstituents.suffix.value(),JetsName,"_constituentsIndex") for JetsName in self.JetsNames])

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -1346,7 +1346,7 @@ def makeTreeFromMiniAOD(self,process):
 
         # store AK15 genjets
         if self.geninfo:
-	        self.VectorRecoCand.extend(['ak15GenJetsNoNu(GenJetsAK15)'])
+            self.VectorRecoCand.extend(['ak15GenJetsNoNu(GenJetsAK15)'])
 
     ## ----------------------------------------------------------------------------------------------
     ## Jet constituents

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -386,7 +386,7 @@ def makeTreeFromMiniAOD(self,process):
             )
 
             # todo: revamp jet toolbox to handle this
-            if not self.doZinv: # calling jet toolbox again for ak8 would break after this, so skip it
+            if self.geninfo and not self.doZinv: # calling jet toolbox again for ak8 would break after this, so skip it
                 process = self.transformJetSeq(process, "ak8GenJetsNoNu", {"SoftDrop":"ak8GenJetsNoNuSoftDrop"}, "recoGenJets")
             process.ak8PFJetsPuppiLowCutSoftDrop.jetPtMin = cms.double(10) # to match central clustering
             process = self.transformJetSeq(process, "ak8PFJetsPuppiLowCut", {"SoftDrop":"ak8PFJetsPuppiLowCutSoftDrop"}, "recoPFJets")
@@ -1281,7 +1281,8 @@ def makeTreeFromMiniAOD(self,process):
             matched = cms.InputTag("ak15PFJetsPuppiSoftDropBeta1")
         )
 
-        process = self.transformJetSeq(process, "ak15GenJetsNoNu", {"SoftDrop":"ak15GenJetsNoNuSoftDrop"}, "recoGenJets")
+        if self.geninfo:
+            process = self.transformJetSeq(process, "ak15GenJetsNoNu", {"SoftDrop":"ak15GenJetsNoNuSoftDrop"}, "recoGenJets")
         process = self.transformJetSeq(process, "ak15PFJetsPuppi", {"SoftDrop":"ak15PFJetsPuppiSoftDrop", "SoftDropBeta1":"ak15PFJetsPuppiSoftDropBeta1"}, "recoPFJets")
 
         # update userfloats (used for jet ID, including ID for JEC/JER variations)
@@ -1344,7 +1345,8 @@ def makeTreeFromMiniAOD(self,process):
         self.JetsNames.append("JetsAK15")
 
         # store AK15 genjets
-        self.VectorRecoCand.extend (['ak15GenJetsNoNu(GenJetsAK15)'])
+        if self.geninfo:
+	        self.VectorRecoCand.extend(['ak15GenJetsNoNu(GenJetsAK15)'])
 
     ## ----------------------------------------------------------------------------------------------
     ## Jet constituents

--- a/Utils/src/JetsConstituents.cc
+++ b/Utils/src/JetsConstituents.cc
@@ -20,6 +20,20 @@
 
 typedef math::PtEtaPhiELorentzVector LorentzVector;
 
+namespace {
+
+bool same_indices(const std::vector<int>& values){
+	int base_value = -1;
+	for(auto value : values){
+		if(value==-1) continue;
+		if(base_value==-1) base_value = value;
+		else if(base_value!=value) return false;
+	}
+	return true;
+}
+
+}
+
 //base class for constituent properties
 class CandPropBase {
 	public:
@@ -174,7 +188,7 @@ void JetsConstituents::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 	//between-collection safety check (also include constituent collection)
 	processIndex.push_back(h_cands->ptrs()[0].id().processIndex());
 	productIndex.push_back(h_cands->ptrs()[0].id().productIndex());
-	if(std::adjacent_find(processIndex.begin(),processIndex.end(),std::not_equal_to<int>())!=processIndex.end() or std::adjacent_find(productIndex.begin(),productIndex.end(),std::not_equal_to<int>())!=productIndex.end()){
+	if(!same_indices(processIndex) or !same_indices(productIndex)){
 		std::stringstream ss;
 		for(unsigned i = 0; i < processIndex.size(); ++i){
 			ss << "(" << processIndex[i] << ", " << productIndex[i] << "), ";


### PR DESCRIPTION
* add `tchannel` arg where needed
* remove SVJ settings from ttbar powheg samples, since ttjets madgraph now available
* fix some genjet changes to apply only to MC
* fix jet constituent process/product index check, constituent collection for non-reclustered case