### PR TITLE
Handle PDFs, Scales, and PSs for Stealth Signals

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -155,7 +155,7 @@ def makeTreeFromMiniAOD(self,process):
         process.PDFWeights = PDFWeightProducer.clone(
             recalculatePDFs = cms.bool(self.signal),
             recalculateScales = cms.bool(False),
-            normalize = (not any(s in self.sample for s in ["SVJ","EMJ","RPV","SYY","SHH"])), # skip normalization only for SVJ and EMJ signals
+            normalize = (not any(s in self.sample for s in ["SVJ","EMJ"])), # skip normalization only for SVJ and EMJ signals
             pdfSetName = cms.string("NNPDF31_nlo_as_0118"),
 
         )

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -155,8 +155,9 @@ def makeTreeFromMiniAOD(self,process):
         process.PDFWeights = PDFWeightProducer.clone(
             recalculatePDFs = cms.bool(self.signal),
             recalculateScales = cms.bool(False),
-            normalize = (not any(s in self.sample for s in ["SVJ","EMJ"])), # skip normalization only for SVJ and EMJ signals
+            normalize = (not any(s in self.sample for s in ["SVJ","EMJ","RPV","SYY","SHH"])), # skip normalization only for SVJ and EMJ signals
             pdfSetName = cms.string("NNPDF31_nlo_as_0118"),
+
         )
         if "SVJ" in self.sample: # skip trying to get scale and PDF weights for SVJ signals
             process.PDFWeights.nScales = 0
@@ -169,6 +170,10 @@ def makeTreeFromMiniAOD(self,process):
             process.PDFWeights.nQCD = 2
             process.PDFWeights.nEM = 0
             process.PDFWeights.recalculateScales = True
+        if any(s in self.sample for s in ["RPV", "SYY", "SHH"]):
+            process.PDFWeights.nPDFs = 0
+            process.PDFWeights.pdfSetName = cms.string("NNPDF31_nnlo_as_0118_mc_hessian_pdfas")
+
         self.VectorFloat.extend(['PDFWeights:PDFweights','PDFWeights:ScaleWeights','PDFWeights:PSweights'])
 
     ## ----------------------------------------------------------------------------------------------

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -157,7 +157,6 @@ def makeTreeFromMiniAOD(self,process):
             recalculateScales = cms.bool(False),
             normalize = (not any(s in self.sample for s in ["SVJ","EMJ"])), # skip normalization only for SVJ and EMJ signals
             pdfSetName = cms.string("NNPDF31_nlo_as_0118"),
-
         )
         if "SVJ" in self.sample: # skip trying to get scale and PDF weights for SVJ signals
             process.PDFWeights.nScales = 0

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -158,6 +158,7 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   bool found_scales = false;
   bool found_pdfs = false;
   bool found_pss = false;
+  unsigned offset = 0;
   
   if(!handles.empty()){
     edm::Handle<LHEEventProduct> LheInfo = handles[0];
@@ -175,22 +176,19 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
   if(genHandle.isValid()){
     auto helper = makeHelper(genHandle.product(),norm_);
     if((!found_scales and nScales_>0) or (!found_pdfs and nPDFs_>0)){
-      unsigned offset = 1;
       //renormalization/factorization scale weights
+      offset++;
       found_scales = helper.fillWeights(scaleweights.get(),offset,nScales_,wtype::scale);
       //pdf weights
-      if(found_scales) found_pdfs = helper.fillWeights(pdfweights.get(),nScales_+offset,nPDFs_,wtype::pdf);
+      if(found_scales){
+        offset += nScales_;
+        found_pdfs = helper.fillWeights(pdfweights.get(),offset,nPDFs_,wtype::pdf);
+      }
     }
-    else if (!found_pss and nPSs_>0){
-        unsigned offset = 0;
-        found_pss = helper.fillWeights(psweights.get(),offset,nPSs_,wtype::ps);
-    }
-
-    // Extra check here when scales and PS weights are in GenEventInfoProduct
-    // Scales should have just been found above, but still need to go for PS now
-    if(!found_pss and found_scales and nPSs_>0){
-      unsigned offset = 1;
-      found_pss = helper.fillWeights(psweights.get(),nScales_+offset,nPSs_,wtype::ps);
+    if(!found_pss and nPSs_>0){
+      // Check here when scales and PS weights are in GenEventInfoProduct (no PDFs)
+      // Scales should have just been found above, but still need to go for PS now
+      found_pss = helper.fillWeights(psweights.get(),offset,nPSs_,wtype::ps);
     }
 
     //if pdf weights still not found, recalculate them

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -166,6 +166,7 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
     found_scales = helper.fillWeights(scaleweights.get(),0,nScales_,wtype::scale);
     //pdf weights
     if(found_scales) found_pdfs = helper.fillWeights(pdfweights.get(),nScales_,nPDFs_,wtype::pdf);
+
   }
   
   //check GenEventInfoProduct if LHEEventProduct not found or empty
@@ -181,14 +182,16 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       //pdf weights
       if(found_scales) found_pdfs = helper.fillWeights(pdfweights.get(),nScales_+offset,nPDFs_,wtype::pdf);
     }
-    else if(!found_pss and nPSs_>0){
+    if(!found_pss and found_scales and nPSs_>0){
       unsigned offset = 0;
-      found_pss = helper.fillWeights(psweights.get(),offset,nPSs_,wtype::ps);
+      std::cout << "PS WEIGHTS" << std::endl;
+      found_pss = helper.fillWeights(psweights.get(),nScales_+offset,nPSs_,wtype::ps);
     }
 
     //if pdf weights still not found, recalculate them
     //taken from https://github.com/cms-sw/cmssw/blob/CMSSW_10_2_X/ElectroWeakAnalysis/Utilities/src/PdfWeightProducer.cc
     if(!found_pdfs and recalculatePDFs_){
+
       float Q = genHandle->pdf()->scalePDF;
 
       int id1 = lhapdfPDGID(genHandle->pdf()->id.first);

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -36,6 +36,8 @@ class PDFWeightHelper {
       output->reserve(max-offset);
       for (unsigned int i = offset; i < max; i++) {
         output->push_back(this->getWeight(i)*norm);
+
+        std::cout << "WEIGHT " << i << ": " << this->getWeight(i)*norm << std::endl;
       }
       return !output->empty();
     }
@@ -182,7 +184,7 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       if(found_scales) found_pdfs = helper.fillWeights(pdfweights.get(),nScales_+offset,nPDFs_,wtype::pdf);
     }
     if(!found_pss and found_scales and nPSs_>0){
-      unsigned offset = 0;
+      unsigned offset = 1;
       found_pss = helper.fillWeights(psweights.get(),nScales_+offset,nPSs_,wtype::ps);
     }
 

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -36,8 +36,6 @@ class PDFWeightHelper {
       output->reserve(max-offset);
       for (unsigned int i = offset; i < max; i++) {
         output->push_back(this->getWeight(i)*norm);
-
-        std::cout << "WEIGHT " << i << ": " << this->getWeight(i)*norm << std::endl;
       }
       return !output->empty();
     }
@@ -183,6 +181,13 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
       //pdf weights
       if(found_scales) found_pdfs = helper.fillWeights(pdfweights.get(),nScales_+offset,nPDFs_,wtype::pdf);
     }
+    else if (!found_pss and nPSs_>0){
+        unsigned offset = 0;
+        found_pss = helper.fillWeights(psweights.get(),offset,nPSs_,wtype::ps);
+    }
+
+    // Extra check here when scales and PS weights are in GenEventInfoProduct
+    // Scales should have just been found above, but still need to go for PS now
     if(!found_pss and found_scales and nPSs_>0){
       unsigned offset = 1;
       found_pss = helper.fillWeights(psweights.get(),nScales_+offset,nPSs_,wtype::ps);

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -166,7 +166,6 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
     found_scales = helper.fillWeights(scaleweights.get(),0,nScales_,wtype::scale);
     //pdf weights
     if(found_scales) found_pdfs = helper.fillWeights(pdfweights.get(),nScales_,nPDFs_,wtype::pdf);
-
   }
   
   //check GenEventInfoProduct if LHEEventProduct not found or empty
@@ -184,14 +183,12 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
     }
     if(!found_pss and found_scales and nPSs_>0){
       unsigned offset = 0;
-      std::cout << "PS WEIGHTS" << std::endl;
       found_pss = helper.fillWeights(psweights.get(),nScales_+offset,nPSs_,wtype::ps);
     }
 
     //if pdf weights still not found, recalculate them
     //taken from https://github.com/cms-sw/cmssw/blob/CMSSW_10_2_X/ElectroWeakAnalysis/Utilities/src/PdfWeightProducer.cc
     if(!found_pdfs and recalculatePDFs_){
-
       float Q = genHandle->pdf()->scalePDF;
 
       int id1 = lhapdfPDGID(genHandle->pdf()->id.first);

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -184,6 +184,11 @@ void PDFWeightProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Ev
         offset += nScales_;
         found_pdfs = helper.fillWeights(pdfweights.get(),offset,nPDFs_,wtype::pdf);
       }
+      // At this point, no PDFs or scales to be found for current sample,
+      // so set offset back to 0 before attempting to get PSs below
+      else{
+        offset--;
+      }
     }
     if(!found_pss and nPSs_>0){
       // Check here when scales and PS weights are in GenEventInfoProduct (no PDFs)


### PR DESCRIPTION
Ultra Legacy Stealth signal samples do not contain any PDF sets (`LHEEventProduct` is missing from the event). Likewise, the information contained in the `GenEventInfoProduct` pertains to factorization/renormalization weights, _and_ PS weights.

Thus, this PR allows `TreeMaker` to accommodate such a scenario for the Stealth signals, while still trying to be compatible with all other scenarios. The chosen PDF set is based on the recommendations at [1], for positive-definite sets.

[1] https://cms-pdmv.gitbook.io/project/mccontact/info-for-mc-production-for-ultra-legacy-campaigns-2016-2017-2018#recommendations-on-the-usage-of-pdfs-and-cpx-tunes