### PR TITLE
 [Run2_UL] Clean mode with folders

### DIFF
--- a/Production/test/condorSub/jobSubmitterTM.py
+++ b/Production/test/condorSub/jobSubmitterTM.py
@@ -180,23 +180,34 @@ class jobSubmitterTM(jobSubmitter):
                 # store protojob
                 self.protoJobs.append(job)
 
+    def findFolderizedJobs(self,job):
+        if not hasattr(self,"checkedDirectories"):
+            setattr(self,"checkedDirectories",set())
+
+        if hasattr(self,"output"):
+            bottomDir = self.output + "/" + job.name.replace('.','/')
+            if bottomDir not in self.checkedDirectories:
+                finishedFilesPerJob = pyxrdfsls(bottomDir)
+                finishedFilesPerJobSplit = [finished.split('/') for finished in finishedFilesPerJob]
+                finishedFilesPerJob = ['.'.join(finished[-3:-1]) + "_" + finished[-1].replace("_RA2AnalysisTree.root","") for finished in finishedFilesPerJobSplit]
+                self.filesSet |= set(finishedFilesPerJob)
+                self.checkedDirectories.add(bottomDir)
+
     def doMissing(self,job):
         # add to finished files in case the files are folderized
         if self.useFolders:
-            if not hasattr(self,"checkedDirectories"):
-                setattr(self,"checkedDirectories",set())
-
-            if hasattr(self,"output"):
-                bottomDir = self.output + "/" + job.name.replace('.','/')
-                if bottomDir not in self.checkedDirectories:
-                    finishedFilesPerJob = pyxrdfsls(bottomDir,self.minDate,self.maxDate)
-                    finishedFilesPerJobSplit = [finished.split('/') for finished in finishedFilesPerJob]
-                    finishedFilesPerJob = ['.'.join(finished[-3:-1]) + "_" + finished[-1].replace("_RA2AnalysisTree.root","") for finished in finishedFilesPerJobSplit]
-                    self.filesSet |= set(finishedFilesPerJob)
-                    self.checkedDirectories.add(bottomDir)
+            self.findFolderizedJobs(job)
 
         # now do the rest of missing mode
         super(jobSubmitterTM,self).doMissing(job)
+
+    def doClean(self,job):
+        # add to finished files in case the files are folderized
+        if self.useFolders:
+            self.findFolderizedJobs(job)
+
+        # now do the rest of clean mode
+        super(jobSubmitterTM,self).doClean(job)
 
     def finishedToJobName(self,val):
         return val.split("/")[-1].replace("_RA2AnalysisTree.root","")


### PR DESCRIPTION
Make sure that clean mode works with folderized outputs. Currently clean mode only looks in the top level directory and sees no finished jobs. Unfortunately, the actual job level outputs aren't available during the initialization of clean mode [1], but only during the job-by-job stage. For each job, the outputs in the bottom level folder are checked and the files which are missing from the list of finished files are added to the list of finished files. Thus, the final list of finished files is built up job-by-job. There is an optimization already in place to make sure that each bottom level directory is only checked once. This reduces the number of xrdfs calls.

In my testing, this works and correctly cleans up the logs for the V20v2 production when the -f option is used.

[1] It's really the missing mode code which does the majority of the initialization.