### PR TITLE
Gen weight bug fixes

### DIFF
--- a/Production/test/pdffinder_cfg.py
+++ b/Production/test/pdffinder_cfg.py
@@ -2,6 +2,7 @@
 from TreeMaker.Utils.CommandLineParams import CommandLineParams
 parameters = CommandLineParams()
 name = parameters.value("name","")
+num = parameters.value("num", 0)
 redir = parameters.value("redir","root://cmsxrootd.fnal.gov/")
 
 # handle site name usage
@@ -17,10 +18,10 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 # only need one event to get run info
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 
-# this selects the first input file
+# this selects the first input file by default
 readFiles = getattr(__import__("TreeMaker.Production."+name+"_cff",fromlist=["readFiles"]),"readFiles")
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(readFiles[0])
+    fileNames = cms.untracked.vstring(readFiles[num])
 )
 
 # log output

--- a/Production/test/runMakeTreeFromMiniAOD_cfg.py
+++ b/Production/test/runMakeTreeFromMiniAOD_cfg.py
@@ -90,7 +90,7 @@ if debugjets:
     producer_types_to_debug.extend(["JetProperties"])
 # to check theory weights
 if debugweights:
-    producer_types_to_debug.extend(["LHEWeightProductProducer","GenWeightProductProducer"])
+    producer_types_to_debug.extend(["LHEWeightProductProducer","GenWeightProductProducer","PDFWeightProducer"])
 if len(producer_types_to_debug)>0:
     from HLTrigger.Configuration.common import producers_by_type
     for prod in producers_by_type(process,*producer_types_to_debug):

--- a/Utils/src/PDFWeightProducer.cc
+++ b/Utils/src/PDFWeightProducer.cc
@@ -156,6 +156,11 @@ void PDFWeightProducer::fillPDF(std::vector<float>& product, const std::vector<d
 }
 
 void PDFWeightProducer::fillScale(std::vector<float>& product, const std::vector<double>& weights, const gen::ScaleWeightGroupInfo& info) const {
+  if(product.empty()){
+    if(debug_)
+      edm::LogWarning("TreeMaker") << "Did not find any scale weights for this event";
+    return;
+  }
   const unsigned nScales = 9;
   if(info.isWellFormed()){
     product.reserve(nScales);
@@ -170,6 +175,11 @@ void PDFWeightProducer::fillScale(std::vector<float>& product, const std::vector
 }
 
 void PDFWeightProducer::fillPS(std::vector<float>& product, const std::vector<double>& weights, const gen::PartonShowerWeightGroupInfo& info) const {
+  if(product.empty()){
+    if(debug_)
+      edm::LogWarning("TreeMaker") << "Did not find any PS weights for this event";
+    return;
+  }
   const unsigned nPSs = 14;
   if(info.isWellFormed()){
     product.reserve(nPSs);


### PR DESCRIPTION
Some issue with the new gen weight parsing code is causing occasional exceptions. This is a temporary workaround to finish the ongoing production while the underlying cause is debugged further. A subsequent update will come later.