### PR TITLE
Fix subjets

### DIFF
--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -942,9 +942,6 @@ def makeTreeFromMiniAOD(self,process):
         process.JetPropertiesAK8.ecfN2b2 = cms.vstring('ak8PFJetsPuppiLowCutSoftDropValueMap:nb2AK8PuppiLowCutSoftDropN2')
         process.JetPropertiesAK8.ecfN3b1 = cms.vstring('ak8PFJetsPuppiLowCutSoftDropValueMap:nb1AK8PuppiLowCutSoftDropN3')
         process.JetPropertiesAK8.ecfN3b2 = cms.vstring('ak8PFJetsPuppiLowCutSoftDropValueMap:nb2AK8PuppiLowCutSoftDropN3')
-        process.JetPropertiesAK8.softDropMass = cms.vstring('SoftDrop')
-        process.JetPropertiesAK8.subjets = cms.vstring('SoftDrop')
-        process.JetPropertiesAK8.SJbDiscriminatorCSV = cms.vstring('SoftDrop', 'pfCombinedInclusiveSecondaryVertexV2BJetTags')
     if self.systematics:
         process.JetPropertiesAK8.properties.extend(["jecUnc"])
         process.JetPropertiesAK8.jecUnc = cms.vstring(JetAK8TagJECTmp.value())

--- a/TreeMaker/python/makeTreeFromMiniAOD_cff.py
+++ b/TreeMaker/python/makeTreeFromMiniAOD_cff.py
@@ -417,6 +417,7 @@ def makeTreeFromMiniAOD(self,process):
             if self.geninfo and not self.doZinv: # calling jet toolbox again for ak8 would break after this, so skip it
                 process = self.transformJetSeq(process, "ak8GenJetsNoNu", {"SoftDrop":"ak8GenJetsNoNuSoftDrop"}, "recoGenJets")
             process.ak8PFJetsPuppiLowCutSoftDrop.jetPtMin = cms.double(10) # to match central clustering
+            process.ak8PFJetsPuppiLowCut.jetPtMin = cms.double(10) # to match above
             process = self.transformJetSeq(process, "ak8PFJetsPuppiLowCut", {"SoftDrop":"ak8PFJetsPuppiLowCutSoftDrop"}, "recoPFJets")
 
             JetAK8Tag = cms.InputTag("packedPatJetsAK8PFPuppiLowCutSoftDrop")


### PR DESCRIPTION
Occasional mismatches between the number of subjet four-vectors and the number of subjet substructure quantities were observed when AK8 low-pt reclustering was enabled. There were two issues:
1. inconsistent subjet collections were used for different property branches (seems to be some outdated code from early development that wasn't cleaned up)
2. the `jetPtMin` cuts were not synchronized between the regular clustering and the SoftDrop transform. This can cause `JetSubstructurePacker` to duplicate subjets for low-pt jets that were skipped by SoftDrop. Should be addressed centrally in the future (the one-shot transform approach to FastjetJetProducer may obviate the need for `JetSubstructurePacker` in its current form, if adopted by JME).