### PR TITLE
add smearing & systematics for AK15 jets

### DIFF
--- a/TreeMaker/python/JetDepot.py
+++ b/TreeMaker/python/JetDepot.py
@@ -44,7 +44,7 @@ def JetDepot(process, JetTag, jecUncDir=0, storeJec=False, doSmear=True, jerUncD
 
 from TreeMaker.TreeMaker.addJetInfo import addJetInfo
 
-def JetVariations(self, process, JetTag, SkipTag=cms.VInputTag(), suff='', vars='makeJetVars'):
+def JetVariations(self, process, JetTag, SkipTag=cms.VInputTag(), suff='', puppiSpecific='puppiSpecificAK8', vars='makeJetVars'):
         makeJetVarsFn = getattr(self,vars)
 
         # JEC unc up
@@ -62,6 +62,7 @@ def JetVariations(self, process, JetTag, SkipTag=cms.VInputTag(), suff='', vars=
             storeProperties=0,
             SkipTag=SkipTag,
             systType="JEC",
+            puppiSpecific=puppiSpecific,
         )
         
         # JEC unc down
@@ -78,6 +79,7 @@ def JetVariations(self, process, JetTag, SkipTag=cms.VInputTag(), suff='', vars=
             storeProperties=0,
             SkipTag=SkipTag,
             systType="JEC",
+            puppiSpecific=puppiSpecific,
         )
 
         # JER unc up
@@ -94,6 +96,7 @@ def JetVariations(self, process, JetTag, SkipTag=cms.VInputTag(), suff='', vars=
             storeProperties=0,
             SkipTag=SkipTag,
             systType="JER",
+            puppiSpecific=puppiSpecific,
         )
         
         # JER unc down
@@ -110,6 +113,7 @@ def JetVariations(self, process, JetTag, SkipTag=cms.VInputTag(), suff='', vars=
             storeProperties=0,
             SkipTag=SkipTag,
             systType="JER",
+            puppiSpecific=puppiSpecific,
         )
 
         # append factors to central collection

--- a/TreeMaker/python/makeJetVars.py
+++ b/TreeMaker/python/makeJetVars.py
@@ -59,7 +59,8 @@ def makeGoodJets(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInpu
 # 0 = scalars (+ origIndex,jerFactor for syst)
 # 1 = 0 + 4vecs, masks, minimal set of properties
 # 2 = all properties
-def makeJetVars(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInputTag(), onlyGoodJets=False, systType=""):
+# puppiSpecific is not used, but just there to make interfaces consistent
+def makeJetVars(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInputTag(), onlyGoodJets=False, systType="", puppiSpecific=""):
     ## ----------------------------------------------------------------------------------------------
     ## GoodJets
     ## ----------------------------------------------------------------------------------------------
@@ -281,7 +282,7 @@ def makeJetVars(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInput
 # 2 = 1 + subjet properties + extra substructure
 # 3 = 2 + constituents (large)
 # SkipTag is not used, but just there to make interfaces consistent
-def makeJetVarsAK8(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInputTag(), systType="", doECFs=True, doDeepAK8=True, doDeepDoubleB=True, CandTag=cms.InputTag("packedPFCandidates"),puppiSpecific="", subjetTag='SoftDropPuppiUpdated'):
+def makeJetVarsAK8(self, process, JetTag, suff, storeProperties, SkipTag=cms.VInputTag(), systType="", doECFs=True, doDeepAK8=True, doDeepDoubleB=True, CandTag=cms.InputTag("packedPFCandidates"),puppiSpecific="puppiSpecificAK8", subjetTag='SoftDropPuppiUpdated'):
     # select good jets before anything else - eliminates bad AK8 jets (low pT, no constituents stored, etc.)
     process, GoodJetsTag = self.makeGoodJets(process,JetTag,suff,storeProperties,jetConeSize=0.8,puppiSpecific=puppiSpecific)
 
@@ -485,9 +486,9 @@ def makeJetVarsAK8(self, process, JetTag, suff, storeProperties, SkipTag=cms.VIn
                 'hfEMEnergyFraction',
                 'hfHadronEnergyFraction',
             ])
-            JetPropertiesAK8.neutralHadronPuppiMultiplicity = cms.vstring("puppiSpecificAK8:neutralHadronPuppiMultiplicity")
-            JetPropertiesAK8.neutralPuppiMultiplicity = cms.vstring("puppiSpecificAK8:neutralPuppiMultiplicity")
-            JetPropertiesAK8.photonPuppiMultiplicity = cms.vstring("puppiSpecificAK8:photonPuppiMultiplicity")
+            JetPropertiesAK8.neutralHadronPuppiMultiplicity = cms.vstring(puppiSpecific+":neutralHadronPuppiMultiplicity")
+            JetPropertiesAK8.neutralPuppiMultiplicity = cms.vstring(puppiSpecific+":neutralPuppiMultiplicity")
+            JetPropertiesAK8.photonPuppiMultiplicity = cms.vstring(puppiSpecific+":photonPuppiMultiplicity")
             self.VectorDouble.extend([
                 'JetProperties'+suff+':muonEnergyFraction(Jets'+suff+'_muonEnergyFraction)',
                 'JetProperties'+suff+':chargedHadronEnergyFraction(Jets'+suff+'_chargedHadronEnergyFraction)',


### PR DESCRIPTION
Mainly intended for boosted SVJ signals, though since the JER smearing had not been applied to AK15 jets before, this should ultimately be propagated to relevant background MC samples for consistency.