### PR TITLE
[Run2_UL] Change copy protocol for T1_US_FNAL

### DIFF
--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -92,14 +92,17 @@ if [[ -z "$CMSSITE" ]] || [[ "$CMSSITE" == "" ]]; then
 fi
 export CMDSTR="xrdcp"
 export GFLAG=""
+export COPYARGS="-f"
 if [[ ( "$CMSSITE" == *"T1_US_FNAL"* && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
 	export CMDSTR="gfal-copy"
 	export GFLAG="-g"
+	export COPYARGS="${COPYARGS} -p"
 	export WEBDAV_ENDPOINT="davs://cmseos.fnal.gov:9000/eos/uscms/store/user/"
 	export OUTDIR=${WEBDAV_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
 elif [[ "${OUTDIR}" == *"davs://"* ]]; then
 	export CMDSTR="gfal-copy"
 	export GFLAG="-g"
+	export COPYARGS="${COPYARGS} -p"
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do
@@ -111,7 +114,7 @@ for FILE in *.root; do
 		echo -e "\t   After change: ${FILE_DST}"
 	fi
 	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE_DST}"
-	stageOut ${GFLAG} -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE_DST} -r -c '*.root'
+	stageOut ${GFLAG} -x ${COPYARGS} -i ${FILE} -o ${OUTDIR}/${FILE_DST} -r -c '*.root'
 	XRDEXIT=$?
 	if [[ $XRDEXIT -ne 0 ]]; then
 		echo "exit code $XRDEXIT, failure in $CMDSTR"

--- a/Production/test/condorSub/step2.sh
+++ b/Production/test/condorSub/step2.sh
@@ -95,9 +95,9 @@ export GFLAG=""
 if [[ ( "$CMSSITE" == *"T1_US_FNAL"* && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
 	export CMDSTR="gfal-copy"
 	export GFLAG="-g"
-	export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
-	export OUTDIR=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
-elif [[ "${OUTDIR}" == *"gsiftp://"* ]]; then
+	export WEBDAV_ENDPOINT="davs://cmseos.fnal.gov:9000/eos/uscms/store/user/"
+	export OUTDIR=${WEBDAV_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
+elif [[ "${OUTDIR}" == *"davs://"* ]]; then
 	export CMDSTR="gfal-copy"
 	export GFLAG="-g"
 fi

--- a/Production/test/condorSub/step2Neff.sh
+++ b/Production/test/condorSub/step2Neff.sh
@@ -60,19 +60,22 @@ if [[ -z "$CMSSITE" ]] || [[ "$CMSSITE" == "" ]]; then
 fi
 export CMDSTR="xrdcp"
 export GFLAG=""
+export COPYARGS="-f"
 if [[ ( "$CMSSITE" == *"T1_US_FNAL"* && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
     export CMDSTR="gfal-copy"
     export GFLAG="-g"
+    export COPYARGS="${COPYARGS} -p"
     export WEBDAV_ENDPOINT="davs://cmseos.fnal.gov:9000/eos/uscms/store/user/"
     export OUTDIR=${WEBDAV_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
 elif [[ "${OUTDIR}" == *"davs://"* ]]; then
     export CMDSTR="gfal-copy"
     export GFLAG="-g"
+    export COPYARGS="${COPYARGS} -p"
 fi
 echo "$CMDSTR output for condor"
 for FILE in *.root; do
 	echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE}"
-	stageOut ${GFLAG} -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE} -r -c '*.root'
+	stageOut ${GFLAG} -x ${COPYARGS} -i ${FILE} -o ${OUTDIR}/${FILE} -r -c '*.root'
 	XRDEXIT=$?
 	if [[ $XRDEXIT -ne 0 ]]; then
 		echo "exit code $XRDEXIT, failure in $CMDSTR"

--- a/Production/test/condorSub/step2Neff.sh
+++ b/Production/test/condorSub/step2Neff.sh
@@ -63,9 +63,9 @@ export GFLAG=""
 if [[ ( "$CMSSITE" == *"T1_US_FNAL"* && "${OUTDIR}" == *"root://cmseos.fnal.gov/"* ) ]]; then
     export CMDSTR="gfal-copy"
     export GFLAG="-g"
-    export GSIFTP_ENDPOINT="gsiftp://cmseos-gridftp.fnal.gov//eos/uscms/store/user/"
-    export OUTDIR=${GSIFTP_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
-elif [[ "${OUTDIR}" == *"gsiftp://"* ]]; then
+    export WEBDAV_ENDPOINT="davs://cmseos.fnal.gov:9000/eos/uscms/store/user/"
+    export OUTDIR=${WEBDAV_ENDPOINT}${OUTDIR#root://cmseos.fnal.gov//store/user/}
+elif [[ "${OUTDIR}" == *"davs://"* ]]; then
     export CMDSTR="gfal-copy"
     export GFLAG="-g"
 fi


### PR DESCRIPTION
Change the output protocol for T1_US_FNAL from gsiftp to WebDAV. gsiftp is being phased out and the default protocol for CMS transfers is now WebDAV. While this doesn't change the executable running the copy command (gfal-copy) it does change the protocol used.