### PR TITLE
Updating reco photon collection to add photons passing mva based ID

### DIFF
--- a/Utils/src/PhotonIDisoProducer.cc
+++ b/Utils/src/PhotonIDisoProducer.cc
@@ -262,7 +262,7 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
     bool passIso=false;
     bool passIsoLoose=false;
     bool passAcc=false;
-
+    bool passMVAId =false;
     double PhEta=iPhoton.eta();
 
     if(fabs(PhEta) < 1.4442  ){
@@ -314,8 +314,15 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
 	}
       }
     }
+    //apply mva based ID criteria
+    if(isBarrelPhoton){
+      if(phoMVAID>-0.02) passMVAId=true;
+    }
+    else if(isEndcapPhoton){
+      if(phoMVAID >-0.26) passMVAId=true;
+    }
     // check if photon is a good loose photon
-    if( passAcc && iPhoton.pt() > pt_cut_ && ((passIDLoose && passIsoLoose) || phoMVAID >-0.02)){//pure photons
+    if( passAcc && iPhoton.pt() > pt_cut_ && ((passIDLoose && passIsoLoose) || passMVAId)){//pure photons
       goodPhotons->push_back( iPhoton );
       if(iPhoton.pt() > high_pt_cut_) highPhotons->push_back( iPhoton );
       photon_isEB->push_back( iPhoton.isEB() );

--- a/Utils/src/PhotonIDisoProducer.cc
+++ b/Utils/src/PhotonIDisoProducer.cc
@@ -315,7 +315,7 @@ PhotonIDisoProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Event
       }
     }
     // check if photon is a good loose photon
-    if( passAcc && passIDLoose && passIsoLoose && iPhoton.pt() > pt_cut_){//pure photons
+    if( passAcc && iPhoton.pt() > pt_cut_ && ((passIDLoose && passIsoLoose) || phoMVAID >-0.02)){//pure photons
       goodPhotons->push_back( iPhoton );
       if(iPhoton.pt() > high_pt_cut_) highPhotons->push_back( iPhoton );
       photon_isEB->push_back( iPhoton.isEB() );


### PR DESCRIPTION
This PR contains changes in which we also save reco photons which are passing a mva ID but not passing loose cut based ID. So essentially we have added an 'OR' condition while saving the reco photon collection. 
This will not have any noticeable impact on the ntuples size.
This change is aimed for v6 production of v20 ntuples